### PR TITLE
Make combustion more flexible

### DIFF
--- a/doc/using_tespy.rst
+++ b/doc/using_tespy.rst
@@ -71,7 +71,7 @@ Moreover, it is possible to specify parameters for the component, for example po
 The full list of parameters for a specific component (e. g. a valve) is stated in the classes documentation.
 
 .. note::
-	Parameters for components are generally optional. Only the components label and in case you want to use a combustion chamber, the combustion chambers fuel, are mandatory parameters to provide.
+	Parameters for components are generally optional. Only the components label and in case you want to use a stoichiometric combustion chamber, its fuel and air composition, are mandatory parameters to provide.
 	If an optional parameter is not specified by the user, it will be a result of the plants simulation. In this way, the set of equations a component returns is determined by which parameters you specify.
 	You can find all equations in the :ref:`components documentation <using_tespy_components_label>` as well. The example below shows how to create a component with specific parameters, set or reset and how to unset a parameter:
 
@@ -1023,7 +1023,7 @@ Offdesign calculations use the referenced value from your system design point fo
 	The available keywords for the dictionary are
 
 	- 'c' for the component instance,
-	- 'p' for the parameter (the cogeneration unit has different parameters, have a look at the :ref:`cogeneration unit example <cogeneration_unit_label>`),
+	- 'p' for the parameter (the cogeneration unit has various parameters, have a look at the :ref:`cogeneration unit example <cogeneration_unit_label>`),
 	- 'P_ref' for the reference heat flow/power value of the component and
 	- 'char' for the characteristic line.
 

--- a/doc/whats_new/v0-1-2.rst
+++ b/doc/whats_new/v0-1-2.rst
@@ -4,10 +4,14 @@ v0.1.2 (July, some day, 2019)
 New Features
 ############
 - The water electrolyzer is available as new component of TESPy (`PR #73 <https://github.com/oemof/tespy/pull/73>`_).
+- The components :py:class:`Combustion chamber <tespy.components.components.combustion_chamber>` and :py:class:`Cogeneration unit <tespy.components.components.cogeneration_unit>`
+  now work with fuel mixtures, too. Specification of the component's fuel is not required anymore, the software automatically detects,
+  which fuels are connected to the component's inlets. Available fuels are: methane, ethane, propane, butane and hydrogen (`PR #79 <https://github.com/oemof/tespy/pull/79>`_).
 
 Documentation
 #############
 - Fix some typos in the docstrings and improvements of default values (`PR #69 <https://github.com/oemof/tespy/pull/69>`_ and `PR #71 <https://github.com/oemof/tespy/pull/71>`_).
+- Update combustion chamber tutorial (`PR #79 <https://github.com/oemof/tespy/pull/79>`_).
 
 Parameter renaming
 ##################
@@ -18,6 +22,7 @@ Testing
 Bug fixes
 #########
 - Fix convergence check for negative minimum enthalpy values (`PR #71 <https://github.com/oemof/tespy/pull/71>`_).
+- Add an error message if the user did not add any connections to the network (`PR #79 <https://github.com/oemof/tespy/pull/79>`_).
 
 Other changes
 #############

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -629,6 +629,13 @@ class network:
             - Set component and connection design point properties.
             - Switch from design/offdesign parameter specification.
         """
+        if len(self.conns) == 0:
+            msg = ('No connections have been added to the network, please '
+                   'make sure to add your connections with the '
+                   '.add_conns() method.')
+            logging.error(msg)
+            raise hlp.TESPyNetworkError(msg)
+
         if len(self.fluids) == 0:
             msg = ('Network has no fluids, please specify a list with fluids on network creation.')
             logging.error(msg)

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -383,36 +383,18 @@ def test_tespy_fluid_alias_value():
 
 class combustion_chamber_error_tests:
 
-    def setup(self):
-        self.nw = nwk.network(['H2O', 'N2', 'O2', 'Ar', 'CO2', 'H2'])
-        self.comb = cmp.combustion_chamber('combustion chamber')
-        c1 = con.connection(cmp.source('air'), 'out1', self.comb, 'in1')
-        c2 = con.connection(cmp.source('fuel'), 'out1', self.comb, 'in2')
-        c3 = con.connection(self.comb, 'out1', cmp.sink('flue gas'), 'in1')
-        self.nw.add_conns(c1, c2, c3)
-
     @raises(hlp.TESPyComponentError)
     def test_combustion_chamber_missing_fuel(self):
         """
-        Test missing fuel specification error.
+        Test no fuel in network.
         """
-        self.nw.solve('design', init_only=True)
-
-    @raises(hlp.TESPyComponentError)
-    def test_combustion_chamber_missing_fuel(self):
-        """
-        Test fuel not in network.
-        """
-        self.comb.set_attr(fuel='CH4')
-        self.nw.solve('design', init_only=True)
-
-    @raises(hlp.TESPyComponentError)
-    def test_combustion_chamber_missing_fuel(self):
-        """
-        Test non available fuel.
-        """
-        self.comb.set_attr(fuel='NH3')
-        self.nw.solve('design', init_only=True)
+        nw = nwk.network(['H2O', 'N2', 'O2', 'Ar', 'CO2'])
+        comb = cmp.combustion_chamber('combustion chamber')
+        c1 = con.connection(cmp.source('air'), 'out1', comb, 'in1')
+        c2 = con.connection(cmp.source('fuel'), 'out1', comb, 'in2')
+        c3 = con.connection(comb, 'out1', cmp.sink('flue gas'), 'in1')
+        nw.add_conns(c1, c2, c3)
+        nw.solve('design', init_only=True)
 
 
 class combustion_chamber_stoich_error_tests:


### PR DESCRIPTION
The combustion chamber and cogeneration unit should work with a mix of different fuels and not only one specific fuel. The keyword argument fuel will be deprecated as the component will automatically recognize available fuels in the incoming mass flows. Still to do:

- [x] update documentation.
- [x] create an example with a mixture of different fuels.

Resolve #77 
Resolve #76 