### PR TITLE
functionality for subcooling and superheating

### DIFF
--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -7900,7 +7900,7 @@ class heat_exchanger(component):
     >>> nw.add_conns(tes_he, he_tes, hs_he, he_hs)
     >>> he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5,
     ...     design=['pr1', 'pr2', 'ttd_u'], offdesign=['zeta1', 'zeta2', 'kA'])
-    >>> hs_he.set_attr(T=120, p=3, fluid={'water': 1})
+    >>> hs_he.set_attr(td_bp=-10, p=3, fluid={'water': 1})
     >>> he_hs.set_attr(T=70)
     >>> tes_he.set_attr(p=5, fluid={'water': 1})
     >>> tes_he.set_attr(T=40)
@@ -7908,15 +7908,15 @@ class heat_exchanger(component):
     >>> nw.solve('design')
     >>> nw.save('tmp')
     >>> round(tes_he.m.val, 2)
-    0.25
+    0.24
     >>> round(he_tes.T.val, 1)
-    115.0
+    118.5
     >>> he.set_attr(Q=-60e3)
     >>> nw.solve('offdesign', design_path='tmp')
     >>> round(tes_he.m.val, 2)
-    0.19
+    0.18
     >>> round(he_tes.T.val, 1)
-    115.9
+    119.4
     >>> shutil.rmtree('./tmp', ignore_errors=True)
     """
 
@@ -8814,7 +8814,7 @@ class condenser(heat_exchanger):
     >>> nw.add_conns(amb_he, he_amb, hs_he, he_hs)
     >>> he.set_attr(pr1=0.98, pr2=0.999, design=['pr2'],
     ...     offdesign=['zeta2', 'kA'])
-    >>> hs_he.set_attr(T=120, p=1, fluid={'water': 1, 'air': 0})
+    >>> hs_he.set_attr(td_bp=20, p=1, fluid={'water': 1, 'air': 0})
     >>> amb_he.set_attr(fluid={'water': 0, 'air': 1}, T=20)
     >>> he_amb.set_attr(p=1, T=40, design=['T'])
     >>> he.set_attr(Q=-80e3)

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -21,7 +21,7 @@ from tespy.tools.helpers import (
     h_ps, h_pT ,s_ph, s_pT,
     molar_mass_flow, lamb,
     molar_masses, err,
-    dc_cp, dc_cc, dc_cm, dc_gcp, memorise, single_fluid
+    dc_cp, dc_cc, dc_cm, dc_gcp, memorise, single_fluid, dc_simple, data_container
 )
 from tespy.components import characteristics as cmp_char
 
@@ -130,11 +130,14 @@ class component:
             if key in var:
 
                 # data container specification
-                if (isinstance(kwargs[key], dc_cp) or
-                        isinstance(kwargs[key], dc_cc) or
-                        isinstance(kwargs[key], dc_cm) or
-                        isinstance(kwargs[key], dc_gcp)):
-                    self.__dict__.update({key: kwargs[key]})
+                if isinstance(kwargs[key], data_container):
+                    if isinstance(kwargs[key], self.get_attr(key)):
+                        self.__dict__.update({key: kwargs[key]})
+                    else:
+                        msg = ('The keyword ' + key + ' expects a data_container of type ' + str(type(self.get_attr(key))) +
+                               ', a data_container of type ' + str(type(kwargs[key])) + ' was supplied.')
+                        logging.error(msg)
+                        raise TypeError(msg)
 
                 elif isinstance(self.get_attr(key), dc_cp):
                     # value specification for component properties
@@ -183,6 +186,15 @@ class component:
                         msg = ('Bad datatype for keyword argument ' + key + ' at ' + self.label + '.')
                         logging.error(msg)
                         raise TypeError(msg)
+
+                elif isinstance(self.get_attr(key), dc_simple):
+                    if isinstance(kwargs[key], float):
+                        if np.isnan(kwargs[key]):
+                            self.get_attr(key).set_attr(val_set=False)
+                        else:
+                            self.get_attr(key).set_attr(val=kwargs[key], val_set=True)
+                    else:
+                        self.get_attr(key).set_attr(val=kwargs[key], val_set=True)
 
             # export sources or sinks as subsystem interface
             elif key == 'interface':
@@ -2419,10 +2431,10 @@ class node(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    num_in : float
+    num_in : float/tespy.helpers.dc_simple
         Number of inlets for this component.
 
-    num_out : float
+    num_out : float/tespy.helpers.dc_simple
         Number of outlets for this component.
 
     Note
@@ -2468,18 +2480,18 @@ class node(component):
         return 'node'
 
     def attr(self):
-        return {'num_in': dc_cp(printout=False),
-                'num_out': dc_cp(printout=False)}
+        return {'num_in': dc_simple(),
+                'num_out': dc_simple()}
 
     def inlets(self):
-        if self.num_in.is_set:
+        if self.num_in.val_set:
             return ['in' + str(i + 1) for i in range(self.num_in.val)]
         else:
             self.set_attr(num_in=2)
             return self.inlets()
 
     def outlets(self):
-        if self.num_out.is_set:
+        if self.num_out.val_set:
             return ['out' + str(i + 1) for i in range(self.num_out.val)]
         else:
             self.set_attr(num_out=2)
@@ -2846,7 +2858,7 @@ class splitter(node):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    num_out : float
+    num_out : float/tespy.helpers.dc_simple
         Number of outlets for this component.
 
     Example
@@ -2881,13 +2893,13 @@ class splitter(node):
         return 'splitter'
 
     def attr(self):
-        return {'num_out': dc_cp(printout=False)}
+        return {'num_out': dc_simple()}
 
     def inlets(self):
         return ['in1']
 
     def outlets(self):
-        if self.num_out.is_set:
+        if self.num_out.val_set:
             return ['out' + str(i + 1) for i in range(self.num_out.val)]
         else:
             self.set_attr(num_out=2)
@@ -3048,7 +3060,7 @@ class separator(node):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    num_out : float
+    num_out : float/tespy.helpers.dc_simple
         Number of outlets for this component.
 
     Example
@@ -3081,13 +3093,13 @@ class separator(node):
         return 'separator'
 
     def attr(self):
-        return {'num_out': dc_cp(printout=False)}
+        return {'num_out': dc_simple()}
 
     def inlets(self):
         return ['in1']
 
     def outlets(self):
-        if self.num_out.is_set:
+        if self.num_out.val_set:
             return ['out' + str(i + 1) for i in range(self.num_out.val)]
         else:
             self.set_attr(num_out=2)
@@ -3246,7 +3258,7 @@ class merge(node):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    num_in : float
+    num_in : float/tespy.helpers.dc_simple
         Number of inlets for this component.
 
     Example
@@ -3281,11 +3293,11 @@ class merge(node):
         return 'merge'
 
     def attr(self):
-        return {'num_in': dc_cp(printout=False),
+        return {'num_in': dc_simple(),
                 'zero_flag': dc_cp(printout=False)}
 
     def inlets(self):
-        if self.num_in.is_set:
+        if self.num_in.val_set:
             return ['in' + str(i + 1) for i in range(self.num_in.val)]
         else:
             self.set_attr(num_in=2)
@@ -3446,7 +3458,7 @@ class combustion_chamber(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    fuel : str
+    fuel : str/tespy.helpers.dc_simple
         Fuel for the combustion chamber, see list of available fluids above.
 
     lamb : float/tespy.helpers.dc_cp
@@ -3497,7 +3509,7 @@ class combustion_chamber(component):
         return 'combustion chamber'
 
     def attr(self):
-        return {'fuel': dc_cp(printout=False), 'lamb': dc_cp(), 'ti': dc_cp(),
+        return {'fuel': dc_simple(), 'lamb': dc_cp(), 'ti': dc_cp(),
                 'S': dc_cp()}
 
     def inlets(self):
@@ -3517,7 +3529,7 @@ class combustion_chamber(component):
         self.m_deriv = self.mass_flow_deriv()
         self.p_deriv = self.pressure_deriv()
 
-        if not self.fuel.is_set:
+        if not self.fuel.val_set:
             msg = 'Must specify fuel for component ' + self.label + '. Available fuels are: ' + str(self.fuels()) + '.'
             logging.error(msg)
             raise TESPyComponentError(msg)
@@ -4488,11 +4500,11 @@ class combustion_chamber_stoich(combustion_chamber):
         return 'combustion chamber stoichiometric flue gas'
 
     def attr(self):
-        return {'fuel': dc_cp(printout=False),
-                'fuel_alias': dc_cp(printout=False),
-                'air': dc_cp(printout=False),
-                'air_alias': dc_cp(printout=False),
-                'path': dc_cp(printout=False),
+        return {'fuel': dc_simple(),
+                'fuel_alias': dc_simple(),
+                'air': dc_simple(),
+                'air_alias': dc_simple(),
+                'path': dc_simple(),
                 'lamb': dc_cp(), 'ti': dc_cp(), 'S': dc_cp()}
 
     def inlets(self):
@@ -4512,12 +4524,12 @@ class combustion_chamber_stoich(combustion_chamber):
         self.m_deriv = self.mass_flow_deriv()
         self.p_deriv = self.pressure_deriv()
 
-        if not self.fuel.is_set or not isinstance(self.fuel.val, dict):
+        if not self.fuel.val_set or not isinstance(self.fuel.val, dict):
             msg = 'Must specify fuel composition for combustion chamber.'
             logging.error(msg)
             raise TESPyComponentError(msg)
 
-        if not self.fuel_alias.is_set:
+        if not self.fuel_alias.val_set:
             msg = 'Must specify fuel alias for combustion chamber.'
             logging.error(msg)
             raise TESPyComponentError(msg)
@@ -4526,12 +4538,12 @@ class combustion_chamber_stoich(combustion_chamber):
             logging.error(msg)
             raise TESPyComponentError(msg)
 
-        if not self.air.is_set or not isinstance(self.air.val, dict):
+        if not self.air.val_set or not isinstance(self.air.val, dict):
             msg = 'Must specify air composition for combustion chamber.'
             logging.error(msg)
             raise TESPyComponentError(msg)
 
-        if not self.air_alias.is_set:
+        if not self.air_alias.val_set:
             msg = 'Must specify air alias for combustion chamber.'
             logging.error(msg)
             raise TESPyComponentError(msg)
@@ -4763,7 +4775,7 @@ class combustion_chamber_stoich(combustion_chamber):
         for f in self.fg.keys():
             self.fg[f] /= m_fg
 
-        if not self.path.is_set:
+        if not self.path.val_set:
             self.path.val = None
         tespy_fluid(self.fuel_alias.val, self.fuel.val, [1000, nw.p_range_SI[1]], nw.T_range_SI, path=self.path.val)
         tespy_fluid(self.fuel_alias.val + '_fg', self.fg, [1000, nw.p_range_SI[1]], nw.T_range_SI, path=self.path.val)
@@ -5313,7 +5325,7 @@ class cogeneration_unit(combustion_chamber):
         return 'cogeneration unit'
 
     def attr(self):
-        return {'fuel': dc_cp(printout=False), 'lamb': dc_cp(), 'ti': dc_cp(),
+        return {'fuel': dc_simple(), 'lamb': dc_cp(), 'ti': dc_cp(),
                 'P': dc_cp(val=1e6, d=1, val_min=1),
                 'Q1': dc_cp(), 'Q2': dc_cp(),
                 'Qloss': dc_cp(val=1e5, d=1, val_min=1),
@@ -9596,7 +9608,7 @@ class subsys_interface(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    num_inter : float/tespy.helpers.dc_cp
+    num_inter : float/tespy.helpers.dc_simple
         Number of interfaces for subsystem.
 
     Note
@@ -9628,16 +9640,16 @@ class subsys_interface(component):
         return 'subsystem interface'
 
     def attr(self):
-        return {'num_inter': dc_cp(printout=False)}
+        return {'num_inter': dc_simple()}
 
     def inlets(self):
-        if self.num_inter.is_set:
+        if self.num_inter.val_set:
             return ['in' + str(i + 1) for i in range(self.num_inter.val)]
         else:
             return ['in1']
 
     def outlets(self):
-        if self.num_inter.is_set:
+        if self.num_inter.val_set:
             return ['out' + str(i + 1) for i in range(self.num_inter.val)]
         else:
             return ['out1']

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -131,7 +131,7 @@ class component:
 
                 # data container specification
                 if isinstance(kwargs[key], data_container):
-                    if isinstance(kwargs[key], self.get_attr(key)):
+                    if isinstance(kwargs[key], type(self.get_attr(key))):
                         self.__dict__.update({key: kwargs[key]})
                     else:
                         msg = ('The keyword ' + key + ' expects a data_container of type ' + str(type(self.get_attr(key))) +

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -157,14 +157,6 @@ class component:
                         self.get_attr(key).set_attr(is_set=True)
                         self.get_attr(key).set_attr(is_var=True)
 
-                    elif isinstance(kwargs[key], str) and kwargs[key] != 'var':
-                        self.get_attr(key).set_attr(val=kwargs[key])
-                        self.get_attr(key).set_attr(is_set=True)
-
-                    elif isinstance(kwargs[key], dict):
-                        self.get_attr(key).set_attr(val=kwargs[key])
-                        self.get_attr(key).set_attr(is_set=True)
-
                     # invalid datatype for keyword
                     else:
                         msg = ('Bad datatype for keyword argument ' + key + ' at ' + self.label + '.')
@@ -188,7 +180,10 @@ class component:
                         raise TypeError(msg)
 
                 elif isinstance(self.get_attr(key), dc_simple):
-                    if isinstance(kwargs[key], float):
+                    if (isinstance(kwargs[key], float) or
+                            isinstance(kwargs[key], np.float64) or
+                            isinstance(kwargs[key], np.int64) or
+                            isinstance(kwargs[key], int)):
                         if np.isnan(kwargs[key]):
                             self.get_attr(key).set_attr(val_set=False)
                         else:
@@ -9625,6 +9620,9 @@ class subsys_interface(component):
     >>> so1 = cmp.source('source 1')
     >>> si1 = cmp.sink('sink 1')
     >>> si = cmp.subsys_interface('test', num_inter=1)
+    >>> si2 = cmp.subsys_interface('test2', num_inter=np.nan)
+    >>> len(si.inlets()) == len(si2.inlets())
+    True
     >>> inc = con.connection(so1, 'out1', si, 'in1')
     >>> outg = con.connection(si, 'out1', si1, 'in1')
     >>> nw.add_conns(inc, outg)

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -7912,7 +7912,7 @@ class heat_exchanger(component):
     >>> nw.add_conns(tes_he, he_tes, hs_he, he_hs)
     >>> he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5,
     ...     design=['pr1', 'pr2', 'ttd_u'], offdesign=['zeta1', 'zeta2', 'kA'])
-    >>> hs_he.set_attr(td_bp=-10, p=3, fluid={'water': 1})
+    >>> hs_he.set_attr(Td_bp=-10, p=3, fluid={'water': 1})
     >>> he_hs.set_attr(T=70)
     >>> tes_he.set_attr(p=5, fluid={'water': 1})
     >>> tes_he.set_attr(T=40)
@@ -8826,7 +8826,7 @@ class condenser(heat_exchanger):
     >>> nw.add_conns(amb_he, he_amb, hs_he, he_hs)
     >>> he.set_attr(pr1=0.98, pr2=0.999, design=['pr2'],
     ...     offdesign=['zeta2', 'kA'])
-    >>> hs_he.set_attr(td_bp=20, p=1, fluid={'water': 1, 'air': 0})
+    >>> hs_he.set_attr(Td_bp=20, p=1, fluid={'water': 1, 'air': 0})
     >>> amb_he.set_attr(fluid={'water': 0, 'air': 1}, T=20)
     >>> he_amb.set_attr(p=1, T=40, design=['T'])
     >>> he.set_attr(Q=-80e3)

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -48,11 +48,15 @@ class connection:
     fluid_balance : boolean
         Fluid balance equation specification.
 
-    x : float/tespy.connections.ref/tespy.tools.helpers.dc_prop
+    x : float/tespy.tools.helpers.dc_prop
         Gas phase mass fraction specification.
 
     T : float/tespy.connections.ref/tespy.tools.helpers.dc_prop
         Temperature specification.
+
+    td_pb : float/tespy.tools.helpers.dc_prop
+        Temperature difference to boiling point at pressure corresponding
+        pressure of this connection in K.
 
     v : float/tespy.tools.helpers.dc_prop
         Volumetric flow specification.
@@ -81,6 +85,7 @@ class connection:
     Example
     -------
     >>> from tespy import con, cmp, hlp
+    >>> import numpy as np
     >>> so1 = cmp.source('source1')
     >>> so2 = cmp.source('source2')
     >>> si1 = cmp.sink('sink1')
@@ -106,6 +111,11 @@ class connection:
     -5
     >>> type(so_si2.m.ref.get_attr('obj'))
     <class 'tespy.connections.connection'>
+    >>> so_si2.set_attr(td_pb=5, T=np.nan)
+    >>> type(so_si2.td_pb)
+    <class 'tespy.tools.helpers.dc_prop'>
+    >>> so_si2.td_pb.val
+    5
     """
 
     def __init__(self, comp1, outlet_id, comp2, inlet_id, **kwargs):
@@ -193,6 +203,10 @@ class connection:
         T : float/tespy.connections.ref/tespy.tools.helpers.dc_prop
             Temperature specification.
 
+        td_pb : float/tespy.tools.helpers.dc_prop
+            Temperature difference to boiling point at pressure corresponding
+            pressure of this connection in K.
+
         v : float/tespy.tools.helpers.dc_prop
             Volumetric flow specification.
 
@@ -263,8 +277,8 @@ class connection:
 
                 # reference object
                 elif isinstance(kwargs[key], ref):
-                    if key == 'x' or key == 'v':
-                        msg = 'References for volumetric flow and vapour mass fraction not implemented.'
+                    if key == 'x' or key == 'v' or key == 'td_bp':
+                        msg = 'References for volumetric flow, vapour mass fraction and subcooling/superheating not implemented.'
                         logging.warning(msg)
                     else:
                         self.get_attr(key).set_attr(ref=kwargs[key])
@@ -339,7 +353,7 @@ class connection:
         """
         return {'m': dc_prop(), 'p': dc_prop(), 'h': dc_prop(), 'T': dc_prop(),
                 'x': dc_prop(), 'v': dc_prop(),
-                'fluid': dc_flu()}
+                'fluid': dc_flu(), 'td_bp': dc_prop()}
 
     def to_flow(self):
         r"""

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -54,7 +54,7 @@ class connection:
     T : float/tespy.connections.ref/tespy.tools.helpers.dc_prop
         Temperature specification.
 
-    td_pb : float/tespy.tools.helpers.dc_prop
+    td_bp : float/tespy.tools.helpers.dc_prop
         Temperature difference to boiling point at pressure corresponding
         pressure of this connection in K.
 
@@ -111,10 +111,10 @@ class connection:
     -5
     >>> type(so_si2.m.ref.get_attr('obj'))
     <class 'tespy.connections.connection'>
-    >>> so_si2.set_attr(td_pb=5, T=np.nan)
-    >>> type(so_si2.td_pb)
+    >>> so_si2.set_attr(td_bp=5, T=np.nan)
+    >>> type(so_si2.td_bp)
     <class 'tespy.tools.helpers.dc_prop'>
-    >>> so_si2.td_pb.val
+    >>> so_si2.td_bp.val
     5
     """
 
@@ -203,7 +203,7 @@ class connection:
         T : float/tespy.connections.ref/tespy.tools.helpers.dc_prop
             Temperature specification.
 
-        td_pb : float/tespy.tools.helpers.dc_prop
+        td_bp : float/tespy.tools.helpers.dc_prop
             Temperature difference to boiling point at pressure corresponding
             pressure of this connection in K.
 

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -275,7 +275,10 @@ class connection:
                     if kwargs[key] in ['l', 'g']:
                         self.state.set_attr(val=kwargs[key], val_set=True)
                     else:
-                        if isinstance(kwargs[key], float):
+                    if (isinstance(kwargs[key], float) or
+                            isinstance(kwargs[key], np.float64) or
+                            isinstance(kwargs[key], np.int64) or
+                            isinstance(kwargs[key], int)):
                             if np.isnan(kwargs[key]):
                                 self.state.set_attr(val=kwargs[key], val_set=False)
                             else:

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 import logging
 
-from tespy.tools.helpers import (TESPyConnectionError, data_container, dc_prop, dc_flu, dc_cp)
+from tespy.tools.helpers import (TESPyConnectionError, data_container, dc_prop, dc_flu, dc_cp, dc_simple)
 from tespy.components import components as cmp
 from tespy.components import characteristics as cmp_char
 
@@ -54,12 +54,15 @@ class connection:
     T : float/tespy.connections.ref/tespy.tools.helpers.dc_prop
         Temperature specification.
 
-    td_bp : float/tespy.tools.helpers.dc_prop
+    Td_bp : float/tespy.tools.helpers.dc_prop
         Temperature difference to boiling point at pressure corresponding
         pressure of this connection in K.
 
     v : float/tespy.tools.helpers.dc_prop
         Volumetric flow specification.
+
+    state : str
+        State of the pure fluid on this connection: liquid ('l') or gaseous ('g').
 
     design : list
         List containing design parameters (stated as string).
@@ -111,10 +114,10 @@ class connection:
     -5
     >>> type(so_si2.m.ref.get_attr('obj'))
     <class 'tespy.connections.connection'>
-    >>> so_si2.set_attr(td_bp=5, T=np.nan)
-    >>> type(so_si2.td_bp)
+    >>> so_si2.set_attr(Td_bp=5, T=np.nan)
+    >>> type(so_si2.Td_bp)
     <class 'tespy.tools.helpers.dc_prop'>
-    >>> so_si2.td_bp.val
+    >>> so_si2.Td_bp.val
     5
     """
 
@@ -203,12 +206,15 @@ class connection:
         T : float/tespy.connections.ref/tespy.tools.helpers.dc_prop
             Temperature specification.
 
-        td_bp : float/tespy.tools.helpers.dc_prop
+        Td_bp : float/tespy.tools.helpers.dc_prop
             Temperature difference to boiling point at pressure corresponding
             pressure of this connection in K.
 
         v : float/tespy.tools.helpers.dc_prop
             Volumetric flow specification.
+
+        state : str
+            State of the pure fluid on this connection: liquid ('l') or gaseous ('g').
 
         design : list
             List containing design parameters (stated as String).
@@ -230,6 +236,11 @@ class connection:
           in 'design', e. g. :code:`design=['T', 'p']`, are unset in any offdesign
           calculation, parameters given in 'offdesign' are set for offdesign
           calculation.
+
+        - The property state is applied on pure fluids only. If you specify the
+          desired state of the fluid at a connection the convergence check will
+          adjust the enthalpy values of that connection for the first iterations
+          in order to meet the state requirement.
         """
         var = self.attr()
         var0 = [x + '0' for x in var.keys()]
@@ -260,14 +271,30 @@ class connection:
                         logging.error(msg)
                         raise TypeError(msg)
 
+                elif key == 'state':
+                    if kwargs[key] in ['l', 'g']:
+                        self.state.set_attr(val=kwargs[key], val_set=True)
+                    else:
+                        if isinstance(kwargs[key], float):
+                            if np.isnan(kwargs[key]):
+                                self.state.set_attr(val=kwargs[key], val_set=False)
+                            else:
+                                msg = 'Datatype for keyword argument ' + str(key) + ' must be str.'
+                                logging.error(msg)
+                                raise TypeError(msg)
+                        else:
+                            msg = 'Keyword argument ' + str(key) + ' must be \'l\' or \'g\'.'
+                            logging.error(msg)
+                            raise ValueError(msg)
+
+
                 elif (isinstance(kwargs[key], float) or
                         isinstance(kwargs[key], np.float64) or
                         isinstance(kwargs[key], np.int64) or
                         isinstance(kwargs[key], int)):
                     # unset
                     if np.isnan(kwargs[key]) and key not in var0:
-                        self.get_attr(key).set_attr(val_set=False)
-                        self.get_attr(key).set_attr(ref_set=False)
+                        self.get_attr(key).set_attr(val_set=False, ref_set=False)
                     # starting value
                     elif key in var0:
                         self.get_attr(key.replace('0', '')).set_attr(val0=kwargs[key])
@@ -277,7 +304,7 @@ class connection:
 
                 # reference object
                 elif isinstance(kwargs[key], ref):
-                    if key == 'x' or key == 'v' or key == 'td_bp':
+                    if key == 'x' or key == 'v' or key == 'Td_bp':
                         msg = 'References for volumetric flow, vapour mass fraction and subcooling/superheating not implemented.'
                         logging.warning(msg)
                     else:
@@ -353,7 +380,7 @@ class connection:
         """
         return {'m': dc_prop(), 'p': dc_prop(), 'h': dc_prop(), 'T': dc_prop(),
                 'x': dc_prop(), 'v': dc_prop(),
-                'fluid': dc_flu(), 'td_bp': dc_prop()}
+                'fluid': dc_flu(), 'Td_bp': dc_prop(), 'state': dc_simple()}
 
     def to_flow(self):
         r"""

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -275,10 +275,10 @@ class connection:
                     if kwargs[key] in ['l', 'g']:
                         self.state.set_attr(val=kwargs[key], val_set=True)
                     else:
-                    if (isinstance(kwargs[key], float) or
-                            isinstance(kwargs[key], np.float64) or
-                            isinstance(kwargs[key], np.int64) or
-                            isinstance(kwargs[key], int)):
+                        if (isinstance(kwargs[key], float) or
+                                isinstance(kwargs[key], np.float64) or
+                                isinstance(kwargs[key], np.int64) or
+                                isinstance(kwargs[key], int)):
                             if np.isnan(kwargs[key]):
                                 self.state.set_attr(val=kwargs[key], val_set=False)
                             else:

--- a/tespy/network_reader.py
+++ b/tespy/network_reader.py
@@ -272,7 +272,7 @@ def construct_comps(c, *args):
                 kwargs[key] = dc
             # component parameters
             if isinstance(value, hlp.dc_simple):
-                dc = hlp.dc_cp(val=c[key], is_set=c[key + '_set'])
+                dc = hlp.dc_simple(val=c[key], is_set=c[key + '_set'])
                 kwargs[key] = dc
             # component characteristics
             elif isinstance(value, hlp.dc_cc):
@@ -426,7 +426,7 @@ def construct_conns(c, *args):
                              ref=None, ref_set=c[key + '_ref_set'])
             kwargs[key] = dc
 
-    key = state
+    key = 'state'
     dc = hlp.dc_simple(val=c[key], val_set=c[key + '_set'])
 
     # read fluid vector

--- a/tespy/network_reader.py
+++ b/tespy/network_reader.py
@@ -268,8 +268,11 @@ def construct_comps(c, *args):
             # component parameters
             if isinstance(value, hlp.dc_cp):
                 dc = hlp.dc_cp(val=c[key],
-                               is_set=c[key + '_set'],
-                               is_var=c[key + '_var'])
+                               is_set=c[key + '_set'], is_var=c[key + '_var'])
+                kwargs[key] = dc
+            # component parameters
+            if isinstance(value, hlp.dc_simple):
+                dc = hlp.dc_cp(val=c[key], is_set=c[key + '_set'])
                 kwargs[key] = dc
             # component characteristics
             elif isinstance(value, hlp.dc_cc):
@@ -416,12 +419,15 @@ def construct_conns(c, *args):
             kwargs[key] = c[key]
 
     # read fluid properties
-    for key in ['m', 'p', 'h', 'T', 'x', 'v']:
+    for key in ['m', 'p', 'h', 'T', 'x', 'v', 'Td_bp']:
         if key in c:
             dc = hlp.dc_prop(val=c[key], val0=c[key + '0'], val_set=c[key + '_set'],
                              unit=c[key + '_unit'], unit_set=c[key + '_unit_set'],
                              ref=None, ref_set=c[key + '_ref_set'])
             kwargs[key] = dc
+
+    key = state
+    dc = hlp.dc_simple(val=c[key], val_set=c[key + '_set'])
 
     # read fluid vector
     val = {}

--- a/tespy/network_reader.py
+++ b/tespy/network_reader.py
@@ -272,7 +272,7 @@ def construct_comps(c, *args):
                 kwargs[key] = dc
             # component parameters
             if isinstance(value, hlp.dc_simple):
-                dc = hlp.dc_simple(val=c[key], is_set=c[key + '_set'])
+                dc = hlp.dc_simple(val=c[key], val_set=c[key + '_set'])
                 kwargs[key] = dc
             # component characteristics
             elif isinstance(value, hlp.dc_cc):

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -1045,12 +1045,13 @@ class network:
                 except ValueError:
                     pass
 
-            if c.Td_bp.val_set and not c.h.val_set:
-                if c.Td_bp.val_SI > 0:
+            # check if fluid enthalpy is below/above wet steam area
+            if (c.Td_bp.val_set or c.state.val_set) and not c.h.val_set:
+                if (c.Td_bp.val_SI > 0 or (c.state.val=='g' and c.state.val_set)):
                     h = hlp.h_mix_pQ(c.to_flow(), 1)
                     if c.h.val_SI < h:
                         c.h.val_SI = h * 1.2
-                else:
+                elif (c.Td_bp.val_SI < 0 or (c.state.val=='l' and c.state.val_set)):
                     h = hlp.h_mix_pQ(c.to_flow(), 0)
                     if c.h.val_SI > h:
                         c.h.val_SI = h * 0.8
@@ -1521,15 +1522,15 @@ class network:
                 c.h.val_SI = hmax * 0.9
                 logging.debug(self.property_range_message(c, 'h'))
 
-            if c.Td_bp.val_set and not c.h.val_set and self.iter < 3:
-                if c.Td_bp.val_SI > 0:
+            if (c.Td_bp.val_set or c.state.val_set) and not c.h.val_set and self.iter < 3:
+                if (c.Td_bp.val_SI > 0 or (c.state.val=='g' and c.state.val_set)):
                     h = hlp.h_mix_pQ(c.to_flow(), 1)
                     if c.h.val_SI < h:
-                        c.h.val_SI = h * 1.05
-                else:
+                        c.h.val_SI = h * 1.02
+                elif (c.Td_bp.val_SI < 0 or (c.state.val=='l' and c.state.val_set)):
                     h = hlp.h_mix_pQ(c.to_flow(), 0)
                     if c.h.val_SI > h:
-                        c.h.val_SI = h * 0.95
+                        c.h.val_SI = h * 0.98
 
         elif self.iter < 4 and self.init_path is None:
             # pressure

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -2435,6 +2435,10 @@ class network:
                 df[key + '_ref_d'] = self.conns.apply(network.get_props, axis=1, args=(key, 'ref', 'd',))
                 df[key + '_ref_set'] = self.conns.apply(network.get_props, axis=1, args=(key, 'ref_set',))
 
+        key = 'state'
+        df[key] = self.conns.apply(network.get_props, axis=1, args=(key, 'val'))
+        df[key + '_set'] = self.conns.apply(network.get_props, axis=1, args=(key, 'val_set'))
+
         for val in self.fluids:
             # fluid mass fraction
             df[val] = self.conns.apply(network.get_props, axis=1, args=('fluid', 'val', val))

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -1004,18 +1004,18 @@ class network:
         """
         # fluid properties
         for c in self.conns.index:
-            for key in ['m', 'p', 'h', 'T', 'x', 'v', 'td_bp']:
-                if not c.get_attr(key).unit_set and key != 'x' and key != 'td_bp':
+            for key in ['m', 'p', 'h', 'T', 'x', 'v', 'Td_bp']:
+                if not c.get_attr(key).unit_set and key != 'x' and key != 'Td_bp':
                     c.get_attr(key).unit = self.get_attr(key + '_unit')
-                if key not in ['T', 'x', 'v', 'td_bp'] and not c.get_attr(key).val_set:
+                if key not in ['T', 'x', 'v', 'Td_bp'] and not c.get_attr(key).val_set:
                     self.init_val0(c, key)
                     c.get_attr(key).val_SI = c.get_attr(key).val0 * self.get_attr(key)[c.get_attr(key).unit]
-                elif key not in ['T', 'x', 'v', 'td_bp'] and c.get_attr(key).val_set:
+                elif key not in ['T', 'x', 'v', 'Td_bp'] and c.get_attr(key).val_set:
                     c.get_attr(key).val_SI = c.get_attr(key).val * self.get_attr(key)[c.get_attr(key).unit]
                 elif key == 'T' and c.T.val_set:
                     c.T.val_SI = (c.T.val + self.T[c.T.unit][0]) * self.T[c.T.unit][1]
-                elif key == 'td_bp' and c.td_bp.val_set:
-                    c.td_bp.val_SI = c.td_bp.val
+                elif key == 'Td_bp' and c.Td_bp.val_set:
+                    c.Td_bp.val_SI = c.Td_bp.val
                 elif key == 'x' and c.x.val_set:
                     c.x.val_SI = c.x.val
                 elif key == 'v' and c.v.val_set:
@@ -1045,8 +1045,8 @@ class network:
                 except ValueError:
                     pass
 
-            if c.td_bp.val_set and not c.h.val_set:
-                if c.td_bp.val_SI > 0:
+            if c.Td_bp.val_set and not c.h.val_set:
+                if c.Td_bp.val_SI > 0:
                     h = hlp.h_mix_pQ(c.to_flow(), 1)
                     if c.h.val_SI < h:
                         c.h.val_SI = h * 1.2
@@ -1521,8 +1521,8 @@ class network:
                 c.h.val_SI = hmax * 0.9
                 logging.debug(self.property_range_message(c, 'h'))
 
-            if c.td_bp.val_set and not c.h.val_set and self.iter < 3:
-                if c.td_bp.val_SI > 0:
+            if c.Td_bp.val_set and not c.h.val_set and self.iter < 3:
+                if c.Td_bp.val_SI > 0:
                     h = hlp.h_mix_pQ(c.to_flow(), 1)
                     if c.h.val_SI < h:
                         c.h.val_SI = h * 1.05
@@ -1686,7 +1686,7 @@ class network:
         data = network.solve_conn(args=(self, [self.conns], ))
 
         row = self.num_comp_eq
-        var = {0: 'm', 1: 'p', 2: 'h', 3: 'T', 4: 'x', 5: 'v', 6: 'td_bp',
+        var = {0: 'm', 1: 'p', 2: 'h', 3: 'T', 4: 'x', 5: 'v', 6: 'Td_bp',
                7: 'm', 8: 'p', 9: 'h', 10: 'T'}
         vec_res = []
 
@@ -1755,7 +1755,7 @@ class network:
                 nw.solve_prop_eq(c.name, 'T'),
                 nw.solve_prop_eq(c.name, 'x'),
                 nw.solve_prop_eq(c.name, 'v'),
-                nw.solve_prop_eq(c.name, 'td_bp'),
+                nw.solve_prop_eq(c.name, 'Td_bp'),
                 nw.solve_prop_ref_eq(c.name, 'm'),
                 nw.solve_prop_ref_eq(c.name, 'p'),
                 nw.solve_prop_ref_eq(c.name, 'h'),
@@ -1768,7 +1768,7 @@ class network:
                 nw.solve_prop_deriv(c.name, 'T'),
                 nw.solve_prop_deriv(c.name, 'x'),
                 nw.solve_prop_deriv(c.name, 'v'),
-                nw.solve_prop_deriv(c.name, 'td_bp'),
+                nw.solve_prop_deriv(c.name, 'Td_bp'),
                 nw.solve_prop_ref_deriv(c.name, 'm'),
                 nw.solve_prop_ref_deriv(c.name, 'p'),
                 nw.solve_prop_ref_deriv(c.name, 'h'),
@@ -1873,10 +1873,10 @@ class network:
             else:
                 return None
 
-        elif var == 'td_bp':
-            if c.td_bp.val_set:
+        elif var == 'Td_bp':
+            if c.Td_bp.val_set:
                 flow = c.to_flow()
-                return hlp.T_mix_ph(flow) - c.td_bp.val_SI - hlp.T_bp_p(flow)
+                return hlp.T_mix_ph(flow) - c.Td_bp.val_SI - hlp.T_bp_p(flow)
             else:
                 return None
 
@@ -2060,8 +2060,8 @@ class network:
             else:
                 return None
 
-        elif var == 'td_bp':
-            if c.td_bp.val_set:
+        elif var == 'Td_bp':
+            if c.Td_bp.val_set:
                 flow = c.to_flow()
                 deriv = np.zeros((1, 1, self.num_conn_vars))
                 # dtd / dp
@@ -2184,7 +2184,7 @@ class network:
         n = 0
         for c in self.conns.index:
             n += [c.m.val_set, c.p.val_set, c.h.val_set, c.T.val_set,
-                  c.x.val_set, c.v.val_set, c.td_bp.val_set].count(True)
+                  c.x.val_set, c.v.val_set, c.Td_bp.val_set].count(True)
             n += [c.m.ref_set, c.p.ref_set, c.h.ref_set,
                   c.T.ref_set].count(True)
             n += list(c.fluid.val_set.values()).count(True)
@@ -2418,7 +2418,7 @@ class network:
             df['design'] = self.conns.apply(network.get_props, axis=1, args=('design',))
             df['offdesign'] = self.conns.apply(network.get_props, axis=1, args=('offdesign',))
 
-        cols = ['m', 'p', 'h', 'T', 'x', 'v']
+        cols = ['m', 'p', 'h', 'T', 'x', 'v', 'Td_bp']
         for key in cols:
             # values and units
             df[key] = self.conns.apply(network.get_props, axis=1, args=(key, 'val'))

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -1004,16 +1004,18 @@ class network:
         """
         # fluid properties
         for c in self.conns.index:
-            for key in ['m', 'p', 'h', 'T', 'x', 'v']:
-                if not c.get_attr(key).unit_set and key != 'x':
+            for key in ['m', 'p', 'h', 'T', 'x', 'v', 'td_bp']:
+                if not c.get_attr(key).unit_set and key != 'x' and key != 'td_bp':
                     c.get_attr(key).unit = self.get_attr(key + '_unit')
                 if key not in ['T', 'x', 'v'] and not c.get_attr(key).val_set:
                     self.init_val0(c, key)
                     c.get_attr(key).val_SI = c.get_attr(key).val0 * self.get_attr(key)[c.get_attr(key).unit]
-                elif key not in ['T', 'x', 'v'] and c.get_attr(key).val_set:
+                elif key not in ['T', 'x', 'v', 'td_bp'] and c.get_attr(key).val_set:
                     c.get_attr(key).val_SI = c.get_attr(key).val * self.get_attr(key)[c.get_attr(key).unit]
                 elif key == 'T' and c.T.val_set:
                     c.T.val_SI = (c.T.val + self.T[c.T.unit][0]) * self.T[c.T.unit][1]
+                elif key == 'td_bp' and c.td_bp.val_set:
+                    c.td_bp.val_SI = c.td_bp.val
                 elif key == 'x' and c.x.val_set:
                     c.x.val_SI = c.x.val
                 elif key == 'v' and c.v.val_set:
@@ -1042,6 +1044,16 @@ class network:
                     c.h.val_SI = hlp.h_mix_pT(c.to_flow(), c.T.val_SI)
                 except ValueError:
                     pass
+
+            if c.td_bp.val_set and not c.h.val_set:
+                if c.td_bp.val_SI > 0:
+                    h = hlp.h_mix_pQ(c.to_flow(), 1)
+                    if c.h.val_SI < h:
+                        c.h.val_SI = h * 1.2
+                else:
+                    h = hlp.h_mix_pQ(c.to_flow(), 0)
+                    if c.h.val_SI > h:
+                        c.h.val_SI = h * 0.8
 
         msg = 'Generated starting values for specified temperature and vapour mass fraction.'
         logging.debug(msg)
@@ -1509,6 +1521,16 @@ class network:
                 c.h.val_SI = hmax * 0.9
                 logging.debug(self.property_range_message(c, 'h'))
 
+            if c.td_bp.val_set and not c.h.val_set and self.iter < 3:
+                if c.td_bp.val_SI > 0:
+                    h = hlp.h_mix_pQ(c.to_flow(), 1)
+                    if c.h.val_SI < h:
+                        c.h.val_SI = h * 1.05
+                else:
+                    h = hlp.h_mix_pQ(c.to_flow(), 0)
+                    if c.h.val_SI > h:
+                        c.h.val_SI = h * 0.95
+
         elif self.iter < 4 and self.init_path is None:
             # pressure
             if c.p.val_SI <= self.p_range_SI[0] and not c.p.val_set:
@@ -1664,8 +1686,8 @@ class network:
         data = network.solve_conn(args=(self, [self.conns], ))
 
         row = self.num_comp_eq
-        var = {0: 'm', 1: 'p', 2: 'h', 3: 'T', 4: 'x', 5: 'v',
-               6: 'm', 7: 'p', 8: 'h', 9: 'T'}
+        var = {0: 'm', 1: 'p', 2: 'h', 3: 'T', 4: 'x', 5: 'v', 6: 'td_bp',
+               7: 'm', 8: 'p', 9: 'h', 10: 'T'}
         vec_res = []
 
         # write data in residual vector and jacobian matrix
@@ -1733,6 +1755,7 @@ class network:
                 nw.solve_prop_eq(c.name, 'T'),
                 nw.solve_prop_eq(c.name, 'x'),
                 nw.solve_prop_eq(c.name, 'v'),
+                nw.solve_prop_eq(c.name, 'td_bp'),
                 nw.solve_prop_ref_eq(c.name, 'm'),
                 nw.solve_prop_ref_eq(c.name, 'p'),
                 nw.solve_prop_ref_eq(c.name, 'h'),
@@ -1745,6 +1768,7 @@ class network:
                 nw.solve_prop_deriv(c.name, 'T'),
                 nw.solve_prop_deriv(c.name, 'x'),
                 nw.solve_prop_deriv(c.name, 'v'),
+                nw.solve_prop_deriv(c.name, 'td_bp'),
                 nw.solve_prop_ref_deriv(c.name, 'm'),
                 nw.solve_prop_ref_deriv(c.name, 'p'),
                 nw.solve_prop_ref_deriv(c.name, 'h'),
@@ -1817,6 +1841,13 @@ class network:
         .. math::
             val = \dot{V}_{j} - v \left( p_{j}, h_{j} \right) \cdot \dot{m}_j
 
+        **superheating or subcooling** *Works with pure fluids only!*
+
+        .. math::
+            val = T_{j} - td_{bp} - T_{bp}\left( p_{j}, fluid_{j} \right)
+
+            \text{td: temperature difference, bp: boiling point}
+
         **vapour mass fraction** *Works with pure fluids only!*
 
         .. math::
@@ -1839,6 +1870,13 @@ class network:
             if c.v.val_set:
                 flow = c.to_flow()
                 return c.v.val_SI - hlp.v_mix_ph(flow) * c.m.val_SI
+            else:
+                return None
+
+        elif var == 'td_bp':
+            if c.td_bp.val_set:
+                flow = c.to_flow()
+                return hlp.T_mix_ph(flow) - c.td_bp.val_SI - hlp.T_bp_p(flow)
             else:
                 return None
 
@@ -1924,6 +1962,7 @@ class network:
         **mass flow, pressure and enthalpy**
 
         .. math::
+
             J\left(\frac{\partial f_{i}}{\partial m_{j}}\right) = 1\\
             \text{for equation i, connection j}\\
             \text{pressure and enthalpy analogously}
@@ -1931,31 +1970,51 @@ class network:
         **temperatures**
 
         .. math::
+
             J\left(\frac{\partial f_{i}}{\partial p_{j}}\right) =
-            -\frac{dT_{j}}{dp_{j}}\\
+            -\frac{\partial T_{j}}{\partial p_{j}}\\
             J(\left(\frac{\partial f_{i}}{\partial h_{j}}\right) =
-            -\frac{dT_{j}}{dh_{j}}\\
+            -\frac{\partial T_{j}}{\partial h_{j}}\\
             J\left(\frac{\partial f_{i}}{\partial fluid_{j,k}}\right) =
-            - \frac{dT_{j}}{dfluid_{j,k}}
-            \; , \forall k \in \text{fluid components}\\
+            - \frac{\partial T_{j}}{\partial fluid_{j,k}}
+
+            \forall k \in \text{fluid components}\\
             \text{for equation i, connection j}
 
         **volumetric flow**
 
         .. math::
+
             J\left(\frac{\partial f_{i}}{\partial m_{j}}\right) =
             -v \left( p_{j}, h_{j} \right)\\
             J\left(\frac{\partial f_{i}}{\partial p_{j}}\right) =
-            -\frac{dv_{j}}{dp_{j}} \cdot \dot{m}_j\\
+            -\frac{\partial v_{j}}{\partial p_{j}} \cdot \dot{m}_j\\
             J(\left(\frac{\partial f_{i}}{\partial h_{j}}\right) =
-            -\frac{dv_{j}}{dh_{j}} \cdot \dot{m}_j\\
+            -\frac{\partial v_{j}}{\partial h_{j}} \cdot \dot{m}_j\\
 
-            \; , \forall k \in \text{fluid components}\\
+            \forall k \in \text{fluid components}\\
             \text{for equation i, connection j}
+
+        **superheating or subcooling** *Works with pure fluids only!*
+
+        .. math::
+
+            J\left(\frac{\partial f_{i}}{\partial p_{j}}\right) =
+            \frac{\partial T \left( p_{j}, h_{j}, fluid_{j} \right)}
+            {\partial p_{j}} -
+            \frac{\partial T_{bp} \left( p_{j}, fluid_{j} \right)}
+            {\partial p_{j}} \\
+            J\left(\frac{\partial f_{i}}{\partial h_{j}}\right) =
+            \frac{\partial T \left( p_{j}, h_{j}, fluid_{j} \right)}
+            {\partial h_{j}}\\
+
+            \text{for equation i, connection j}\\
+            \text{td: temperature difference, bp: boiling point}
 
         **vapour mass fraction** *Works with pure fluids only!*
 
         .. math::
+
             J\left(\frac{\partial f_{i}}{\partial p_{j}}\right) =
             -\frac{\partial h \left( p_{j}, x_{j}, fluid_{j} \right)}
             {\partial p_{j}}\\
@@ -1997,6 +2056,18 @@ class network:
                 deriv[0, 0, 1] = -hlp.dv_mix_dph(flow) * c.m.val_SI
                 # dv / dh
                 deriv[0, 0, 2] = -hlp.dv_mix_pdh(flow) * c.m.val_SI
+                return deriv
+            else:
+                return None
+
+        elif var == 'td_bp':
+            if c.td_bp.val_set:
+                flow = c.to_flow()
+                deriv = np.zeros((1, 1, self.num_conn_vars))
+                # dtd / dp
+                deriv[0, 0, 1] = hlp.dT_mix_dph(flow) - hlp.dT_bp_dp(flow)
+                # dtd / dh
+                deriv[0, 0, 2] = hlp.dT_mix_pdh(flow)
                 return deriv
             else:
                 return None
@@ -2112,8 +2183,8 @@ class network:
 
         n = 0
         for c in self.conns.index:
-            n += [c.m.val_set, c.p.val_set, c.h.val_set,
-                  c.T.val_set, c.x.val_set, c.v.val_set].count(True)
+            n += [c.m.val_set, c.p.val_set, c.h.val_set, c.T.val_set,
+                  c.x.val_set, c.v.val_set, c.td_bp.val_set].count(True)
             n += [c.m.ref_set, c.p.ref_set, c.h.ref_set,
                   c.T.ref_set].count(True)
             n += list(c.fluid.val_set.values()).count(True)

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -1007,7 +1007,7 @@ class network:
             for key in ['m', 'p', 'h', 'T', 'x', 'v', 'td_bp']:
                 if not c.get_attr(key).unit_set and key != 'x' and key != 'td_bp':
                     c.get_attr(key).unit = self.get_attr(key + '_unit')
-                if key not in ['T', 'x', 'v'] and not c.get_attr(key).val_set:
+                if key not in ['T', 'x', 'v', 'td_bp'] and not c.get_attr(key).val_set:
                     self.init_val0(c, key)
                     c.get_attr(key).val_SI = c.get_attr(key).val0 * self.get_attr(key)[c.get_attr(key).unit]
                 elif key not in ['T', 'x', 'v', 'td_bp'] and c.get_attr(key).val_set:

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -2511,6 +2511,11 @@ class network:
                     df[col + '_var'] = df.apply(network.get_props, axis=1, args=(col, 'is_var'))
 
                 # component property container
+                elif isinstance(dc, hlp.dc_simple):
+                    df[col] = df.apply(network.get_props, axis=1, args=(col, 'val'))
+                    df[col + '_set'] = df.apply(network.get_props, axis=1, args=(col, 'val_set'))
+
+                # component property container
                 elif isinstance(dc, hlp.dc_gcp):
                     df[col] = df.apply(network.get_props, axis=1, args=(col, 'method'))
 

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -1005,8 +1005,11 @@ class network:
         # fluid properties
         for c in self.conns.index:
             for key in ['m', 'p', 'h', 'T', 'x', 'v', 'Td_bp']:
-                if not c.get_attr(key).unit_set and key != 'x' and key != 'Td_bp':
-                    c.get_attr(key).unit = self.get_attr(key + '_unit')
+                if not c.get_attr(key).unit_set and key != 'x':
+                    if key == 'Td_bp':
+                        c.get_attr(key).unit = self.get_attr('T_unit')
+                    else:
+                        c.get_attr(key).unit = self.get_attr(key + '_unit')
                 if key not in ['T', 'x', 'v', 'Td_bp'] and not c.get_attr(key).val_set:
                     self.init_val0(c, key)
                     c.get_attr(key).val_SI = c.get_attr(key).val0 * self.get_attr(key)[c.get_attr(key).unit]
@@ -1015,7 +1018,7 @@ class network:
                 elif key == 'T' and c.T.val_set:
                     c.T.val_SI = (c.T.val + self.T[c.T.unit][0]) * self.T[c.T.unit][1]
                 elif key == 'Td_bp' and c.Td_bp.val_set:
-                    c.Td_bp.val_SI = c.Td_bp.val
+                    c.Td_bp.val_SI = c.Td_bp.val * self.T[c.T.unit][1]
                 elif key == 'x' and c.x.val_set:
                     c.x.val_SI = c.x.val
                 elif key == 'v' and c.v.val_set:

--- a/tespy/tools/helpers.py
+++ b/tespy/tools/helpers.py
@@ -1471,6 +1471,68 @@ def dh_mix_dpQ(flow, Q):
 # %%
 
 
+def T_bp_p(flow):
+    r"""
+    Calculates temperature from boiling point pressure.
+
+    Parameters
+    ----------
+    flow : list
+        Fluid property vector containing mass flow, pressure, enthalpy and fluid composition.
+
+    Returns
+    -------
+    T : float
+        Temperature at boiling point.
+
+    Note
+    ----
+    This function works for pure fluids only!
+    """
+    n = molar_mass_flow(flow[3])
+
+    for fluid, x in flow[3].items():
+        if x > err:
+            pp = flow[1] * x / (molar_masses[fluid] * n)
+
+            memorise.heos[fluid].update(CP.PQ_INPUTS, pp, 1)
+            return memorise.heos[fluid].T()
+
+
+def dT_bp_dp(flow):
+    r"""
+    Calculate partial derivate of temperature to boiling point pressure.
+
+    Parameters
+    ----------
+    flow : list
+        Fluid property vector containing mass flow, pressure, enthalpy and fluid composition.
+
+    Returns
+    -------
+    dT / dp : float
+        Partial derivative of temperature to boiling point pressure in K / Pa.
+
+        .. math::
+
+            \frac{\partial h_{mix}}{\partial p} =
+            \frac{T_{bp}(p+d)-T_{bp}(p-d)}{2 \cdot d}\\
+            Q: \text{vapour mass fraction}
+
+    Note
+    ----
+    This works for pure fluids only!
+    """
+    d = 1
+    u = flow.copy()
+    l = flow.copy()
+    u[1] += d
+    l[1] -= d
+    return (T_bp_p(u) - T_bp_p(l)) / (2 * d)
+
+# %%
+
+
 def v_mix_ph(flow):
     r"""
     Calculates the specific volume from pressure and enthalpy.

--- a/tespy/tools/helpers.py
+++ b/tespy/tools/helpers.py
@@ -82,6 +82,8 @@ class data_container:
     >>> type(hlp.dc_prop(val=5, val_SI=500000, val_set=True, unit='bar',
     ...     unit_set=False, ref=None, ref_set=False))
     <class 'tespy.tools.helpers.dc_prop'>
+    >>> type(hlp.dc_simple(val=5, val_set=False))
+    <class 'tespy.tools.helpers.dc_simple'>
     """
 
     def __init__(self, **kwargs):
@@ -176,6 +178,23 @@ class dc_prop(data_container):
         return {'val': np.nan, 'val0': np.nan, 'val_SI': 0, 'val_set': False,
                 'ref': None, 'ref_set': False,
                 'unit': None, 'unit_set': False, 'design': np.nan}
+
+
+class dc_simple(data_container):
+    r"""
+    Simple data container without data type restrictions to val field.
+
+    Parameters
+    ----------
+    val : no specific datatype
+        Value for the property, no predefined datatype. Unset this property by
+        stating val=np.nan.
+
+    val_set : boolean
+        Has the value for this property been set? default: val_set=False.
+    """
+    def attr(self):
+        return {'val': np.nan, 'val_set': False}
 
 
 class dc_flu(data_container):

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -94,6 +94,7 @@ class specification_error_tests:
         self.set_attr_ValueError(self.comp, offdesign=['Q'])
 
         self.set_attr_ValueError(self.conn, offdesign=['f'])
+        self.set_attr_ValueError(self.conn, state='f')
 
         self.set_attr_ValueError(self.nw, m_unit='kg')
         self.set_attr_ValueError(self.nw, h_unit='kg')
@@ -108,11 +109,13 @@ class specification_error_tests:
         self.set_attr_TypeError(self.comp, P=[5])
         self.set_attr_TypeError(self.comp, tiP_char=None)
         self.set_attr_TypeError(self.comp, design='f')
+        self.set_attr_TypeError(self.comp, fuel=hlp.dc_cp(val='CH4'))
 
         self.set_attr_TypeError(self.conn, design='h')
         self.set_attr_TypeError(self.conn, fluid_balance=1)
         self.set_attr_TypeError(self.conn, h0=[4])
         self.set_attr_TypeError(self.conn, fluid=5)
+        self.set_attr_TypeError(self.conn, state=5)
 
         self.set_attr_TypeError(self.nw, p_range=5)
         self.set_attr_TypeError(self.nw, h_range=5)


### PR DESCRIPTION
Add functionality for setting subcooling oder superheating temperature. With this feature you are able to specify the temperature difference to boiling point (`Td_bp`). I have added an example code:

```
nw = nwk.network(['water', 'air'], T_unit='C', p_unit='bar', h_unit='kJ / kg')

so = cmp.source('so')
si = cmp.sink('si')

c = con.connection(so, 'out1', si, 'in1')

nw.add_conns(c)

c.set_attr(p=1, fluid={'water': 1, 'air': 0}, m=5, Td_bp=-5) # temperature is 5 K below boiling point

nw.solve('design')
nw.print_results()

c.set_attr(p=1, fluid={'water': 1, 'air': 0}, m=5, Td_bp=5) # temperature is 5 K above boiling point

nw.solve('design')
nw.print_results()
```
resolve #65