### PR TITLE
features/printoptions

### DIFF
--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -5157,7 +5157,7 @@ class heat_exchanger_simple(component):
                 ttd_l = T_o - t_a
 
             if ttd_u < 0 or ttd_l < 0:
-                if nw.compcerr:
+                if nw.comperr:
                     msg = ('##### ERROR #####\n'
                            'Invalid value for terminal temperature difference '
                            'at component ' + self.label + '.\n'

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -222,9 +222,6 @@ class component:
                        str(key))
                 raise ValueError(msg)
 
-#        print('Updated ', self, '.')
-#        print(self.__dict__)
-
     def get_attr(self, key):
         """
         get the value of a components attribute
@@ -238,8 +235,8 @@ class component:
         if key in self.__dict__:
             return self.__dict__[key]
         else:
-            print(self.component(), ' \"', self.label, '\" '
-                  'has no attribute \"', key, '\"')
+            print(self.component(), '\"' + self.label + '\" '
+                  'has no attribute \"' + key + '\"')
             return None
 
     def comp_init(self, nw):
@@ -1108,9 +1105,6 @@ class turbomachine(component):
     def print_parameters(self, nw):
 
         print('##### ', self.label, ' #####')
-        if self.eta_s.val > 1:
-            print('!!!!! Error in parametrisation of the model, '
-                  'eta_s higher than 1 !!!!!')
         print('P = ', self.P.val, 'W; '
               'eta_s = ', self.eta_s.val, '; '
               'pr = ', self.pr.val, '; '
@@ -1518,14 +1512,16 @@ class pump(turbomachine):
         if (mode == 'pre' and 'eta_s' in self.offdesign) or mode == 'post':
             self.eta_s.val = ((self.h_os(inl, outl) - inl[0].h.val_SI) /
                               (outl[0].h.val_SI - inl[0].h.val_SI))
-            if self.eta_s.val > 1 or self.eta_s.val <= 0:
-                msg = ('Invalid value for isentropic efficiency.\n'
+            if self.eta_s.val > 1 or self.eta_s.val <= 0 and nw.comperr:
+                msg = ('##### ERROR #####\n'
+                       'Invalid value for isentropic efficiency: '
                        'eta_s =', self.eta_s.val)
                 print(msg)
                 nw.errors += [self]
 
         if (mode == 'pre' and 'eta_s_char' in self.offdesign):
-            print('Creating characteristics for component ', self)
+            if nw.compinfo:
+                print('Creating characteristics for component ', self)
             v_opt = (self.i0[0] *
                      (v_mix_ph(self.i0) + v_mix_ph(self.o0)) / 2)
             H_opt = ((self.o0[1] - self.i0[1]) /
@@ -1925,8 +1921,9 @@ class compressor(turbomachine):
             self.eta_s.val = ((self.h_os(inl, outl) -
                                inl[0].h.val_SI) /
                               (outl[0].h.val_SI - inl[0].h.val_SI))
-            if self.eta_s.val > 1 or self.eta_s.val <= 0:
-                msg = ('Invalid value for isentropic efficiency.\n'
+            if self.eta_s.val > 1 or self.eta_s.val <= 0 and nw.comperr:
+                msg = ('##### ERROR #####\n'
+                       'Invalid value for isentropic efficiency: '
                        'eta_s =', self.eta_s.val)
                 print(msg)
                 nw.errors += [self]
@@ -1953,17 +1950,19 @@ class compressor(turbomachine):
                 )
             vigv = self.char_map.func.get_vigv(n, m, (o1[1] * self.i0[1]) /
                                                      (i1[1] * self.o0[1]))
-            if abs(self.vigv.val - vigv) > err:
-                print('!!!!! Selected inlet guide vane angle is not feasible '
-                      '!!!!!')
+            if abs(self.vigv.val - vigv) > err and nw.compwarn:
+                msg = ('##### WARNING #####\n'
+                       'Selected inlet guide vane angle is not feasible.')
                 if self.vigv.val > vigv:
-                    print('calculated maximum angle:', vigv,
-                          'selected:', self.vigv.val)
+                    msg += ('calculated maximum angle: ' + str(vigv) +
+                            ' selected: ' + str(self.vigv.val))
                 else:
-                    print('calculated minimum angle:', vigv,
-                          'selected:', self.vigv.val)
+                    msg += ('calculated minimum angle: ' + str(vigv) +
+                            ' selected: ' + str(self.vigv.val))
+                print(msg)
+
             else:
-                print('vigv = ', self.vigv.val)
+                print('vigv =', self.vigv.val)
 
 # %%
 
@@ -2335,8 +2334,9 @@ class turbine(turbomachine):
         if (mode == 'pre' and 'eta_s' in self.offdesign) or mode == 'post':
             self.eta_s.val = ((outl[0].h.val_SI - inl[0].h.val_SI) /
                               (self.h_os(inl, outl) - inl[0].h.val_SI))
-            if self.eta_s.val > 1 or self.eta_s.val <= 0:
-                msg = ('Invalid value for isentropic efficiency.\n'
+            if self.eta_s.val > 1 or self.eta_s.val <= 0 and nw.comperr:
+                msg = ('##### ERROR #####\n'
+                       'Invalid value for isentropic efficiency: '
                        'eta_s =', self.eta_s.val)
                 print(msg)
                 nw.errors += [self]
@@ -3671,7 +3671,7 @@ class combustion_chamber(component):
                      nw.comps.loc[self].o.tolist())
 
         print('##### ', self.label, ' #####')
-        print('Thermal Input = ', self.ti.val,
+        print('thermal input = ', self.ti.val,
               'lambda = ', self.lamb.val,
               'S = ', self.S.val)
         j = 1
@@ -5157,11 +5157,12 @@ class heat_exchanger_simple(component):
                 ttd_l = T_o - t_a
 
             if ttd_u < 0 or ttd_l < 0:
-                msg = ('Invalid value for terminal temperature '
-                       'difference.'
-                       'ttd_u =', ttd_u,
-                       'ttd_l =', ttd_l)
-                print(msg)
+                if nw.compcerr:
+                    msg = ('##### ERROR #####\n'
+                           'Invalid value for terminal temperature difference '
+                           'at component ' + self.label + '.\n'
+                           'ttd_u = ' + str(ttd_u) + ' ttd_l = ' + str(ttd_l))
+                    print(msg)
                 nw.errors += [self]
 
             if mode == 'post':
@@ -5188,11 +5189,16 @@ class heat_exchanger_simple(component):
         # improve this part (for heat exchangers only atm)
         if self.kA.is_set:
             expr = inl[0].m.val_SI / self.i0[0]
-            if (expr > self.kA_char.func.x[-1] or
-                    expr < self.kA_char.func.x[0]):
-                msg = ('Warning: Expression for characteristics out of bounds:'
-                       ' value is ' + str(expr))
-                print(msg)
+            minval = self.kA_char.func.x[0]
+            maxval = self.kA_char.func.x[-1]
+            if expr > maxval or expr < minval:
+                if nw.compwarn:
+                    msg = ('##### WARNING #####\n'
+                           'Expression for characteristics out of bounds [' +
+                           str(minval) + ', ' + str(maxval) + '], '
+                           ' value is ' + str(expr) + ' at ' +
+                           self.label + '.')
+                    print(msg)
                 nw.errors += [self]
 
     def print_parameters(self, nw):
@@ -6006,11 +6012,13 @@ class heat_exchanger(component):
             self.ttd_l.val = T_o1 - T_i2
 
         if self.ttd_u.val < 0 or self.ttd_l.val < 0:
-            msg = ('Invalid value for terminal temperature '
-                   'difference.'
-                   'ttd_u =', self.ttd_u.val,
-                   'ttd_l =', self.ttd_l.val)
-            print(msg)
+            if nw.comperr:
+                msg = ('##### ERROR #####\n'
+                       'Invalid value for terminal temperature difference '
+                       'at component ' + self.label + '.\n'
+                       'ttd_u = ' + str(self.ttd_u) + ' '
+                       'ttd_l = ' + str(self.ttd_l))
+                print(msg)
             nw.errors += [self]
 
         if (mode == 'pre' and 'Q' in self.offdesign) or mode == 'post':
@@ -6055,28 +6063,34 @@ class heat_exchanger(component):
         # improve this part (for heat exchangers only atm)
         if self.kA.is_set:
             expr = inl[0].m.val_SI / self.i10[0]
-            if (expr > self.kA_char1.func.x[-1] or
-                    expr < self.kA_char1.func.x[0]):
-                msg = ('Warning: Expression for characteristics out of bounds:'
-                       ' value is ' + str(expr))
-                print(msg)
+            minval = self.kA_char1.func.x[0]
+            maxval = self.kA_char1.func.x[-1]
+            if expr > maxval or expr < minval:
+                if nw.compwarn:
+                    msg = ('##### WARNING #####\n'
+                           'Expression for characteristics out of bounds [' +
+                           str(minval) + ', ' + str(maxval) + '], '
+                           ' value is ' + str(expr) + ' at ' +
+                           self.label + '.')
+                    print(msg)
                 nw.errors += [self]
 
             expr = inl[1].m.val_SI / self.i20[0]
-            if (expr > self.kA_char2.func.x[-1] or
-                    expr < self.kA_char2.func.x[0]):
-                msg = ('Warning: Expression for characteristics out of bounds:'
-                       ' value is ' + str(expr))
-                print(msg)
+            minval = self.kA_char2.func.x[0]
+            maxval = self.kA_char2.func.x[-1]
+            if expr > maxval or expr < minval:
+                if nw.compwarn:
+                    msg = ('##### WARNING #####\n'
+                           'Expression for characteristics out of bounds [' +
+                           str(minval) + ', ' + str(maxval) + '], '
+                           ' value is ' + str(expr) + ' at ' +
+                           self.label + '.')
+                    print(msg)
                 nw.errors += [self]
 
     def print_parameters(self, nw):
 
         print('##### ', self.label, ' #####')
-        if self.ttd_u.val < 0 and self.kA.is_set:
-            print('!!!!! ERROR calculating heat exchanger: !!!!!\n'
-                  'Negative value for TTD at given logarithmic temperature '
-                  'difference or kA, result may be wrong.')
         print('Q = ', self.Q.val, 'W; '
               'ttd_u = ', self.ttd_u.val, 'K; '
               'ttd_l = ', self.ttd_l.val, 'K; '

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -123,6 +123,10 @@ class network:
               'T': 'K'
               }
 
+        # printoptions
+        self.print_level = 'info'
+        self.set_printoptions()
+
         # standard unit set
         self.m_unit = self.SI_units['m']
         self.p_unit = self.SI_units['p']
@@ -250,12 +254,90 @@ class network:
         if key in self.__dict__:
             return self.__dict__[key]
         else:
-            print('No attribute \"', key, '\" available!')
+            if self.nwkwarn:
+                print('No attribute \"' + str(key) + '\" available!')
             return None
 
     def attr(self):
         return ['m_unit', 'p_unit', 'h_unit', 'T_unit',
                 'p_range', 'h_range', 'T_range']
+
+    def set_printoptions(self, **kwargs):
+        """r
+
+        sets the printoptions for the calculation.
+
+        :returns: no return value
+
+        **allowed keywords** in kwargs:
+
+        - print_level (*str*) - select the print level:
+
+                - info
+                - warn
+                - err
+                - none
+
+        - compinfo (*bool*) - print infos of components
+        - compwarn (*bool*) - print warnings of components
+        - comperr (*bool*) - print errors of components
+
+        - nwkinfo (*bool*) - print info of network
+        - nwkwarn (*bool*) - print warnings of network
+        - nwkerr (*bool*) - print errors of network
+
+        - iterinfo (*bool*) - print iterations
+
+        """
+        self.print_level = kwargs.get('print_level', self.print_level)
+
+        if self.print_level == 'info':
+            self.compinfo = True
+            self.nwkinfo = True
+            self.iterinfo = True
+            self.compwarn = True
+            self.nwkwarn = True
+            self.comperr = True
+            self.nwkerr = True
+
+        elif self.print_level == 'warn':
+            self.compinfo = False
+            self.nwkinfo = False
+            self.iterinfo = False
+            self.compwarn = True
+            self.nwkwarn = True
+            self.comperr = True
+            self.nwkerr = True
+
+        elif self.print_level == 'err':
+            self.compinfo = False
+            self.nwkinfo = False
+            self.iterinfo = False
+            self.compwarn = False
+            self.nwkwarn = False
+            self.comperr = True
+            self.nwkerr = True
+
+        elif self.print_level == 'none':
+            self.compinfo = False
+            self.nwkinfo = False
+            self.iterinfo = False
+            self.compwarn = False
+            self.nwkwarn = False
+            self.comperr = False
+            self.nwkerr = False
+        else:
+            msg = ('Available print leves are: \'info\', \'warn\', \'err\' and'
+                   '\'none\'.')
+            raise ValueError(msg)
+
+        self.compinfo = kwargs.get('compinfo', self.compinfo)
+        self.nwkinfo = kwargs.get('nwkinfo', self.nwkinfo)
+        self.iterinfo = kwargs.get('iterinfo', self.iterinfo)
+        self.compwarn = kwargs.get('compwarn', self.compwarn)
+        self.nwkwarn = kwargs.get('nwkwarn', self.nwkwarn)
+        self.comperr = kwargs.get('comperr', self.comperr)
+        self.nwkerr = kwargs.get('nwkerr', self.nwkerr)
 
     def add_subsys(self, *args):
         """
@@ -405,7 +487,8 @@ class network:
                 raise hlp.MyNetworkError(msg)
 
         self.checked = True
-        print('Networkcheck successfull.')
+        if self.nwkinfo:
+            print('Networkcheck successfull.')
 
     def initialise(self):
         """
@@ -419,10 +502,10 @@ class network:
 
         :returns: no return value
         """
-
-        msg = ('Have you adjusted the value ranges for pressure, enthalpy'
-               ' and temperature according to the specified unit system?')
-        print(msg)
+        if self.nwkinfo:
+            msg = ('Have you adjusted the value ranges for pressure, enthalpy'
+                   ' and temperature according to the specified unit system?')
+            print(msg)
 
         if len(self.fluids) == 0:
             msg = ('Network has no fluids, please specify a list with fluids '
@@ -740,7 +823,7 @@ class network:
         if math.isnan(c.get_attr(key).val0):
             val_s = c.s.initialise_source(c, key)
             val_t = c.t.initialise_target(c, key)
-#            print(key, c.s.label, val_s, c.t.label, val_t)
+
             if val_s == 0 and val_t == 0:
                 if key == 'p':
                     c.get_attr(key).val0 = 1e5
@@ -946,7 +1029,8 @@ class network:
 
         self.initialise()
 
-        print('Network initialised.')
+        if self.nwkinfo:
+            print('Network initialised.')
 
         if init_only:
             return
@@ -957,7 +1041,8 @@ class network:
         self.convergence[2] = np.zeros((len(self.conns), 0))
         self.res = np.array([])
 
-        print('Solving network.')
+        if self.nwkinfo:
+            print('Solving network.')
 
         self.vec_res = []
         self.iter = 0
@@ -992,6 +1077,16 @@ class network:
         self.solve_loop()
         end_time = time.time()
 
+        if self.iterinfo:
+            print('--------+----------+----------+----------+----------+'
+                  '---------')
+            msg = ('Total iterations: ' + str(self.iter) + ', '
+                   'Calculation time: ' +
+                   str(round(end_time - start_time, 1)) + ' s, '
+                   'Iterations per second: ' +
+                   str(round(self.iter / (end_time - start_time), 2)))
+            print(msg)
+
         self.processing('post')
 
         if self.parallel:
@@ -1011,12 +1106,8 @@ class network:
             c.h.val0 = c.h.val
             c.fluid.val0 = c.fluid.val.copy()
 
-        print('Calculation complete.')
-        msg = ('Total iterations:' + str(self.iter) + ' - '
-               'Calculation time:' + str(round(end_time - start_time, 1)) +
-               's - Iterations per second:' +
-               str(round(self.iter / (end_time - start_time), 2)))
-        print(msg)
+        if self.nwkinfo:
+            print('Calculation complete.')
 
     def solve_loop(self):
         """
@@ -1024,7 +1115,12 @@ class network:
 
         **Improvememts**
         """
-        print('iter\t| residual')
+        if self.iterinfo:
+            msg = ('iter\t| residual | massflow | pressure | enthalpy | fluid')
+            print(msg)
+            print('--------+----------+----------+----------+----------+'
+                  '---------')
+
         for self.iter in range(self.max_iter):
 
             self.convergence[0] = np.column_stack((
@@ -1037,49 +1133,39 @@ class network:
             self.solve_control()
             self.res = np.append(self.res, norm(self.vec_res))
 
-            print(self.iter + 1, '\t|', '{:.2e}'.format(norm(self.vec_res)))
+            if self.iterinfo:
+                msg = (str(self.iter + 1))
+                # should this be f(x_i) or the dx_i?
+                # -> accounts for self.res, too.
+                msg += '\t| ' + '{:.2e}'.format(norm(self.vec_res))
+                msg += ' | ' + '{:.2e}'.format(norm(
+                        self.vec_z[0::self.num_vars]))
+                msg += ' | ' + '{:.2e}'.format(norm(
+                        self.vec_z[1::self.num_vars]))
+                msg += ' | ' + '{:.2e}'.format(norm(
+                        self.vec_z[2::self.num_vars]))
+                ls = []
+                for f in range(len(self.fluids)):
+                    ls += self.vec_z[3 + f::self.num_vars].tolist()
 
-            k = 0
-            for c in self.conns.index:
-                self.convergence[0][k][self.iter] = c.m.val_SI
-                self.convergence[1][k][self.iter] = c.p.val_SI
-                self.convergence[2][k][self.iter] = c.h.val_SI
-                k += 1
-
-            if self.iter > 3:
-                self.relax = 1
+                msg += ' | ' + '{:.2e}'.format(norm(ls))
+                print(msg)
 
             self.iter += 1
 
             # stop calculation after rediculous amount of iterations
             if self.iter > 3:
                 if self.res[-1] < hlp.err ** (1 / 2):
-                    if self.num_restart > 0:
-                        self.convergence[0] = np.column_stack((
-                                self.convergence[0], [0] * len(self.conns)))
-                        self.convergence[1] = np.column_stack((
-                                self.convergence[1], [0] * len(self.conns)))
-                        self.convergence[2] = np.column_stack((
-                                self.convergence[2], [0] * len(self.conns)))
-                        self.vec_z = np.zeros((self.num_vars *
-                                               len(self.conns),))
                     break
 
             if self.iter > 15:
                 if (all(self.res[(self.iter - 3):] >= self.res[-2]) and
                         self.res[-1] >= self.res[-2]):
-                    print('ERROR: Convergence is making no progress, '
-                          'calculation stopped.')
-                    if self.num_restart > 0:
-                        self.convergence[0] = np.column_stack((
-                                self.convergence[0], [0] * len(self.conns)))
-                        self.convergence[1] = np.column_stack((
-                                self.convergence[1], [0] * len(self.conns)))
-                        self.convergence[2] = np.column_stack((
-                                self.convergence[2], [0] * len(self.conns)))
-                        self.vec_z = np.zeros((self.num_vars *
-                                               len(self.conns),))
-                    break
+                    if self.nwkwarn:
+                        print('##### WARNING #####\n'
+                              'Convergence is making no progress, calculation '
+                              'stopped.')
+                        break
 
             if self.lin_dep:
                 break
@@ -1115,8 +1201,9 @@ class network:
 
         # check for linear dependency
         if self.lin_dep:
-                msg = ('error calculating the network:\n'
-                       'singularity in jacobian matrix, possible reasons are\n'
+            if self.nwkerr:
+                msg = ('##### ERROR #####\n'
+                       'singularity in jacobian matrix, frequent reasons are\n'
                        '-> given Temperature with given pressure in two phase '
                        'region, try setting enthalpy instead or '
                        'provide accurate starting value for pressure.\n'
@@ -1127,7 +1214,7 @@ class network:
                        'combustion chamber, provide small (near to zero, '
                        'but not zero) starting value.')
                 print(msg)
-                return
+            return
 
         # add increment
         i = 0
@@ -1813,14 +1900,18 @@ class network:
         self.comps.apply(network.process_components, axis=1,
                          args=(self, mode,))
 
-        if mode == 'pre':
-            print('Preprocessing done.')
-        else:
-            print('Postprocessing.')
+        if self.nwkinfo:
+            if mode == 'pre':
+                print('Preprocessing done.')
+            else:
+                print('Postprocessing.')
+
+        if mode == 'post':
             # clear fluid property memory
             hlp.memorise.del_memory(self.fluids)
             self.process_busses()
-            print('Done.')
+            if self.nwkinfo:
+                print('Done.')
 
     def process_busses(self):
         """
@@ -1863,11 +1954,12 @@ class network:
         Q_diss = [x.P for x in self.busses if x.label == 'Q_diss']
 
         if len(P_res) != 0 and len(Q_diss) != 0:
-            print('process key figures')
-            print('eta_th = ' + str(1 - sum(Q_diss) /
-                  (sum(P_res) + sum(Q_diss))))
-            print('eps_hp = ' + str(abs(sum(Q_diss)) / sum(P_res)))
-            print('eps_cm = ' + str(abs(sum(Q_diss)) / sum(P_res) - 1))
+            if self.nwkinfo:
+                print('process key figures')
+                print('eta_th = ' + str(1 - sum(Q_diss) /
+                      (sum(P_res) + sum(Q_diss))))
+                print('eps_hp = ' + str(abs(sum(Q_diss)) / sum(P_res)))
+                print('eps_cm = ' + str(abs(sum(Q_diss)) / sum(P_res) - 1))
 
         msg = 'Do you want to print the components parammeters?'
         if hlp.query_yes_no(msg):


### PR DESCRIPTION
I remodeled the printouts for convergence and info/warnings/errors. It is possible to provide the print_level or the printouts individually. E. g.:
```
mynetwork.set_printoptions(print_level='err', iterinfo=True)
# prints errors only, additionally the iteration progress is printed
```
Also, the printout of the solution progress looks better now. These changes are pushed into dev, but design changes should follow for the printouts of components and connections (`mynetwork.print_results()`), too.