### PR TITLE
solve the filename conflict in Windows by using tespy_fluid feature

### DIFF
--- a/tespy/tools/helpers.py
+++ b/tespy/tools/helpers.py
@@ -634,7 +634,8 @@ class tespy_fluid:
             Lookup value (enthalpy, entropy, density or viscosity)
         """
         df = pd.DataFrame(y, columns=x2, index=x1)
-        path = './LUT/' + self.alias + '/'
+        alias = self.alias.replace('::','_')
+        path = './LUT/' + alias + '/'
         if not os.path.exists(path):
             os.makedirs(path)
         df.to_csv(path + name + '.csv')
@@ -648,7 +649,8 @@ class tespy_fluid:
         name : str
             Name of the lookup table.
         """
-        path = self.path + '/' + self.alias + '/' + name + '.csv'
+        alias = self.alias.replace('::','_')
+        path = self.path + '/' + alias + '/' + name + '.csv'
         df = pd.read_csv(path, index_col=0)
 
         x1 = df.index.get_values()


### PR DESCRIPTION
Dear Francesco,

Here i make a pull request for solving the filename conflict  by using tespy_fluid feature in Windows.

Based on my own understanding, i have changed the save and load path in TESPy for tespy_fluid from ‘TESPy::alias' to 'TESPy_alias'. I have tested it with the online documentation example and could achieve a successful save and load process. But i'm not sure if this change will make conflict in Linux system. So i would like to ask you if you could look into the code change and have a check for it. 

Best regards,
Shuang