### PR TITLE
Features/filename conflict tespy fluid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 
 setup(name='TESPy',
-      version='0.1.0 master',
+      version='0.1.0',
       description='Thermal Engineering Systems in Python (TESPy)',
       url='http://github.com/oemof/tespy',
       author='Francesco Witte',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 
 setup(name='TESPy',
-      version='0.1.0',
+      version='0.1.0 dev',
       description='Thermal Engineering Systems in Python (TESPy)',
       url='http://github.com/oemof/tespy',
       author='Francesco Witte',

--- a/tespy/tools/helpers.py
+++ b/tespy/tools/helpers.py
@@ -634,7 +634,8 @@ class tespy_fluid:
             Lookup value (enthalpy, entropy, density or viscosity)
         """
         df = pd.DataFrame(y, columns=x2, index=x1)
-        path = './LUT/' + self.alias + '/'
+        alias = self.alias.replace('::','_')
+        path = './LUT/' + alias + '/'
         if not os.path.exists(path):
             os.makedirs(path)
         df.to_csv(path + name + '.csv')
@@ -648,7 +649,8 @@ class tespy_fluid:
         name : str
             Name of the lookup table.
         """
-        path = self.path + '/' + self.alias + '/' + name + '.csv'
+        alias = self.alias.replace('::','_')
+        path = self.path + '/' + alias + '/' + name + '.csv'
         df = pd.read_csv(path, index_col=0)
 
         x1 = df.index.get_values()


### PR DESCRIPTION
Dear Francesco,

I opened this pull request trying to solve the network saving and loading conflict when using TESPy0.1.0 on Windows. Since Windows could not create a folder containing the character of ' : ', I have changed the to save folder name containing the user defined fluid from 'TESPy::myfluid' into 'TESPy_myfluid'. But I'm not so surely if this change will make other conflicts when running the TESPy. So please review this change in this pull request. Thanks.

best,
Shuang