### PR TITLE
Make offdesign calculation more flexible

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,7 @@ Discover noteable new features and improvements in each release
     :local:
     :backlinks: top
 
+.. include::  whats_new/v0-1-3.rst
 .. include::  whats_new/v0-1-2.rst
 .. include::  whats_new/v0-1-1.rst
 .. include::  whats_new/v0-1-0.rst

--- a/doc/whats_new/v0-1-3.rst
+++ b/doc/whats_new/v0-1-3.rst
@@ -1,0 +1,32 @@
+v0.1.3 (to be dated)
+++++++++++++++++++++
+
+New Features
+############
+- Individual design path specification is available: Specify the design_path individually for single connections or a components in your network, if 
+  you want the individual design parameters be loaded from a different design case than the network's design case given in the network's
+  design path (`PR #84 <https://github.com/oemof/tespy/pull/84>`_).
+
+Documentation
+#############
+
+Parameter renaming
+##################
+
+Testing
+#######
+- Added tests for the new design path feature (`PR #84 <https://github.com/oemof/tespy/pull/84>`_).
+
+Bug fixes
+#########
+- Offdesign values for connections are specified from the design case files (`PR #84 <https://github.com/oemof/tespy/pull/84>`_). Before, the offdesign values
+  were the actual values of the fluid property in the last calculation (which is not necessarily the design case).
+
+Other changes
+#############
+- Improved calculation speed for fluid mixture properties with the parameter T0 as starting value for root finding (`PR #84 <https://github.com/oemof/tespy/pull/84>`_).
+  
+Contributors
+############
+
+- Francesco Witte

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -17,11 +17,12 @@ import CoolProp.CoolProp as CP
 from tespy.tools.helpers import (
     num_fluids, fluid_structure, TESPyComponentError, tespy_fluid,
     v_mix_ph, h_mix_pT, h_mix_ps, s_mix_pT, s_mix_ph, T_mix_ph, visc_mix_ph,
-    dT_mix_dph, dT_mix_pdh, dT_mix_ph_dfluid, h_mix_pQ, dh_mix_dpQ,
-    h_ps, h_pT ,s_ph, s_pT,
+    dT_mix_dph, dT_mix_pdh, dT_mix_ph_dfluid, h_mix_pQ, dh_mix_dpQ, T_bp_p,
+    h_ps, h_pT, s_ph,
     molar_mass_flow, lamb,
     molar_masses, err,
-    dc_cp, dc_cc, dc_cm, dc_gcp, memorise, single_fluid, dc_simple, data_container
+    dc_cp, dc_cc, dc_cm, dc_gcp, memorise, single_fluid, dc_simple,
+    data_container
 )
 from tespy.components import characteristics as cmp_char
 
@@ -37,9 +38,6 @@ class component:
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -50,28 +48,27 @@ class component:
         Path to the components design case.
 
     **kwargs :
-        See the class documentation of desired component for available keywords.
+        See the class documentation of desired component for available
+        keywords.
 
     Note
     ----
-    The initialisation method (__init__), setter method (set_attr) and getter method (get_attr)
-    are used for instances of class component and its children.
+    The initialisation method (__init__), setter method (set_attr) and getter
+    method (get_attr) are used for instances of class component and its
+    children.
 
-    Allowed keywords in kwargs are 'mode', 'design' and 'offdesign'. Additional
-    keywords depend on the type of component you want to create.
+    Allowed keywords in kwargs are 'design_path', 'design' and 'offdesign'.
+    Additional keywords depend on the type of component you want to create.
 
     Example
     -------
-    Basic example for a setting up a tespy.components.components.component object.
-    This example does not run a tespy calculation.
+    Basic example for a setting up a tespy.components.components.component
+    object. This example does not run a tespy calculation.
 
     >>> from tespy import cmp
     >>> comp = cmp.component('myComponent')
-    >>> comp.set_attr(mode='man')
     >>> type(comp)
     <class 'tespy.components.components.component'>
-    >>> comp.get_attr('mode')
-    'man'
     """
 
     def __init__(self, label, **kwargs):
@@ -82,13 +79,13 @@ class component:
             logging.error(msg)
             raise ValueError(msg)
         elif len([x for x in [';', ',', '.'] if x in label]) > 0:
-            msg = ('Can\'t use ' + str([';', ',', '.']) + ' in label (' + str(self.component()) + ').')
+            msg = ('Can\'t use ' + str([';', ',', '.']) + ' in label (' +
+                   str(self.component()) + ').')
             logging.error(msg)
             raise ValueError(msg)
         else:
             self.label = label
 
-        self.mode = 'auto'
         self.design_path = None
 
         # set default design and offdesign parameters
@@ -106,13 +103,11 @@ class component:
 
     def set_attr(self, **kwargs):
         r"""
-        Sets, resets or unsets attributes of a component for provided keyword arguments.
+        Sets, resets or unsets attributes of a component for provided keyword
+        arguments.
 
         Parameters
         ----------
-        mode : str
-            'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
         design : list
             List containing design parameters (stated as String).
 
@@ -123,12 +118,14 @@ class component:
             Path to the components design case.
 
         **kwargs :
-            See the class documentation of desired component for available keywords.
+            See the class documentation of desired component for available
+            keywords.
 
         Note
         ----
         Allowed keywords in kwargs are obtained from class documentation as all
-        components share the :func:`tespy.components.components.component.set_attr` method.
+        components share the
+        :func:`tespy.components.components.component.set_attr` method.
         """
         var = self.attr().keys()
 
@@ -235,15 +232,6 @@ class component:
                     logging.error(msg)
                     raise ValueError(msg)
 
-            elif key == 'mode':
-                if kwargs[key] in ['man', 'auto']:
-                    self.__dict__.update({key: kwargs[key]})
-                else:
-                    msg = ('Mode must be \'man\' or \'auto\' at ' +
-                           self.label + '.')
-                    logging.error(msg)
-                    raise ValueError(msg)
-
             elif key == 'design_path':
                 if isinstance(kwargs[key], str) or kwargs[key] is None:
                     self.__dict__.update({key: kwargs[key]})
@@ -276,7 +264,8 @@ class component:
         if key in self.__dict__:
             return self.__dict__[key]
         else:
-            msg = 'Component ' + self.label + ' has no attribute \"' + key + '\".'
+            msg = ('Component ' + self.label + ' has no attribute \"' +
+                   key + '\".')
             logging.error(msg)
             raise KeyError(msg)
 
@@ -298,9 +287,9 @@ class component:
                     self.num_vars += 1
                     self.vars[self.get_attr(var)] = var
 
-        msg = 'Component ' + self.label + ' has ' + str(self.num_vars) + ' custom variables.'
+        msg = ('The component ' + self.label + ' has ' + str(self.num_vars) +
+               ' custom variables.')
         logging.debug(msg)
-
 
         # characteristics creation
         for key, val in self.attr().items():
@@ -308,20 +297,23 @@ class component:
                 generate_char = False
                 if self.get_attr(key).func is None:
                     generate_char = True
-                elif (not np.array_equal(self.get_attr(key).func.x, self.get_attr(key).x) or
-                      not np.array_equal(self.get_attr(key).func.y, self.get_attr(key).y)):
+                elif (not np.array_equal(self.get_attr(key).func.x,
+                                         self.get_attr(key).x) or
+                      not np.array_equal(self.get_attr(key).func.y,
+                                         self.get_attr(key).y)):
                     generate_char = True
 
                 if generate_char:
                     self.get_attr(key).func = cmp_char.characteristics(
-                            method=self.get_attr(key).method, x=self.get_attr(key).x,
+                            method=self.get_attr(key).method,
+                            x=self.get_attr(key).x,
                             y=self.get_attr(key).y, comp=self.component())
                     self.get_attr(key).x = self.get_attr(key).func.x
                     self.get_attr(key).y = self.get_attr(key).func.y
 
-                    msg = 'Generated characteristic line for attribute ' + key + ' at component ' + self.label + '.'
+                    msg = ('Generated characteristic line for attribute ' +
+                           key + ' at component ' + self.label + '.')
                     logging.debug(msg)
-
 
         self.num_fl = len(nw.fluids)
         self.fluids = nw.fluids
@@ -349,7 +341,8 @@ class component:
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -375,7 +368,8 @@ class component:
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -435,7 +429,8 @@ class component:
 
     def fluid_func(self):
         r"""
-        Calculates the vector of residual values for component's fluid balance equations.
+        Calculates the vector of residual values for component's fluid balance
+        equations.
 
         Returns
         -------
@@ -443,7 +438,8 @@ class component:
             Vector of residual values for component's fluid balance.
 
             .. math::
-                0 = fluid_{i,in} - fluid_{i,out} \; \forall i \in \mathrm{fluid}
+                0 = fluid_{i,in} - fluid_{i,out} \;
+                \forall i \in \mathrm{fluid}
         """
         vec_res = []
 
@@ -473,7 +469,8 @@ class component:
 
     def mass_flow_func(self):
         r"""
-        Calculates the residual value for component's mass flow balance equation.
+        Calculates the residual value for component's mass flow balance
+        equation.
 
         Returns
         -------
@@ -499,10 +496,12 @@ class component:
         Returns
         -------
         deriv : list
-            Matrix with partial derivatives for the mass flow balance equations.
+            Matrix with partial derivatives for the mass flow balance
+            equations.
         """
 
-        deriv = np.zeros((1, self.num_i + self.num_o + self.num_vars, 3 + self.num_fl))
+        deriv = np.zeros((1, self.num_i + self.num_o +
+                          self.num_vars, 3 + self.num_fl))
         for i in range(self.num_i):
             deriv[0, i, 0] = 1
         for j in range(self.num_o):
@@ -513,7 +512,8 @@ class component:
 
     def numeric_deriv(self, func, dx, pos, **kwargs):
         r"""
-        Calculates partial derivative of the function func to dx at given connection.
+        Calculates partial derivative of the function func to dx at given
+        connection.
 
         Parameters
         ----------
@@ -524,13 +524,15 @@ class component:
             Partial derivative.
 
         pos : int
-            Position of connection regarding to inlets and outlet of the component,
-            logic: ['in1', 'in2', ..., 'out1', ...] -> 0, 1, ..., n, n + 1, ..., n + m
+            Position of connection regarding to inlets and outlet of the
+            component, logic: ['in1', 'in2', ..., 'out1', ...] ->
+            0, 1, ..., n, n + 1, ..., n + m
 
         Returns
         -------
         deriv : float/list
-            Partial derivative(s) of the function :math:`f` to variable(s) :math:`x`.
+            Partial derivative(s) of the function :math:`f` to variable(s)
+            :math:`x`.
 
             .. math::
 
@@ -599,7 +601,7 @@ class component:
 
 # %%
 
-    def zeta_func(self ):
+    def zeta_func(self):
         r"""
         Calculates residual value of :math:`\zeta`-function.
 
@@ -613,14 +615,16 @@ class component:
                 val = \begin{cases}
                 p_{in} - p_{out} & |\dot{m}| < \epsilon \\
                 \zeta - \frac{(p_{in} - p_{out}) \cdot \pi^2}{8 \cdot
-                \dot{m}_{in} \cdot |\dot{m}_{in}| \cdot \frac{v_{in} + v_{out}}{2}} &
+                \dot{m}_{in} \cdot |\dot{m}_{in}| \cdot \frac{v_{in} +
+                v_{out}}{2}} &
                 |\dot{m}| > \epsilon
                 \end{cases}
 
         Note
         ----
-        The zeta value is caluclated on the basis of a given pressure loss at a given flow rate.
-        As the cross sectional area A will not change, it is possible to handle the equation in this way.
+        The zeta value is caluclated on the basis of a given pressure loss at
+        a given flow rate. As the cross sectional area A will not change, it is
+        possible to handle the equation in this way.
 
         .. math::
 
@@ -638,12 +642,15 @@ class component:
             return i[1] - o[1]
 
         else:
+            v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+            v_o = v_mix_ph(o, T0=self.outl[0].T.val_SI)
             return (val - (i[1] - o[1]) * math.pi ** 2 /
-                    (8 * abs(i[0]) * i[0] * (v_mix_ph(i) + v_mix_ph(o)) / 2))
+                    (8 * abs(i[0]) * i[0] * (v_i + v_o) / 2))
 
     def zeta2_func(self):
         r"""
-        calculates residual value of :math:`\zeta`-function (for heat exchangers at lower temperature side).
+        calculates residual value of :math:`\zeta`-function (for heat
+        exchangers at lower temperature side).
 
         Returns
         -------
@@ -655,14 +662,16 @@ class component:
                 val = \begin{cases}
                 p_{in} - p_{out} & |\dot{m}| < \epsilon \\
                 \zeta_2 - \frac{(p_{2,in} - p_{2,out}) \cdot \pi^2}{8 \cdot
-                \dot{m}_{2,in} \cdot |\dot{m}_{2,in}| \cdot \frac{v_{2,in} + v_{2,out}}{2}} &
+                \dot{m}_{2,in} \cdot |\dot{m}_{2,in}| \cdot \frac{v_{2,in} +
+                v_{2,out}}{2}} &
                 |\dot{m}| > \epsilon
                 \end{cases}
 
         Note
         ----
-        The zeta value is caluclated on the basis of a given pressure loss at a given flow rate.
-        As the cross sectional area A will not change, it is possible to handle the equation in this way.
+        The zeta value is caluclated on the basis of a given pressure loss at a
+        given flow rate. As the cross sectional area A will not change, it is
+        possible to handle the equation in this way.
 
         .. math::
 
@@ -675,9 +684,10 @@ class component:
         if abs(i[0]) < 1e-4:
             return i[1] - o[1]
         else:
-
+            v_i = v_mix_ph(i, T0=self.inl[1].T.val_SI)
+            v_o = v_mix_ph(o, T0=self.outl[1].T.val_SI)
             return (self.zeta2.val - (i[1] - o[1]) * math.pi ** 2 /
-                    (8 * abs(i[0]) * i[0] * (v_mix_ph(i) + v_mix_ph(o)) / 2))
+                    (8 * abs(i[0]) * i[0] * (v_i + v_o) / 2))
 
 # %%
 
@@ -693,9 +703,6 @@ class source(component):
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -724,9 +731,6 @@ class sink(component):
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -784,10 +788,6 @@ class turbomachine(component):
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual
-        switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -1003,9 +1003,9 @@ class turbomachine(component):
                 if x > err:
                     return h_ps(o[1], s_ph(i[1], i[2], fluid), fluid)
         else:
-            T_mix = T_mix_ph(i)
+            T_mix = T_mix_ph(i, T0=self.inl[0].T.val_SI)
             s_mix = s_mix_pT(i, T_mix)
-            return h_mix_ps(o, s_mix)
+            return h_mix_ps(o, s_mix, T0=self.outl[0].T.val_SI)
 
     def bus_func(self, bus):
         r"""
@@ -1108,9 +1108,6 @@ class pump(turbomachine):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -1172,13 +1169,15 @@ class pump(turbomachine):
         return 'pump'
 
     def attr(self):
-        return {'P': dc_cp(), 'eta_s': dc_cp(), 'pr': dc_cp(), 'Sirr': dc_simple(),
+        return {'P': dc_cp(), 'eta_s': dc_cp(), 'pr': dc_cp(),
+                'Sirr': dc_simple(),
                 'eta_s_char': dc_cc(method='GENERIC'),
                 'flow_char': dc_cc()}
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for pump.
+        Calculates vector vec_res with results of additional equations for
+        pump.
 
         Equations
 
@@ -1208,7 +1207,8 @@ class pump(turbomachine):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -1248,7 +1248,8 @@ class pump(turbomachine):
 
     def eta_s_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the isentropic efficiency function.
+        Calculates the matrix of partial derivatives of the isentropic
+        efficiency function.
 
         Returns
         -------
@@ -1257,12 +1258,10 @@ class pump(turbomachine):
         """
         deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
 
-        for i in range(2):
-            deriv[0, i, 1] = self.numeric_deriv(self.eta_s_func, 'p', i)
-            if i == 0:
-                deriv[0, i, 2] = self.numeric_deriv(self.eta_s_func, 'h', i)
-            else:
-                deriv[0, i, 2] = -self.eta_s.val
+        deriv[0, 0, 1] = self.numeric_deriv(self.eta_s_func, 'p', 0)
+        deriv[0, 1, 1] = self.numeric_deriv(self.eta_s_func, 'p', 1)
+        deriv[0, 0, 2] = self.numeric_deriv(self.eta_s_func, 'h', 0)
+        deriv[0, 1, 2] = -self.eta_s.val
 
         return deriv.tolist()
 
@@ -1277,8 +1276,11 @@ class pump(turbomachine):
 
             .. math::
 
-                0 = \left( h_{out} - h_{in} \right) \cdot \frac{\Delta h_{s,ref}}{\Delta h_{ref}}
-                \cdot char\left( \frac{\dot{m}_{in} \cdot v_{in}}{\dot{m}_{in,ref} \cdot v_{in,ref}} \right) - \left( h_{out,s} - h_{in} \right)
+                0 = \left( h_{out} - h_{in} \right) \cdot
+                \frac{\Delta h_{s,ref}}{\Delta h_{ref}}
+                \cdot char\left( \frac{\dot{m}_{in} \cdot
+                v_{in}}{\dot{m}_{in,ref} \cdot v_{in,ref}} \right) -
+                \left( h_{out,s} - h_{in} \right)
         """
         # actual values
         i = self.inl[0].to_flow()
@@ -1286,13 +1288,17 @@ class pump(turbomachine):
         # design values
         i_d = self.inl[0].to_flow_design()
 
-        expr = i[0] * v_mix_ph(i) / (i_d[0] * v_mix_ph(i_d))
+        v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
 
-        return (o[2] - i[2]) * self.eta_s.design * self.eta_s_char.func.f_x(expr) - (self.h_os('post') - i[2])
+        expr = i[0] * v_i / (i_d[0] * v_mix_ph(i_d))
+
+        return ((o[2] - i[2]) * self.eta_s.design *
+                self.eta_s_char.func.f_x(expr) - (self.h_os('post') - i[2]))
 
     def eta_s_char_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the isentropic efficiency characteristic function.
+        Calculates the matrix of partial derivatives of the isentropic
+        efficiency characteristic function.
 
         Returns
         -------
@@ -1302,9 +1308,10 @@ class pump(turbomachine):
         deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
 
         deriv[0, 0, 0] = self.numeric_deriv(self.eta_s_char_func, 'm', 0)
-        for i in range(2):
-            deriv[0, i, 1] = self.numeric_deriv(self.eta_s_char_func, 'p', i)
-            deriv[0, i, 2] = self.numeric_deriv(self.eta_s_char_func, 'h', i)
+        deriv[0, 0, 1] = self.numeric_deriv(self.eta_s_char_func, 'p', 0)
+        deriv[0, 0, 2] = self.numeric_deriv(self.eta_s_char_func, 'h', 0)
+        deriv[0, 1, 1] = self.numeric_deriv(self.eta_s_char_func, 'p', 1)
+        deriv[0, 1, 2] = self.numeric_deriv(self.eta_s_char_func, 'h', 1)
 
         return deriv.tolist()
 
@@ -1319,18 +1326,20 @@ class pump(turbomachine):
 
             .. math::
 
-                0 = p_{out} - p_{in} - char\left( \dot{m}_{in} \cdot v_{in} \right)
+                0 = p_{out} - p_{in} - char\left( \dot{m}_{in}
+                \cdot v_{in} \right)
         """
         i = self.inl[0].to_flow()
         o = self.outl[0].to_flow()
 
-        expr = i[0] * v_mix_ph(i)
+        expr = i[0] * v_mix_ph(i, T0=self.inl[0].T.val_SI)
 
         return o[1] - i[1] - self.flow_char.func.f_x(expr)
 
     def flow_char_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the flow characteristic of a pump.
+        Calculates the matrix of partial derivatives of the flow characteristic
+        of a pump.
 
         Returns
         -------
@@ -1357,7 +1366,8 @@ class pump(turbomachine):
 
         Note
         ----
-        Manipulate enthalpies/pressure at inlet and outlet if not specified by user to match physically feasible constraints.
+        Manipulate enthalpies/pressure at inlet and outlet if not specified by
+        user to match physically feasible constraints.
         """
         i, o = self.inl, self.outl
 
@@ -1372,18 +1382,21 @@ class pump(turbomachine):
                 i[0].h.val_SI = o[0].h.val_SI * 0.9
 
         if self.flow_char.is_set:
-            expr = i[0].m.val_SI * v_mix_ph(i[0].to_flow())
+            expr = i[0].m.val_SI * v_mix_ph(i[0].to_flow(), T0=i[0].T.val_SI)
 
             if expr > self.flow_char.func.x[-1] and not i[0].m.val_set:
-                i[0].m.val_SI = self.flow_char.func.x[-1] / v_mix_ph(i[0].to_flow())
+                i[0].m.val_SI = (self.flow_char.func.x[-1] /
+                                 v_mix_ph(i[0].to_flow(), T0=i[0].T.val_SI))
             elif expr < self.flow_char.func.x[1] and not i[0].m.val_set:
-                i[0].m.val_SI = self.flow_char.func.x[0] / v_mix_ph(i[0].to_flow())
+                i[0].m.val_SI = (self.flow_char.func.x[0] /
+                                 v_mix_ph(i[0].to_flow(), T0=i[0].T.val_SI))
             else:
                 pass
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -1412,7 +1425,8 @@ class pump(turbomachine):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -1456,14 +1470,14 @@ class pump(turbomachine):
             # get bound errors for isentropic efficiency characteristics
             i = self.inl[0].to_flow()
             i_d = self.inl[0].to_flow_design()
-            expr = i[0] * v_mix_ph(i) / (i_d[0] * v_mix_ph(i_d))
+            v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+            expr = i[0] * v_i / (i_d[0] * v_mix_ph(i_d))
             self.eta_s_char.func.get_bound_errors(expr, self.label)
 
         if self.flow_char.is_set:
             # get bound errors for flow characteristics
             i = self.inl[0].to_flow()
-            o = self.outl[0].to_flow()
-            expr = i[0] * v_mix_ph(i)
+            expr = i[0] * v_mix_ph(i, T0=self.inl[0].T.val_SI)
             self.flow_char.func.get_bound_errors(expr, self.label)
 
 # %%
@@ -1508,9 +1522,6 @@ class compressor(turbomachine):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -1531,8 +1542,9 @@ class compressor(turbomachine):
         or use generic values (e. g. calculated from design case).
 
     char_map : str/tespy.helpers.dc_cm
-        Characteristic map for pressure rise and isentropic efficiency vs. nondimensional mass flow,
-        see tespy.components.characteristics.compressor for further information.
+        Characteristic map for pressure rise and isentropic efficiency vs.
+        nondimensional mass flow, see
+        tespy.components.characteristics.compressor for further information.
 
     igva : str/float/tespy.helpers.dc_cp
         Inlet guide vane angle, :math:`igva/^\circ`.
@@ -1594,7 +1606,8 @@ class compressor(turbomachine):
         if generate_char:
             self.char_map.func = cmp_char.char_map(
                     x=self.char_map.x, y=self.char_map.y, z1=self.char_map.z1,
-                    z2=self.char_map.z2, method=self.char_map.method, comp=self.component())
+                    z2=self.char_map.z2, method=self.char_map.method,
+                    comp=self.component())
             self.char_map.x = self.char_map.func.x
             self.char_map.y = self.char_map.func.y
             self.char_map.z1 = self.char_map.func.z1
@@ -1602,7 +1615,8 @@ class compressor(turbomachine):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for compressor.
+        Calculates vector vec_res with results of additional equations for
+        compressor.
 
         Equations
 
@@ -1632,7 +1646,8 @@ class compressor(turbomachine):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -1672,7 +1687,8 @@ class compressor(turbomachine):
 
     def eta_s_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the isentropic efficiency function.
+        Calculates the matrix of partial derivatives of the isentropic
+        efficiency function.
 
         Returns
         -------
@@ -1681,18 +1697,17 @@ class compressor(turbomachine):
         """
         mat_deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
 
-        for i in range(2):
-            mat_deriv[0, i, 1] = self.numeric_deriv(self.eta_s_func, 'p', i)
-            if i == 0:
-                mat_deriv[0, i, 2] = self.numeric_deriv(self.eta_s_func, 'h', i)
-            else:
-                mat_deriv[0, i, 2] = -self.eta_s.val
+        mat_deriv[0, 0, 1] = self.numeric_deriv(self.eta_s_func, 'p', 0)
+        mat_deriv[0, 1, 1] = self.numeric_deriv(self.eta_s_func, 'p', 1)
+        mat_deriv[0, 0, 2] = self.numeric_deriv(self.eta_s_func, 'h', 0)
+        mat_deriv[0, 1, 2] = -self.eta_s.val
 
         return mat_deriv.tolist()
 
     def eta_s_char_func(self):
         r"""
-        Equation for given isentropic efficiency characteristic of a compressor.
+        Equation for given isentropic efficiency characteristic of a
+        compressor.
 
         Returns
         -------
@@ -1701,8 +1716,10 @@ class compressor(turbomachine):
 
             .. math::
 
-                0 = \left( h_{out} - h_{in} \right) \cdot \frac{\Delta h_{s,ref}}{\Delta h_{ref}}
-                \cdot char\left( \dot{m}_{in} \cdot v_{in} \right) - \left( h_{out,s} - h_{in} \right)
+                0 = \left( h_{out} - h_{in} \right) \cdot
+                \frac{\Delta h_{s,ref}}{\Delta h_{ref}}
+                \cdot char\left( \dot{m}_{in} \cdot v_{in} \right) -
+                \left( h_{out,s} - h_{in} \right)
         """
         # actual values
         i = self.inl[0].to_flow()
@@ -1719,15 +1736,18 @@ class compressor(turbomachine):
             if not np.isnan([i_d[1], o_d[1]]).any():
                 expr = (o[1] * i_d[1]) / (i[1] * o_d[1])
         else:
-            msg = 'Must provide a parameter for eta_s_char at component ' + self.label + '.'
+            msg = ('Must provide a parameter for eta_s_char at component ' +
+                   self.label + '.')
             logging.error(msg)
             raise ValueError(msg)
 
-        return (self.eta_s.design * self.eta_s_char.func.f_x(expr) * (o[2] - i[2]) - (self.h_os('post') - i[2]))
+        return (self.eta_s.design * self.eta_s_char.func.f_x(expr) *
+                (o[2] - i[2]) - (self.h_os('post') - i[2]))
 
     def eta_s_char_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the isentropic efficiency characteristic function.
+        Calculates the matrix of partial derivatives of the isentropic
+        efficiency characteristic function.
 
         Returns
         -------
@@ -1753,7 +1773,8 @@ class compressor(turbomachine):
             - Y: nondimensional mass flow
             - Z1: pressure ratio equation
             - Z2: isentropic efficiency equation
-            - igva: variable inlet guide vane angle (assumed 0° if not specified)
+            - igva: variable inlet guide vane angle (assumed 0° if not
+              specified)
 
             .. math::
 
@@ -1762,7 +1783,8 @@ class compressor(turbomachine):
                 Y = \frac{\dot{m}_\mathrm{1} \cdot p_\mathrm{1,ref}}
                 {\dot{m}_\mathrm{1,ref} \cdot p_\mathrm{1} \cdot X}
 
-                Z1 = \frac{p_2 \cdot p_\mathrm{1,ref}}{p_1 \cdot p_\mathrm{2,ref}}-
+                Z1 = \frac{p_2 \cdot p_\mathrm{1,ref}}
+                {p_1 \cdot p_\mathrm{2,ref}}-
                 pr_{c}(char(m, igva))
 
                 Z2 = \frac{\eta_\mathrm{s,c}}{\eta_\mathrm{s,c,ref}} -
@@ -1780,19 +1802,23 @@ class compressor(turbomachine):
         i_d = self.inl[0].to_flow_design()
         o_d = self.outl[0].to_flow_design()
 
-        x = math.sqrt(T_mix_ph(i_d) / T_mix_ph(i))
+        T_i = T_mix_ph(i, T0=self.inl[0].T.val_SI)
+
+        x = math.sqrt(T_mix_ph(i_d) / T_i)
         y = (i[0] * i_d[1]) / (i_d[0] * i[1] * x)
 
         pr, eta = self.char_map.func.get_pr_eta(x, y, self.igva.val)
 
         z1 = o[1] * i_d[1] / (i[1] * o_d[1]) - pr
-        z2 = (self.h_os('post') - i[2]) / (o[2] - i[2]) / self.eta_s.design - eta
+        z2 = ((self.h_os('post') - i[2]) / (o[2] - i[2]) /
+              self.eta_s.design - eta)
 
         return np.array([z1, z2])
 
     def char_map_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the compressor characteristic map function.
+        Calculates the matrix of partial derivatives of the compressor
+        characteristic map function.
 
         Returns
         -------
@@ -1836,7 +1862,8 @@ class compressor(turbomachine):
 
         Note
         ----
-        Manipulate enthalpies/pressure at inlet and outlet if not specified by user to match physically feasible constraints.
+        Manipulate enthalpies/pressure at inlet and outlet if not specified by
+        user to match physically feasible constraints.
         """
         i, o = self.inl, self.outl
 
@@ -1855,7 +1882,8 @@ class compressor(turbomachine):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -1884,7 +1912,8 @@ class compressor(turbomachine):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -1928,9 +1957,11 @@ class compressor(turbomachine):
             # get bound errors for characteristic map
             i = self.inl[0].to_flow()
             i_d = self.inl[0].to_flow_design()
-            x = math.sqrt(T_mix_ph(i_d)) / math.sqrt(T_mix_ph(i))
+            T_i = T_mix_ph(i, T0=self.inl[0].T.val_SI)
+            x = math.sqrt(T_mix_ph(i_d)) / math.sqrt(T_i)
             y = (i[0] * i_d[1]) / (i_d[0] * i[1] * x)
-            self.char_map.func.get_bound_errors(x, y, self.igva.val, self.label)
+            self.char_map.func.get_bound_errors(x, y, self.igva.val,
+                                                self.label)
 
         if self.eta_s_char.is_set:
             # get bound errors for isentropic efficiency characteristics
@@ -1990,9 +2021,6 @@ class turbine(turbomachine):
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -2056,7 +2084,8 @@ class turbine(turbomachine):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for compressor.
+        Calculates vector vec_res with results of additional equations for
+        turbine.
 
         Equations
 
@@ -2086,7 +2115,8 @@ class turbine(turbomachine):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -2132,7 +2162,8 @@ class turbine(turbomachine):
 
     def eta_s_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the isentropic efficiency function.
+        Calculates the matrix of partial derivatives of the isentropic
+        efficiency function.
 
         Returns
         -------
@@ -2141,12 +2172,10 @@ class turbine(turbomachine):
         """
         mat_deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
 
-        for i in range(2):
-            mat_deriv[0, i, 1] = self.numeric_deriv(self.eta_s_func, 'p', i)
-            if i == 0:
-                mat_deriv[0, i, 2] = self.numeric_deriv(self.eta_s_func, 'h', i)
-            else:
-                mat_deriv[0, i, 2] = -1
+        mat_deriv[0, 0, 1] = self.numeric_deriv(self.eta_s_func, 'p', 0)
+        mat_deriv[0, 1, 1] = self.numeric_deriv(self.eta_s_func, 'p', 1)
+        mat_deriv[0, 0, 2] = self.numeric_deriv(self.eta_s_func, 'h', 0)
+        mat_deriv[0, 1, 2] = -1
 
         return mat_deriv.tolist()
 
@@ -2174,9 +2203,13 @@ class turbine(turbomachine):
         i_d = self.inl[0].to_flow_design()
         o_d = self.outl[0].to_flow_design()
 
+        v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+
         n = 1
-        return (i_d[0] * i[1] / i_d[1] * math.sqrt(i_d[1] * v_mix_ph(i_d) / (i[1] * v_mix_ph(i))) *
-                math.sqrt(abs((1 - (o[1] / i[1]) ** ((n + 1) / n)) / (1 - (o_d[1] / i_d[1]) ** ((n + 1) / n)))) - i[0])
+        return (- i[0] + i_d[0] * i[1] / i_d[1] *
+                math.sqrt(i_d[1] * v_mix_ph(i_d) / (i[1] * v_i)) *
+                math.sqrt(abs((1 - (o[1] / i[1]) ** ((n + 1) / n)) /
+                              (1 - (o_d[1] / i_d[1]) ** ((n + 1) / n)))))
 
     def eta_s_char_func(self):
         r"""
@@ -2189,8 +2222,8 @@ class turbine(turbomachine):
 
             .. math::
 
-                0 = - \left( h_{out} - h_{in} \right) + \eta_{s,e,0} \cdot f\left(
-                expr \right) \cdot \Delta h_{s}
+                0 = - \left( h_{out} - h_{in} \right) + \eta_{s,e,0} \cdot
+                f\left( expr \right) \cdot \Delta h_{s}
         """
         # actual values
         i = self.inl[0].to_flow()
@@ -2204,19 +2237,23 @@ class turbine(turbomachine):
         elif self.eta_s_char.param == 'm':
             expr = i[0] / i_d[0]
         elif self.eta_s_char.param == 'v':
-            expr = i[0] * v_mix_ph(i) / (i_d[0] * v_mix_ph(i_d))
+            v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+            expr = i[0] * v_i / (i_d[0] * v_mix_ph(i_d))
         elif self.eta_s_char.param == 'pr':
             expr = (o[1] * i_d[1]) / (i[1] * o_d[1])
         else:
-            msg = 'Please choose the parameter, you want to link the isentropic efficiency to.'
+            msg = ('Please choose the parameter, you want to link the '
+                   'isentropic efficiency to.')
             logging.error(msg)
             raise ValueError(msg)
 
-        return -(o[2] - i[2]) + self.eta_s.design * self.eta_s_char.func.f_x(expr) * (self.h_os('post') - i[2])
+        return (-(o[2] - i[2]) + self.eta_s.design *
+                self.eta_s_char.func.f_x(expr) * (self.h_os('post') - i[2]))
 
     def eta_s_char_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the isentropic efficiency characteristic function.
+        Calculates the matrix of partial derivatives of the isentropic
+        efficiency characteristic function.
 
         Returns
         -------
@@ -2226,9 +2263,10 @@ class turbine(turbomachine):
         mat_deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
 
         mat_deriv[0, 0, 0] = self.numeric_deriv(self.eta_s_char_func, 'm', 0)
-        for i in range(2):
-            mat_deriv[0, i, 1] = self.numeric_deriv(self.eta_s_char_func, 'p', i)
-            mat_deriv[0, i, 2] = self.numeric_deriv(self.eta_s_char_func, 'h', i)
+        mat_deriv[0, 0, 1] = self.numeric_deriv(self.eta_s_char_func, 'p', 0)
+        mat_deriv[0, 0, 2] = self.numeric_deriv(self.eta_s_char_func, 'h', 0)
+        mat_deriv[0, 1, 1] = self.numeric_deriv(self.eta_s_char_func, 'p', 1)
+        mat_deriv[0, 1, 2] = self.numeric_deriv(self.eta_s_char_func, 'h', 1)
 
         return mat_deriv.tolist()
 
@@ -2243,7 +2281,8 @@ class turbine(turbomachine):
 
         Note
         ----
-        Manipulate enthalpies/pressure at inlet and outlet if not specified by user to match physically feasible constraints.
+        Manipulate enthalpies/pressure at inlet and outlet if not specified by
+        user to match physically feasible constraints.
         """
         i, o = self.inl, self.outl
 
@@ -2266,7 +2305,8 @@ class turbine(turbomachine):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -2295,7 +2335,8 @@ class turbine(turbomachine):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -2347,7 +2388,8 @@ class turbine(turbomachine):
             elif self.eta_s_char.param == 'm':
                 expr = i[0] / i_d[0]
             elif self.eta_s_char.param == 'v':
-                expr = i[0] * v_mix_ph(i) / (i_d[0] * v_mix_ph(i_d))
+                v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+                expr = i[0] * v_i / (i_d[0] * v_mix_ph(i_d))
             elif self.eta_s_char.param == 'pr':
                 expr = (o[1] * i_d[1]) / (i[1] * o_d[1])
 
@@ -2394,9 +2436,6 @@ class node(component):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -2411,11 +2450,17 @@ class node(component):
 
     Note
     ----
-    - Node: Fluid composition and enthalpy at all **outgoing** connections (mass flow leaves the node) is result of mixture of the properties of the incoming connections (mass flow enters node).
-      Incoming and outgoing connections can be a result of the calculation and are not identical to the inlets and outlets!
-    - Splitter: Fluid composition and enthalpy at all outlets is the same as the inlet's properties.
-    - Separator: Fluid composition is variable for all outlets, temperature at all outlets is the same as the inlet's temperature.
-    - Merge: Fluid composition and enthalpy at outlet is result of mixture of the inlet's properties.
+    - Node: Fluid composition and enthalpy at all **outgoing** connections
+      (mass flow leaves the node) is result of mixture of the properties of
+      the incoming connections (mass flow enters node).
+      Incoming and outgoing connections can be a result of the calculation and
+      are not identical to the inlets and outlets!
+    - Splitter: Fluid composition and enthalpy at all outlets is the same as
+      the inlet's properties.
+    - Separator: Fluid composition is variable for all outlets, temperature at
+      all outlets is the same as the inlet's temperature.
+    - Merge: Fluid composition and enthalpy at outlet is result of mixture of
+      the inlet's properties.
 
     Example
     -------
@@ -2534,7 +2579,8 @@ class node(component):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for this
+        component.
 
         Equations
 
@@ -2544,7 +2590,8 @@ class node(component):
 
             .. math::
 
-                0 = \sum_i \left(\dot{m}_{i} \cdot h_{i}\right) - h_{o} \cdot  \sum_i \dot{m}_{i}\\
+                0 = \sum_i \left(\dot{m}_{i} \cdot h_{i}\right) - h_{o} \cdot
+                \sum_i \dot{m}_{i}\\
                 \forall o \in \text{outgoing mass flows}\\
                 \text{i: incoming mass flows}
 
@@ -2601,7 +2648,8 @@ class node(component):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -2616,7 +2664,8 @@ class node(component):
 
         ######################################################################
         # derivatives for energy balance equations
-        deriv = np.zeros((len(self.outg), self.num_i + self.num_o, self.num_fl + 3))
+        deriv = np.zeros((len(self.outg), self.num_i + self.num_o,
+                          self.num_fl + 3))
         k = 0
         for o in self.outg:
             deriv[k, o[1], 2] = -self.m_inc
@@ -2630,7 +2679,8 @@ class node(component):
 
     def fluid_func(self):
         r"""
-        Calculates the vector of residual values for component's fluid balance equations.
+        Calculates the vector of residual values for component's fluid balance
+        equations.
 
         Returns
         -------
@@ -2639,7 +2689,8 @@ class node(component):
 
             .. math::
 
-                0 = \sum_i \left(\dot{m}_{i} \cdot x_{i,j}\right) - x_{o,j} \cdot  \sum_i \dot{m}_{i}\\
+                0 = \sum_i \left(\dot{m}_{i} \cdot x_{i,j}\right) - x_{o,j}
+                \cdot  \sum_i \dot{m}_{i}\\
                 \forall j \in \text{fluids}\\
                 \forall o \in \text{outgoing mass flows}\\
                 \text{i: incoming mass flows}
@@ -2664,7 +2715,8 @@ class node(component):
             Matrix with partial derivatives for the fluid equations.
         """
         num_o = len(self.outg)
-        deriv = np.zeros((self.num_fl * num_o, self.num_i + self.num_o, 3 + self.num_fl))
+        deriv = np.zeros((self.num_fl * num_o, self.num_i + self.num_o,
+                          3 + self.num_fl))
         j = 0
         k = 0
         for fluid in self.fluids:
@@ -2687,7 +2739,8 @@ class node(component):
         deriv : list
             Matrix with partial derivatives for the fluid equations.
         """
-        deriv = np.zeros((self.num_i + self.num_o - 1, self.num_i + self.num_o, self.num_fl + 3))
+        deriv = np.zeros((self.num_i + self.num_o - 1, self.num_i + self.num_o,
+                          self.num_fl + 3))
 
         inl = []
         if self.num_i > 1:
@@ -2730,7 +2783,8 @@ class node(component):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -2759,7 +2813,8 @@ class node(component):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -2822,9 +2877,6 @@ class splitter(node):
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -2890,7 +2942,8 @@ class splitter(node):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for
+        this component.
 
         Equations
 
@@ -2925,7 +2978,8 @@ class splitter(node):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -2945,7 +2999,8 @@ class splitter(node):
         deriv : list
             Matrix with partial derivatives for the fluid equations.
         """
-        deriv = np.zeros((self.num_fl * self.num_o, 1 + self.num_o, 3 + self.num_fl))
+        deriv = np.zeros((self.num_fl * self.num_o, 1 + self.num_o,
+                          3 + self.num_fl))
         k = 0
         for o in self.outl:
             i = 0
@@ -3027,9 +3082,6 @@ class separator(node):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -3085,7 +3137,8 @@ class separator(node):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for
+        this component.
 
         Equations
 
@@ -3117,14 +3170,16 @@ class separator(node):
         ######################################################################
         # equations for energy balance
         for o in self.outl:
-            vec_res += [T_mix_ph(self.inl[0].to_flow()) -
-                        T_mix_ph(o.to_flow())]
+            vec_res += [
+                    T_mix_ph(self.inl[0].to_flow(), T0=self.inl[0].T.val_SI) -
+                    T_mix_ph(o.to_flow(), T0=o.T.val_SI)]
 
         return vec_res
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -3227,9 +3282,6 @@ class merge(node):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -3288,7 +3340,8 @@ class merge(node):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for
+        this component.
 
         Equations
 
@@ -3331,7 +3384,8 @@ class merge(node):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -3422,15 +3476,13 @@ class combustion_chamber(component):
 
     .. note::
 
-        The fuel and the air components can be connected to either of the inlets.
+        The fuel and the air components can be connected to either of the
+        inlets.
 
     Parameters
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -3509,7 +3561,8 @@ class combustion_chamber(component):
         self.fuel_list = []
         fuels = ['methane', 'ethane', 'propane', 'butane', 'hydrogen']
         for f in fuels:
-            self.fuel_list += [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases(f)]]
+            self.fuel_list += [x for x in nw.fluids if x in [a.replace(' ', '')
+                               for a in CP.get_aliases(f)]]
 
         if len(self.fuel_list) == 0:
             msg = ('Your network\'s fluids do not contain any fuels, that are '
@@ -3520,14 +3573,18 @@ class combustion_chamber(component):
             raise TESPyComponentError(msg)
 
         else:
-            msg = ('The fuels for component ' + self.label + 'of type ' +
-                   self.component() + 'are: ' + str(self.fuel_list) + '.')
+            msg = ('The fuels for component ' + self.label + ' of type ' +
+                   self.component() + ' are: ' + str(self.fuel_list) + '.')
             logging.debug(msg)
 
-        self.o2 = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('O2')]][0]
-        self.co2 = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('CO2')]][0]
-        self.h2o = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('H2O')]][0]
-        self.n2 = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('N2')]][0]
+        self.o2 = [x for x in nw.fluids if x in [a.replace(' ', '')
+                   for a in CP.get_aliases('O2')]][0]
+        self.co2 = [x for x in nw.fluids if x in [a.replace(' ', '')
+                    for a in CP.get_aliases('CO2')]][0]
+        self.h2o = [x for x in nw.fluids if x in [a.replace(' ', '')
+                    for a in CP.get_aliases('H2O')]][0]
+        self.n2 = [x for x in nw.fluids if x in [a.replace(' ', '')
+                   for a in CP.get_aliases('N2')]][0]
 
         self.fuels = {}
         for f in self.fuel_list:
@@ -3673,9 +3730,10 @@ class combustion_chamber(component):
         # derivatives for specified lamb
         if self.lamb.is_set:
             deriv = np.zeros((1, 3, self.num_fl + 3))
-            for i in range(2):
-                deriv[0, i, 0] = self.numeric_deriv(self.lambda_func, 'm', i)
-                deriv[0, i, 3:] = self.numeric_deriv(self.lambda_func, 'fluid', i)
+            deriv[0, 0, 0] = self.numeric_deriv(self.lambda_func, 'm', 0)
+            deriv[0, 0, 3:] = self.numeric_deriv(self.lambda_func, 'fluid', 0)
+            deriv[0, 1, 0] = self.numeric_deriv(self.lambda_func, 'm', 1)
+            deriv[0, 1, 3:] = self.numeric_deriv(self.lambda_func, 'fluid', 1)
             mat_deriv += deriv.tolist()
 
         ######################################################################
@@ -3790,7 +3848,8 @@ class combustion_chamber(component):
             .. math::
 
                 0 = res - \begin{cases}
-                -\frac{\dot{m}_{O_2,m} \cdot M_{O_2}}{\lambda} & \lambda \geq 1\\
+                -\frac{\dot{m}_{O_2,m} \cdot M_{O_2}}{\lambda} &
+                \lambda \geq 1\\
                 - \dot{m}_{O_2,m} \cdot M_{O_2} & \lambda < 1
                 \end{cases}
 
@@ -3847,11 +3906,13 @@ class combustion_chamber(component):
                 n_c += n * self.fuels[f]['C']
 
             # stoichiometric oxygen requirement for each fuel
-            n_oxy_stoich[f] = n_fuel[f] * (self.fuels[f]['H'] / 4 + self.fuels[f]['C'])
+            n_oxy_stoich[f] = n_fuel[f] * (self.fuels[f]['H'] / 4 +
+                                           self.fuels[f]['C'])
 
         n_oxygen = 0
         for i in inl:
-            n_oxygen += i.m.val_SI * i.fluid.val[self.o2] / molar_masses[self.o2]
+            n_oxygen += (i.m.val_SI * i.fluid.val[self.o2] /
+                         molar_masses[self.o2])
 
         ######################################################################
         # calculate stoichiometric oxygen
@@ -3893,7 +3954,9 @@ class combustion_chamber(component):
         # equation for fuel
         elif fluid in self.fuel_list:
             if self.lamb.val < 1:
-                n_fuel_exc = (-(n_oxygen / n_oxygen_stoich - 1) * n_oxy_stoich[fluid]) * (self.fuels[f]['H'] / 4 + self.fuels[f]['C'])
+                n_fuel_exc = (-(n_oxygen / n_oxygen_stoich - 1) *
+                              n_oxy_stoich[fluid] *
+                              (self.fuels[f]['H'] / 4 + self.fuels[f]['C']))
             else:
                 n_fuel_exc = 0
             dm = -(n_fuel[fluid] - n_fuel_exc) * molar_masses[fluid]
@@ -3921,8 +3984,9 @@ class combustion_chamber(component):
             Partial derivative.
 
         pos : int
-            Position of connection regarding to inlets and outlet of the component,
-            logic: ['in1', 'in2', ..., 'out1', ...] -> 0, 1, ..., n, n + 1, ..., n + m
+            Position of connection regarding to inlets and outlet of the
+            component, logic: ['in1', 'in2', ..., 'out1', ...] ->
+            0, 1, ..., n, n + 1, ..., n + m
 
         fluid : str
             Fluid to calculate partial derivative of reaction balance for.
@@ -3930,7 +3994,8 @@ class combustion_chamber(component):
         Returns
         -------
         deriv : float/list
-            Partial derivative(s) of the function :math:`f` to variable(s) :math:`x`.
+            Partial derivative(s) of the function :math:`f` to variable(s)
+            :math:`x`.
 
             .. math::
 
@@ -3992,8 +4057,10 @@ class combustion_chamber(component):
             .. math::
 
                 \begin{split}
-                res = & \sum_i \dot{m}_{in,i} \cdot \left( h_{in,i} - h_{in,i,ref} \right)\\
-                & - \sum_j \dot{m}_{out,j} \cdot \left( h_{out,j} - h_{out,j,ref} \right)\\
+                res = & \sum_i \dot{m}_{in,i} \cdot
+                \left( h_{in,i} - h_{in,i,ref} \right)\\
+                & - \sum_j \dot{m}_{out,j} \cdot
+                \left( h_{out,j} - h_{out,j,ref} \right)\\
                 & + H_{I,f} \cdot \left(\sum_i \dot{m}_{in,i} \cdot x_{f,i} -
                 \sum_j \dot{m}_{out,j} \cdot x_{f,j} \right)
                 \end{split}\\
@@ -4019,7 +4086,8 @@ class combustion_chamber(component):
 
         res = 0
         for i in self.inl:
-            res += i.m.val_SI * (i.h.val_SI - h_mix_pT([0, p_ref, 0, i.fluid.val], T_ref))
+            res += i.m.val_SI * (i.h.val_SI -
+                                 h_mix_pT([0, p_ref, 0, i.fluid.val], T_ref))
 
         for o in self.outl:
             dh = 0
@@ -4034,7 +4102,9 @@ class combustion_chamber(component):
                 if h < h_steam:
                     dh = (h_steam - h) * o.fluid.val[self.h2o]
 
-            res -= o.m.val_SI * (o.h.val_SI - h_mix_pT([0, p_ref, 0, o.fluid.val], T_ref) - dh)
+            res -= o.m.val_SI * (o.h.val_SI -
+                                 h_mix_pT([0, p_ref, 0, o.fluid.val], T_ref) -
+                                 dh)
 
         res += self.calc_ti()
 
@@ -4073,7 +4143,8 @@ class combustion_chamber(component):
 
         n_oxygen = 0
         for i in inl:
-            n_oxygen += i.m.val_SI * i.fluid.val[self.o2] / molar_masses[self.o2]
+            n_oxygen += (i.m.val_SI * i.fluid.val[self.o2] /
+                         molar_masses[self.o2])
 
         n_oxygen_stoich = n_h / 4 + n_c
 
@@ -4138,7 +4209,8 @@ class combustion_chamber(component):
 
             .. math::
 
-                val = LHV \cdot \dot{m}_{f} \cdot f_{char}\left( \frac{\dot{m}_{f}}{\dot{m}_{f,ref}}\right)
+                val = LHV \cdot \dot{m}_{f} \cdot
+                f_{char}\left( \frac{\dot{m}_{f}}{\dot{m}_{f,ref}}\right)
         """
         val = self.calc_ti()
         if np.isnan(bus.P_ref):
@@ -4162,17 +4234,18 @@ class combustion_chamber(component):
             Matrix of partial derivatives.
         """
         deriv = np.zeros((1, 3, len(self.inl[0].fluid.val) + 3))
-        for i in range(2):
-            deriv[0, i, 0] = self.numeric_deriv(self.bus_func, 'm', i, bus=bus)
-            deriv[0, i, 3:] = self.numeric_deriv(self.bus_func, 'fluid', i, bus=bus)
+        for i in range(3):
+            deriv[0, i, 0] = self.numeric_deriv(self.bus_func,
+                                                'm', i, bus=bus)
+            deriv[0, i, 3:] = self.numeric_deriv(self.bus_func,
+                                                 'fluid', i, bus=bus)
 
-        deriv[0, 2, 0] = self.numeric_deriv(self.bus_func, 'm', 2, bus=bus)
-        deriv[0, 2, 3:] = self.numeric_deriv(self.bus_func, 'fluid', 2, bus=bus)
         return deriv
 
     def initialise_fluids(self, nw):
         r"""
-        Calculates reaction balance with given lambda of 3 for good generic starting values at the component's outlet.
+        Calculates reaction balance with given lambda of 3 for good generic
+        starting values at the component's outlet.
 
         Parameters
         ----------
@@ -4200,11 +4273,14 @@ class combustion_chamber(component):
         m_h2o = 0
         m_fuel = 0
         for f in self.fuel_list:
-            m_co2 += n_fuel * self.fuels[f]['C'] * molar_masses[self.co2] * fact_fuel[f]
-            m_h2o += n_fuel * self.fuels[f]['H'] / 2 * molar_masses[self.h2o] * fact_fuel[f]
+            m_co2 += (n_fuel * self.fuels[f]['C'] * molar_masses[self.co2] *
+                      fact_fuel[f])
+            m_h2o += (n_fuel * self.fuels[f]['H'] / 2 *molar_masses[self.h2o] *
+                      fact_fuel[f])
             m_fuel += n_fuel * molar_masses[f] * fact_fuel[f]
 
-        n_o2 = (m_co2 / molar_masses[self.co2] + 0.5 * m_h2o / molar_masses[self.h2o]) * lamb
+        n_o2 = (m_co2 / molar_masses[self.co2] +
+                0.5 * m_h2o / molar_masses[self.h2o]) * lamb
 
         m_air = n_o2 * molar_masses[self.o2] / O_2
         m_fg = m_air + m_fuel
@@ -4235,8 +4311,10 @@ class combustion_chamber(component):
 
         Note
         ----
-        Manipulate enthalpies/pressure at inlet and outlet if not specified by user to match physically feasible constraints,
-        keep fluid composition within feasible range and then propagates it towards the outlet.
+        Manipulate enthalpies/pressure at inlet and outlet if not specified
+        by user to match physically feasible constraints, keep fluid
+        composition within feasible range and then propagates it towards the
+        outlet.
         """
         if isinstance(self, cogeneration_unit):
             inl = self.inl[2:]
@@ -4256,7 +4334,8 @@ class combustion_chamber(component):
         # check fluid composition
         for o in outl:
             if o.init_csv is False:
-                fluids = [f for f in o.fluid.val.keys() if not o.fluid.val_set[f]]
+                fluids = [f for f in o.fluid.val.keys()
+                          if not o.fluid.val_set[f]]
                 for f in fluids:
                     if f not in [self.o2, self.co2, self.h2o] + self.fuel_list:
                         m_f = 0
@@ -4323,7 +4402,8 @@ class combustion_chamber(component):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -4352,7 +4432,8 @@ class combustion_chamber(component):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -4445,15 +4526,13 @@ class combustion_chamber_stoich(combustion_chamber):
 
     .. note::
 
-        The fuel and the air components can be connected to either of the inlets.
+        The fuel and the air components can be connected to either of the
+        inlets.
 
     Parameters
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -4465,13 +4544,16 @@ class combustion_chamber_stoich(combustion_chamber):
         Fuel composition, e. g. :code:`{'CH4': 0.96, 'CO2': 0.04}`.
 
     fuel_alias : str
-        Alias for the fuel, name of fuel for usage in network will be TESPy::fuel_alias.
+        Alias for the fuel, name of fuel for usage in network will be
+        TESPy::fuel_alias.
 
     air : dict
-        Fresh air composition, e. g. :code:`{'N2': 0.76, 'O2': 0.23, 'Ar': 0.01}`.
+        Fresh air composition,
+        e. g. :code:`{'N2': 0.76, 'O2': 0.23, 'Ar': 0.01}`.
 
     air_alias : str
-        Alias for the fresh air, name of air for usage in network will be TESPy::air_alias.
+        Alias for the fresh air, name of air for usage in network will be
+        TESPy::air_alias.
 
     path : str
         Path to existing fluid property table.
@@ -4515,7 +4597,8 @@ class combustion_chamber_stoich(combustion_chamber):
     >>> amb = cmp.source('ambient')
     >>> sf = cmp.source('fuel')
     >>> fg = cmp.sink('flue gas outlet')
-    >>> comb = cmp.combustion_chamber_stoich('stoichiometric combustion chamber')
+    >>> comb = cmp.combustion_chamber_stoich(
+    ... 'stoichiometric combustion chamber')
     >>> amb_comb = con.connection(amb, 'out1', comb, 'in1')
     >>> sf_comb = con.connection(sf, 'out1', comb, 'in2')
     >>> comb_fg = con.connection(comb, 'out1', fg, 'in1')
@@ -4603,13 +4686,15 @@ class combustion_chamber_stoich(combustion_chamber):
         # adjust the names for required fluids according to naming in the network
         # air
         for f in self.air.val.keys():
-            alias = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases(f)]]
+            alias = [x for x in nw.fluids if x in [a.replace(' ', '')
+                     for a in CP.get_aliases(f)]]
             if len(alias) > 0:
                 self.air.val[alias[0]] = self.air.val.pop(f)
 
         # fuel
         for f in self.fuel.val.keys():
-            alias = [x for x in self.air.val.keys() if x in [a.replace(' ', '') for a in CP.get_aliases(f)]]
+            alias = [x for x in self.air.val.keys() if x in [a.replace(' ', '')
+                     for a in CP.get_aliases(f)]]
             if len(alias) > 0:
                 self.fuel.val[alias[0]] = self.fuel.val.pop(f)
 
@@ -4617,7 +4702,8 @@ class combustion_chamber_stoich(combustion_chamber):
         fluids = list(self.air.val.keys()) + list(self.fuel.val.keys())
 
         # oxygen
-        alias = [x for x in fluids if x in [a.replace(' ', '') for a in CP.get_aliases('O2')]]
+        alias = [x for x in fluids if x in [a.replace(' ', '')
+                 for a in CP.get_aliases('O2')]]
         if len(alias) == 0:
             msg = 'Oxygen missing in input fluids.'
             logging.error(msg)
@@ -4626,14 +4712,16 @@ class combustion_chamber_stoich(combustion_chamber):
             self.o2 = alias[0]
 
         # carbondioxide
-        self.co2 = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('CO2')]]
+        self.co2 = [x for x in nw.fluids if x in [a.replace(' ', '')
+                    for a in CP.get_aliases('CO2')]]
         if len(self.co2) == 0:
             self.co2 = 'CO2'
         else:
             self.co2 = self.co2[0]
 
         # water
-        self.h2o = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('H2O')]]
+        self.h2o = [x for x in nw.fluids if x in [a.replace(' ', '')
+                    for a in CP.get_aliases('H2O')]]
         if len(self.h2o) == 0:
             self.h2o = 'H2O'
         else:
@@ -4644,7 +4732,9 @@ class combustion_chamber_stoich(combustion_chamber):
 
         # calculate lower heating value of specified fuel
         self.lhv = self.calc_lhv()
-        msg = 'Combustion chamber fuel (' + self.fuel_alias.val + ') LHV is ' + str(self.lhv) + ' for component ' + self.label + '.'
+        msg = ('Combustion chamber fuel (' + self.fuel_alias.val +
+               ') LHV is ' + str(self.lhv) + ' for component ' +
+               self.label + '.')
         logging.debug(msg)
         # generate fluid properties for stoichiometric flue gas
         self.stoich_flue_gas(nw)
@@ -4707,7 +4797,8 @@ class combustion_chamber_stoich(combustion_chamber):
 
     def stoich_flue_gas(self, nw):
         r"""
-        Calculates the fluid composition of the stoichiometric flue gas and creates a custom fluid.
+        Calculates the fluid composition of the stoichiometric flue gas and
+        creates a custom fluid.
 
         - uses one mole of fuel as reference quantity and :math:`\lambda=1`
           for stoichiometric flue gas calculation (no oxygen in flue gas)
@@ -4729,8 +4820,8 @@ class combustion_chamber_stoich(combustion_chamber):
                 m_{fuel} = \frac{1}{M_{fuel}}\\
                 m_{CO_2} = \sum_{i} \frac{x_{i} \cdot m_{fuel} \cdot num_{C,i}
                 \cdot M_{CO_{2}}}{M_{i}}\\
-                m_{H_{2}O} = \sum_{i} \frac{x_{i} \cdot m_{fuel} \cdot num_{H,i}
-                \cdot M_{H_{2}O}}{2 \cdot M_{i}}\\
+                m_{H_{2}O} = \sum_{i} \frac{x_{i} \cdot m_{fuel} \cdot
+                num_{H,i} \cdot M_{H_{2}O}}{2 \cdot M_{i}}\\
                 \forall i \in \text{fuels in fuel vector},\\
                 num = \text{number of atoms in molecule}
 
@@ -4747,7 +4838,8 @@ class combustion_chamber_stoich(combustion_chamber):
             .. math::
 
                 n_{O_2} = \left( \frac{m_{CO_2}}{M_{CO_2}} +
-                \frac{m_{H_{2}O}}{0,5 \cdot M_{H_{2}O}} \right) \cdot \lambda,\\
+                \frac{m_{H_{2}O}}
+                {0,5 \cdot M_{H_{2}O}} \right) \cdot \lambda,\\
                 n_{O_2} = \text{mol of oxygen required}\\
                 m_{air} = \frac{n_{O_2} \cdot M_{O_2}}{x_{O_{2}, air}},\\
                 m_{air} = \text{required total air mass}\\
@@ -4806,7 +4898,8 @@ class combustion_chamber_stoich(combustion_chamber):
         self.fg[self.co2] += m_co2
         self.fg[self.h2o] += m_h2o
 
-        n_o2 = (m_co2 / molar_masses[self.co2] + 0.5 * m_h2o / molar_masses[self.h2o]) * lamb
+        n_o2 = (m_co2 / molar_masses[self.co2] +
+                0.5 * m_h2o / molar_masses[self.h2o]) * lamb
         m_air = n_o2 * molar_masses[self.o2] / self.air.val[self.o2]
 
         self.air_min = m_air / m_fuel
@@ -4825,16 +4918,26 @@ class combustion_chamber_stoich(combustion_chamber):
 
         if not self.path.val_set:
             self.path.val = None
-        tespy_fluid(self.fuel_alias.val, self.fuel.val, [1000, nw.p_range_SI[1]], nw.T_range_SI, path=self.path.val)
-        tespy_fluid(self.fuel_alias.val + '_fg', self.fg, [1000, nw.p_range_SI[1]], nw.T_range_SI, path=self.path.val)
-        msg = 'Generated lookup table for ' + self.fuel_alias.val + ' and for stoichiometric flue gas at stoichiometric combustion chamber ' + self.label + '.'
+        tespy_fluid(self.fuel_alias.val, self.fuel.val,
+                    [1000, nw.p_range_SI[1]], nw.T_range_SI,
+                    path=self.path.val)
+        tespy_fluid(self.fuel_alias.val + '_fg', self.fg,
+                    [1000, nw.p_range_SI[1]], nw.T_range_SI,
+                    path=self.path.val)
+        msg = ('Generated lookup table for ' + self.fuel_alias.val +
+               ' and for stoichiometric flue gas at stoichiometric '
+               'combustion chamber ' + self.label + '.')
         logging.debug(msg)
 
         if self.air_alias.val not in ['Air', 'air']:
-            tespy_fluid(self.air_alias.val, self.air.val, [1000, nw.p_range_SI[1]], nw.T_range_SI, path=self.path.val)
-            msg = 'Generated lookup table for ' + self.air_alias.val + ' at stoichiometric combustion chamber ' + self.label + '.'
+            tespy_fluid(self.air_alias.val, self.air.val,
+                        [1000, nw.p_range_SI[1]], nw.T_range_SI,
+                        path=self.path.val)
+            msg = ('Generated lookup table for ' + self.air_alias.val +
+                   ' at stoichiometric combustion chamber ' + self.label + '.')
         else:
-            msg = 'Using CoolProp air at stoichiometric combustion chamber ' + self.label + '.'
+            msg = ('Using CoolProp air at stoichiometric combustion chamber ' +
+                   self.label + '.')
         logging.debug(msg)
 
     def reaction_balance(self, fluid):
@@ -4970,9 +5073,9 @@ class combustion_chamber_stoich(combustion_chamber):
             Residual value of equation.
 
             .. math::
-                res = \sum_i \dot{m}_{in,i} \cdot \left( h_{in,i} - h_{in,i,ref}
-                \right) - \sum_j \dot{m}_{out,j} \cdot
-                \left( h_{out,j} - h_{out,j,ref} \right) +
+                res = \sum_i \dot{m}_{in,i} \cdot
+                \left( h_{in,i} - h_{in,i,ref} \right) - \sum_j \dot{m}_{out,j}
+                \cdot \left( h_{out,j} - h_{out,j,ref} \right) +
                 H_{I,f} \cdot \left(\sum_i \dot{m}_{in,i} \cdot x_{f,i} -
                 \sum_j \dot{m}_{out,j} \cdot x_{f,j} \right)
                 \; \forall i \in \text{inlets}\; \forall j \in \text{outlets}
@@ -4991,9 +5094,11 @@ class combustion_chamber_stoich(combustion_chamber):
 
         res = 0
         for i in self.inl:
-            res += i.m.val_SI * (i.h.val_SI - h_mix_pT([0, p_ref, 0, i.fluid.val], T_ref))
+            res += i.m.val_SI * (i.h.val_SI -
+                                 h_mix_pT([0, p_ref, 0, i.fluid.val], T_ref))
         for o in self.outl:
-            res -= o.m.val_SI * (o.h.val_SI - h_mix_pT([0, p_ref, 0, o.fluid.val], T_ref))
+            res -= o.m.val_SI * (o.h.val_SI -
+                                 h_mix_pT([0, p_ref, 0, o.fluid.val], T_ref))
 
         return res + self.calc_ti()
 
@@ -5068,7 +5173,8 @@ class combustion_chamber_stoich(combustion_chamber):
 
     def initialise_fluids(self, nw):
         r"""
-        Calculates reaction balance with given lambda of 3 for good generic starting values at the component's outlet.
+        Calculates reaction balance with given lambda of 3 for good generic
+        starting values at the component's outlet.
 
         Parameters
         ----------
@@ -5098,8 +5204,9 @@ class combustion_chamber_stoich(combustion_chamber):
 
         Note
         ----
-        Manipulate enthalpies/pressure at inlet and outlet if not specified by user to match physically feasible constraints,
-        keep fluid composition within feasible range and then propagates it towards the outlet.
+        Manipulate enthalpies/pressure at inlet and outlet if not specified by
+        user to match physically feasible constraints, keep fluid composition
+        within feasible range and then propagates it towards the outlet.
         """
         if self.air_alias.val in ['air', 'Air']:
             air = self.air_alias.val
@@ -5233,15 +5340,13 @@ class cogeneration_unit(combustion_chamber):
 
     .. note::
 
-        The fuel and the air components can be connected to either of the inlets.
+        The fuel and the air components can be connected to either of the
+        inlets.
 
     Parameters
     ----------
     label : str
         The label of the component.
-
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
 
     design : list
         List containing design parameters (stated as String).
@@ -5278,10 +5383,12 @@ class cogeneration_unit(combustion_chamber):
         Pressure ratio heat outlet 2, :math:`pr/1`.
 
     zeta1 : str/float/tespy.helpers.dc_cp
-        Pressure ratio heat outlet 2, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Pressure ratio heat outlet 2,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     zeta2 : str/float/tespy.helpers.dc_cp
-        Pressure ratio heat outlet 2, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Pressure ratio heat outlet 2,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     tiP_char : str/tespy.helpers.dc_cc
         Characteristic line linking fuel input to power output.
@@ -5331,7 +5438,8 @@ class cogeneration_unit(combustion_chamber):
     >>> chp1_cw = con.connection(chp, 'out1', cw_out1, 'in1')
     >>> chp2_cw = con.connection(chp, 'out2', cw_out2, 'in1')
     >>> nw.add_conns(chp1_cw, chp2_cw)
-    >>> chp.set_attr(fuel='CH4', pr1=0.99, pr2=0.99, P=10e6, lamb=1.2, design=['pr1', 'pr2'], offdesign=['zeta1', 'zeta2'])
+    >>> chp.set_attr(fuel='CH4', pr1=0.99, pr2=0.99, P=10e6, lamb=1.2,
+    ... design=['pr1', 'pr2'], offdesign=['zeta1', 'zeta2'])
     >>> amb_comb.set_attr(p=5, T=30,
     ...     fluid={'Ar': 0.0129, 'N2': 0.7553, 'H2O': 0, 'CH4': 0,
     ...         'CO2': 0.0004, 'O2': 0.2314})
@@ -5469,10 +5577,12 @@ class cogeneration_unit(combustion_chamber):
         ######################################################################
         # equations for specified pressure ratios at cooling loops
         if self.pr1.is_set:
-            vec_res += [self.pr1.val * self.inl[0].p.val_SI - self.outl[0].p.val_SI]
+            vec_res += [self.pr1.val * self.inl[0].p.val_SI -
+                        self.outl[0].p.val_SI]
 
         if self.pr2.is_set:
-            vec_res += [self.pr2.val * self.inl[1].p.val_SI - self.outl[1].p.val_SI]
+            vec_res += [self.pr2.val * self.inl[1].p.val_SI -
+                        self.outl[1].p.val_SI]
 
         ######################################################################
         # equations for specified zeta values at cooling loops
@@ -5502,9 +5612,10 @@ class cogeneration_unit(combustion_chamber):
         for fluid in self.fluids:
 
             # fresh air and fuel inlets
-            for i in range(2):
-                deriv[j, i + 2, 0] = self.rb_numeric_deriv('m', i + 2, fluid)
-                deriv[j, i + 2, 3:] = self.rb_numeric_deriv('fluid', i + 2, fluid)
+            deriv[j, 2, 0] = self.rb_numeric_deriv('m', 2, fluid)
+            deriv[j, 2, 3:] = self.rb_numeric_deriv('fluid', 2, fluid)
+            deriv[j, 3, 0] = self.rb_numeric_deriv('m', 3, fluid)
+            deriv[j, 3, 3:] = self.rb_numeric_deriv('fluid', 3, fluid)
 
             # combustion outlet
             deriv[j, 6, 0] = self.rb_numeric_deriv('m', 6, fluid)
@@ -5550,23 +5661,24 @@ class cogeneration_unit(combustion_chamber):
 
         # power and heat loss
         if self.P.is_var:
-            eb_deriv[0, 7 + self.P.var_pos, 0] = self.numeric_deriv(self.energy_balance, 'P', 7)
+            eb_deriv[0, 7 + self.P.var_pos, 0] = (
+                    self.numeric_deriv(self.energy_balance, 'P', 7))
         if self.Qloss.is_var:
-            eb_deriv[0, 7 + self.Qloss.var_pos, 0] = self.numeric_deriv(self.energy_balance, 'Qloss', 7)
+            eb_deriv[0, 7 + self.Qloss.var_pos, 0] = (
+                    self.numeric_deriv(self.energy_balance, 'Qloss', 7))
         mat_deriv += eb_deriv.tolist()
 
         ######################################################################
         # derivatives for thermal input to power charactersitics
         tiP_deriv = np.zeros((1, 7 + self.num_vars, self.num_fl + 3))
-        for i in range(2):
-            tiP_deriv[0, i + 2, 0] = self.numeric_deriv(self.tiP_char_func, 'm', i + 2)
-            tiP_deriv[0, i + 2, 3:] = self.numeric_deriv(self.tiP_char_func, 'fluid', i + 2)
-
-        tiP_deriv[0, 6, 0] = self.numeric_deriv(self.tiP_char_func, 'm', 6)
-        tiP_deriv[0, 6, 3:] = self.numeric_deriv(self.tiP_char_func, 'fluid', 6)
+        for i in [2, 3, 6]:
+            tiP_deriv[0, i, 0] = self.numeric_deriv(self.tiP_char_func, 'm', i)
+            tiP_deriv[0, i, 3:] = (
+                    self.numeric_deriv(self.tiP_char_func, 'fluid', i))
 
         if self.P.is_var:
-            tiP_deriv[0, 7 + self.P.var_pos, 0] = self.numeric_deriv(self.tiP_char_func, 'P', 7)
+            tiP_deriv[0, 7 + self.P.var_pos, 0] = (
+                    self.numeric_deriv(self.tiP_char_func, 'P', 7))
         mat_deriv += tiP_deriv.tolist()
 
         ######################################################################
@@ -5575,14 +5687,14 @@ class cogeneration_unit(combustion_chamber):
         Q1_deriv[0, 0, 0] = self.numeric_deriv(self.Q1_char_func, 'm', 0)
         Q1_deriv[0, 0, 2] = self.numeric_deriv(self.Q1_char_func, 'h', 0)
         Q1_deriv[0, 4, 2] = self.numeric_deriv(self.Q1_char_func, 'h', 4)
-        for i in range(2):
-            Q1_deriv[0, i + 2, 0] = self.numeric_deriv(self.Q1_char_func, 'm', i + 2)
-            Q1_deriv[0, i + 2, 3:] = self.numeric_deriv(self.Q1_char_func, 'fluid', i + 2)
-        Q1_deriv[0, 6, 0] = self.numeric_deriv(self.Q1_char_func, 'm', 6)
-        Q1_deriv[0, 6, 3:] = self.numeric_deriv(self.Q1_char_func, 'fluid', 6)
+        for i in [2, 3, 6]:
+            Q1_deriv[0, i, 0] = self.numeric_deriv(self.Q1_char_func, 'm', i)
+            Q1_deriv[0, i, 3:] = (
+                    self.numeric_deriv(self.Q1_char_func, 'fluid', i))
 
         if self.P.is_var:
-            Q1_deriv[0, 7 + self.P.var_pos, 0] = self.numeric_deriv(self.Q1_char_func, 'P', 7)
+            Q1_deriv[0, 7 + self.P.var_pos, 0] = (
+                    self.numeric_deriv(self.Q1_char_func, 'P', 7))
         mat_deriv += Q1_deriv.tolist()
 
         ######################################################################
@@ -5591,49 +5703,53 @@ class cogeneration_unit(combustion_chamber):
         Q2_deriv[0, 1, 0] = self.numeric_deriv(self.Q2_char_func, 'm', 1)
         Q2_deriv[0, 1, 2] = self.numeric_deriv(self.Q2_char_func, 'h', 1)
         Q2_deriv[0, 5, 2] = self.numeric_deriv(self.Q2_char_func, 'h', 5)
-        for i in range(2):
-            Q2_deriv[0, i + 2, 0] = self.numeric_deriv(self.Q2_char_func, 'm', i + 2)
-            Q2_deriv[0, i + 2, 3:] = self.numeric_deriv(self.Q2_char_func, 'fluid', i + 2)
-        Q2_deriv[0, 6, 0] = self.numeric_deriv(self.Q2_char_func, 'm', 6)
-        Q2_deriv[0, 6, 3:] = self.numeric_deriv(self.Q2_char_func, 'fluid', 6)
+        for i in [2, 3, 6]:
+            Q2_deriv[0, i, 0] = self.numeric_deriv(self.Q2_char_func, 'm', i)
+            Q2_deriv[0, i, 3:] = (
+                    self.numeric_deriv(self.Q2_char_func, 'fluid', i))
 
         if self.P.is_var:
-            Q2_deriv[0, 7 + self.P.var_pos, 0] = self.numeric_deriv(self.Q2_char_func, 'P', 7)
+            Q2_deriv[0, 7 + self.P.var_pos, 0] = (
+                    self.numeric_deriv(self.Q2_char_func, 'P', 7))
         mat_deriv += Q2_deriv.tolist()
 
         ######################################################################
         # derivatives for heat loss to power charactersitics
         Ql_deriv = np.zeros((1, 7 + self.num_vars, self.num_fl + 3))
-        for i in range(2):
-            Ql_deriv[0, i + 2, 0] = self.numeric_deriv(self.Qloss_char_func, 'm', i + 2)
-            Ql_deriv[0, i + 2, 3:] = self.numeric_deriv(self.Qloss_char_func, 'fluid', i + 2)
-        Ql_deriv[0, 6, 0] = self.numeric_deriv(self.Qloss_char_func, 'm', 6)
-        Ql_deriv[0, 6, 3:] = self.numeric_deriv(self.Qloss_char_func, 'fluid', 6)
+        for i in [2, 3, 6]:
+            Ql_deriv[0, i, 0] = (
+                    self.numeric_deriv(self.Qloss_char_func, 'm', i))
+            Ql_deriv[0, i, 3:] = (
+                    self.numeric_deriv(self.Qloss_char_func, 'fluid', i))
 
         if self.P.is_var:
-            Ql_deriv[0, 7 + self.P.var_pos, 0] = self.numeric_deriv(self.Qloss_char_func, 'P', 7)
+            Ql_deriv[0, 7 + self.P.var_pos, 0] = (
+                    self.numeric_deriv(self.Qloss_char_func, 'P', 7))
         if self.Qloss.is_var:
-            Ql_deriv[0, 7 + self.Qloss.var_pos, 0] = self.numeric_deriv(self.Qloss_char_func, 'Qloss', 7)
+            Ql_deriv[0, 7 + self.Qloss.var_pos, 0] = (
+                    self.numeric_deriv(self.Qloss_char_func, 'Qloss', 7))
         mat_deriv += Ql_deriv.tolist()
 
         ######################################################################
         # derivatives for specified lambda
         if self.lamb.is_set:
             lamb_deriv = np.zeros((1, 7 + self.num_vars, self.num_fl + 3))
-            for i in range(2):
-                lamb_deriv[0, i + 2, 0] = self.numeric_deriv(self.lambda_func, 'm', i + 2)
-                lamb_deriv[0, i + 2, 3:] = self.numeric_deriv(self.lambda_func, 'fluid', i + 2)
+            lamb_deriv[0, 2, 0] = self.numeric_deriv(self.lambda_func, 'm', 2)
+            lamb_deriv[0, 2, 3:] = (
+                    self.numeric_deriv(self.lambda_func, 'fluid', 2))
+            lamb_deriv[0, 3, 0] = self.numeric_deriv(self.lambda_func, 'm', 3)
+            lamb_deriv[0, 3, 3:] = (
+                    self.numeric_deriv(self.lambda_func, 'fluid', 3))
             mat_deriv += lamb_deriv.tolist()
 
         ######################################################################
         # derivatives for specified thermal input
         if self.ti.is_set:
             ti_deriv = np.zeros((1, 7 + self.num_vars, self.num_fl + 3))
-            for i in range(2):
-                ti_deriv[0, i + 2, 0] = self.numeric_deriv(self.ti_func, 'm', i + 2)
-                ti_deriv[0, i + 2, 3:] = self.numeric_deriv(self.ti_func, 'fluid', i + 2)
-            ti_deriv[0, 6, 0] = self.numeric_deriv(self.ti_func, 'm', 6)
-            ti_deriv[0, 6, 3:] = self.numeric_deriv(self.ti_func, 'fluid', 6)
+            for i in [2, 3, 6]:
+                ti_deriv[0, i, 0] = self.numeric_deriv(self.ti_func, 'm', i)
+                ti_deriv[0, i, 3:] = (
+                        self.numeric_deriv(self.ti_func, 'fluid', i))
             mat_deriv += ti_deriv.tolist()
 
         ######################################################################
@@ -5690,7 +5806,8 @@ class cogeneration_unit(combustion_chamber):
 
     def fluid_func(self):
         r"""
-        Calculates the vector of residual values for cooling loop fluid balance equations.
+        Calculates the vector of residual values for cooling loop fluid balance
+        equations.
 
         Returns
         -------
@@ -5711,7 +5828,8 @@ class cogeneration_unit(combustion_chamber):
 
     def mass_flow_func(self):
         r"""
-        Calculates the residual value for component's mass flow balance equation.
+        Calculates the residual value for component's mass flow balance
+        equation.
 
         Returns
         -------
@@ -5734,7 +5852,8 @@ class cogeneration_unit(combustion_chamber):
 
     def fluid_deriv(self):
         r"""
-        Calculates the partial derivatives for cooling loop fluid balance equations.
+        Calculates the partial derivatives for cooling loop fluid balance
+        equations.
 
         Returns
         -------
@@ -5797,12 +5916,13 @@ class cogeneration_unit(combustion_chamber):
             .. math::
 
                 \begin{split}
-                0 = & \sum_i \dot{m}_{in,i} \cdot \left( h_{in,i} - h_{in,i,ref}
-                \right)\\
-                & - \sum_j \dot{m}_{out,3} \cdot \left( h_{out,3} - h_{out,3,ref}
-                \right)\\
-                & + H_{I,f} \cdot \left(\sum_i \left(\dot{m}_{in,i} \cdot x_{f,i}
-                \right)- \dot{m}_{out,3} \cdot x_{f,3} \right)\\
+                0 = & \sum_i \dot{m}_{in,i} \cdot
+                \left( h_{in,i} - h_{in,i,ref} \right)\\
+                & - \sum_j \dot{m}_{out,3} \cdot
+                \left( h_{out,3} - h_{out,3,ref} \right)\\
+                & + H_{I,f} \cdot
+                \left(\sum_i \left(\dot{m}_{in,i} \cdot x_{f,i} \right)-
+                \dot{m}_{out,3} \cdot x_{f,3} \right)\\
                 & - \dot{Q}_1 - \dot{Q}_2 - P - \dot{Q}_{loss}\\
                 \end{split}\\
                 \forall i \in [3,4]
@@ -5822,7 +5942,8 @@ class cogeneration_unit(combustion_chamber):
 
         res = 0
         for i in self.inl[2:]:
-            res += i.m.val_SI * (i.h.val_SI - h_mix_pT([0, p_ref, 0, i.fluid.val], T_ref))
+            res += i.m.val_SI * (i.h.val_SI -
+                                 h_mix_pT([0, p_ref, 0, i.fluid.val], T_ref))
 
         for o in self.outl[2:]:
             dh = 0
@@ -5834,13 +5955,16 @@ class cogeneration_unit(combustion_chamber):
                 if h < h_steam:
                     dh = (h_steam - h) * o.fluid.val[self.h2o]
 
-            res -= o.m.val_SI * (o.h.val_SI - h_mix_pT([0, p_ref, 0, o.fluid.val], T_ref) - dh)
+            res -= o.m.val_SI * (o.h.val_SI -
+                                 h_mix_pT([0, p_ref, 0, o.fluid.val], T_ref) -
+                                 dh)
 
         res += self.calc_ti()
 
         # cooling water
         for i in range(2):
-            res -= self.inl[i].m.val_SI * (self.outl[i].h.val_SI - self.inl[i].h.val_SI)
+            res -= self.inl[i].m.val_SI * (self.outl[i].h.val_SI -
+                                           self.inl[i].h.val_SI)
 
         # power output and heat loss
         res -= self.P.val + self.Qloss.val
@@ -5864,12 +5988,20 @@ class cogeneration_unit(combustion_chamber):
             .. math::
 
                 val = \begin{cases}
-                LHV \cdot \dot{m}_{f} \cdot f_{char}\left( \frac{LHV \cdot \dot{m}_{f}}{LHV \cdot \dot{m}_{f, ref}}\right) & \text{key = 'TI'}\\
-                P \cdot f_{char}\left( \frac{P}{P_{ref}}\right) & \text{key = 'P'}\\
-                \left(\dot{Q}_1 + \dot{Q}_2\right) \cdot f_{char}\left( \frac{\dot{Q}_1 + \dot{Q}_2}{\dot{Q}_{1,ref} + \dot{Q}_{2,ref}}\right)& \text{key = 'Q'}\\
-                \dot{Q}_1 \cdot f_{char}\left( \frac{\dot{Q}_1}{\dot{Q}_{1,ref}}\right) & \text{key = 'Q1'}\\
-                \dot{Q}_2 \cdot f_{char}\left( \frac{\dot{Q}_2}{\dot{Q}_{2,ref}}\right) & \text{key = 'Q2'}\\
-                \dot{Q}_{loss} \cdot f_{char}\left( \frac{\dot{Q}_{loss}}{\dot{Q}_{loss,ref}}\right) & \text{key = 'Qloss'}
+                LHV \cdot \dot{m}_{f} \cdot f_{char}\left( \frac{LHV \cdot
+                \dot{m}_{f}}{LHV \cdot \dot{m}_{f, ref}}\right) &
+                \text{key = 'TI'}\\
+                P \cdot f_{char}\left( \frac{P}{P_{ref}}\right) &
+                \text{key = 'P'}\\
+                \left(\dot{Q}_1 + \dot{Q}_2\right) \cdot
+                f_{char}\left( \frac{\dot{Q}_1 + \dot{Q}_2}{\dot{Q}_{1,ref} +
+                \dot{Q}_{2,ref}}\right) & \text{key = 'Q'}\\
+                \dot{Q}_1 \cdot f_{char}\left( \frac{\dot{Q}_1}
+                {\dot{Q}_{1,ref}}\right) & \text{key = 'Q1'}\\
+                \dot{Q}_2 \cdot f_{char}\left( \frac{\dot{Q}_2}
+                {\dot{Q}_{2,ref}}\right) & \text{key = 'Q2'}\\
+                \dot{Q}_{loss} \cdot f_{char}\left( \frac{\dot{Q}_{loss}}
+                {\dot{Q}_{loss,ref}}\right) & \text{key = 'Qloss'}
                 \end{cases}
 
                 \dot{Q}_1=\dot{m}_1 \cdot \left( h_{1,out} - h_{1,in} \right)\\
@@ -5950,7 +6082,8 @@ class cogeneration_unit(combustion_chamber):
         ######################################################################
         # missing/invalid bus parameter
         else:
-            msg = 'The parameter ' + str(bus.param) + ' is not a valid parameter for a ' + self.component() + '.'
+            msg = ('The parameter ' + str(bus.param) +
+                   ' is not a valid parameter for a ' + self.component() + '.')
             logging.error(msg)
             raise ValueError(msg)
 
@@ -5968,38 +6101,42 @@ class cogeneration_unit(combustion_chamber):
         mat_deriv : ndarray
             Matrix of partial derivatives.
         """
-        deriv = np.zeros((1, 7 + self.num_vars, len(self.inl[0].fluid.val) + 3))
+        deriv = np.zeros((1, 7 + self.num_vars,
+                          len(self.inl[0].fluid.val) + 3))
 
         ######################################################################
         # derivatives for bus parameter of thermal input (TI)
         if bus.param == 'TI':
-            for i in range(2):
-                deriv[0, i + 2, 0] = self.numeric_deriv(self.bus_func, 'm', i + 2, bus=bus)
-                deriv[0, i + 2, 3:] = self.numeric_deriv(self.bus_func, 'fluid', i + 2, bus=bus)
-            deriv[0, 6, 0] = self.numeric_deriv(self.bus_func, 'm', 6, bus=bus)
-            deriv[0, 6, 3:] = self.numeric_deriv(self.bus_func, 'fluid', 6, bus=bus)
+            for i in [2, 3, 6]:
+                deriv[0, i, 0] = (
+                        self.numeric_deriv(self.bus_func, 'm', i, bus=bus))
+                deriv[0, i, 3:] = (
+                        self.numeric_deriv(self.bus_func, 'fluid', i, bus=bus))
 
         ######################################################################
         # derivatives for bus parameter of power production (P)
         elif bus.param == 'P':
-            for i in range(2):
-                deriv[0, i + 2, 0] = self.numeric_deriv(self.bus_func, 'm', i + 2, bus=bus)
-                deriv[0, i + 2, 3:] = self.numeric_deriv(self.bus_func, 'fluid', i + 2, bus=bus)
-
-            deriv[0, 6, 0] = self.numeric_deriv(self.bus_func, 'm', 6, bus=bus)
-            deriv[0, 6, 3:] = self.numeric_deriv(self.bus_func, 'fluid', 6, bus=bus)
+            for i in [2, 3, 6]:
+                deriv[0, i, 0] = (
+                        self.numeric_deriv(self.bus_func, 'm', i, bus=bus))
+                deriv[0, i, 3:] = (
+                        self.numeric_deriv(self.bus_func, 'fluid', i, bus=bus))
 
             # variable power
             if self.P.is_var:
-                deriv[0, 7 + self.P.var_pos, 0] = self.numeric_deriv(self.bus_func, 'P', 7, bus=bus)
+                deriv[0, 7 + self.P.var_pos, 0] = (
+                        self.numeric_deriv(self.bus_func, 'P', 7, bus=bus))
 
         ######################################################################
         # derivatives for bus parameter of total heat production (Q)
         elif bus.param == 'Q':
             for i in range(2):
-                deriv[0, i, 0] = self.numeric_deriv(self.bus_func, 'm', i, bus=bus)
-                deriv[0, i, 2] = self.numeric_deriv(self.bus_func, 'h', i, bus=bus)
-                deriv[0, i + 4, 2] = self.numeric_deriv(self.bus_func, 'h', i + 4, bus=bus)
+                deriv[0, i, 0] = (
+                        self.numeric_deriv(self.bus_func, 'm', i, bus=bus))
+                deriv[0, i, 2] = (
+                        self.numeric_deriv(self.bus_func, 'h', i, bus=bus))
+                deriv[0, i + 4, 2] = (
+                        self.numeric_deriv(self.bus_func, 'h', i + 4, bus=bus))
 
         ######################################################################
         # derivatives for bus parameter of heat production 1 (Q1)
@@ -6018,21 +6155,22 @@ class cogeneration_unit(combustion_chamber):
         ######################################################################
         # derivatives for bus parameter of heat loss (Qloss)
         elif bus.param == 'Qloss':
-            for i in range(2):
-                deriv[0, i + 2, 0] = self.numeric_deriv(self.bus_func, 'm', i + 2, bus=bus)
-                deriv[0, i + 2, 3:] = self.numeric_deriv(self.bus_func, 'fluid', i + 2, bus=bus)
-
-            deriv[0, 6, 0] = self.numeric_deriv(self.bus_func, 'm', 6, bus=bus)
-            deriv[0, 6, 3:] = self.numeric_deriv(self.bus_func, 'fluid', 6, bus=bus)
+            for i in [2, 3, 6]:
+                deriv[0, i, 0] = (
+                        self.numeric_deriv(self.bus_func, 'm', i, bus=bus))
+                deriv[0, i, 3:] = (
+                        self.numeric_deriv(self.bus_func, 'fluid', i, bus=bus))
 
             # variable power
             if self.P.is_var:
-                deriv[0, 7 + self.P.var_pos, 0] = self.numeric_deriv(self.bus_func, 'P', 7, bus=bus)
+                deriv[0, 7 + self.P.var_pos, 0] = (
+                        self.numeric_deriv(self.bus_func, 'P', 7, bus=bus))
 
         ######################################################################
         # missing/invalid bus parameter
         else:
-            msg = 'The parameter ' + str(bus.param) + ' is not a valid parameter for a ' + self.component() + '.'
+            msg = ('The parameter ' + str(bus.param) +
+                   ' is not a valid parameter for a ' + self.component() + '.')
             logging.error(msg)
             raise ValueError(msg)
 
@@ -6049,7 +6187,8 @@ class cogeneration_unit(combustion_chamber):
 
             .. math::
 
-                val = \dot{m}_1 \cdot \left(h_{out,1} - h_{in,1} \right) - \dot{Q}_1
+                val = \dot{m}_1 \cdot \left(h_{out,1} -
+                h_{in,1} \right) - \dot{Q}_1
         """
         i = self.inl[0]
         o = self.outl[0]
@@ -6067,7 +6206,8 @@ class cogeneration_unit(combustion_chamber):
 
             .. math::
 
-                0 = \dot{m}_2 \cdot \left(h_{out,2} - h_{in,2} \right) - \dot{Q}_2
+                0 = \dot{m}_2 \cdot \left(h_{out,2} - h_{in,2} \right) -
+                \dot{Q}_2
         """
         i = self.inl[1]
         o = self.outl[1]
@@ -6076,7 +6216,8 @@ class cogeneration_unit(combustion_chamber):
 
     def tiP_char_func(self):
         r"""
-        Calculates the relation of output power and thermal input from specified characteristic line.
+        Calculates the relation of output power and thermal input from
+        specified characteristic line.
 
         Returns
         -------
@@ -6099,7 +6240,8 @@ class cogeneration_unit(combustion_chamber):
 
     def Q1_char_func(self):
         r"""
-        Calculates the relation of heat output 1 and thermal input from specified characteristic lines.
+        Calculates the relation of heat output 1 and thermal input from
+        specified characteristic lines.
 
         Returns
         -------
@@ -6127,11 +6269,13 @@ class cogeneration_unit(combustion_chamber):
             expr = self.P.val / self.P.design
 
         return (self.calc_ti() * self.Q1_char.func.f_x(expr) -
-                self.tiP_char.func.f_x(expr) * i.m.val_SI * (o.h.val_SI - i.h.val_SI))
+                self.tiP_char.func.f_x(expr) * i.m.val_SI *
+                (o.h.val_SI - i.h.val_SI))
 
     def Q2_char_func(self):
         r"""
-        Calculates the relation of heat output 2 and thermal input from specified characteristic lines.
+        Calculates the relation of heat output 2 and thermal input from
+        specified characteristic lines.
 
         Returns
         -------
@@ -6159,11 +6303,13 @@ class cogeneration_unit(combustion_chamber):
             expr = self.P.val / self.P.design
 
         return (self.calc_ti() * self.Q2_char.func.f_x(expr) -
-                self.tiP_char.func.f_x(expr) * i.m.val_SI * (o.h.val_SI - i.h.val_SI))
+                self.tiP_char.func.f_x(expr) * i.m.val_SI *
+                (o.h.val_SI - i.h.val_SI))
 
     def Qloss_char_func(self):
         r"""
-        Calculates the relation of heat loss and thermal input from specified characteristic lines.
+        Calculates the relation of heat loss and thermal input from
+        specified characteristic lines.
 
         Returns
         -------
@@ -6231,7 +6377,8 @@ class cogeneration_unit(combustion_chamber):
 
             .. math::
 
-                P = \frac{LHV \cdot \dot{m}_{f}}{f_{TI}\left(\frac{P}{P_{ref}}\right)}
+                P = \frac{LHV \cdot \dot{m}_{f}}
+                {f_{TI}\left(\frac{P}{P_{ref}}\right)}
 
         """
         if np.isnan(self.P.design):
@@ -6261,11 +6408,13 @@ class cogeneration_unit(combustion_chamber):
         else:
             expr = self.P.val / self.P.design
 
-        return (self.calc_ti() * self.Qloss_char.func.f_x(expr) / self.tiP_char.func.f_x(expr))
+        return (self.calc_ti() * self.Qloss_char.func.f_x(expr) /
+                self.tiP_char.func.f_x(expr))
 
     def initialise_fluids(self, nw):
         r"""
-        Calculates reaction balance with given lambda of 3 for good generic starting values at the combustion's outlet.
+        Calculates reaction balance with given lambda of 3 for good generic
+        starting values at the combustion's outlet.
 
         Parameters
         ----------
@@ -6293,11 +6442,14 @@ class cogeneration_unit(combustion_chamber):
         m_h2o = 0
         m_fuel = 0
         for f in self.fuel_list:
-            m_co2 += n_fuel * self.fuels[f]['C'] * molar_masses[self.co2] * fact_fuel[f]
-            m_h2o += n_fuel * self.fuels[f]['H'] / 2 * molar_masses[self.h2o] * fact_fuel[f]
+            m_co2 += (n_fuel * self.fuels[f]['C'] * molar_masses[self.co2] *
+                      fact_fuel[f])
+            m_h2o += (n_fuel * self.fuels[f]['H'] /
+                      2 * molar_masses[self.h2o] * fact_fuel[f])
             m_fuel += n_fuel * molar_masses[f] * fact_fuel[f]
 
-        n_o2 = (m_co2 / molar_masses[self.co2] + 0.5 * m_h2o / molar_masses[self.h2o]) * lamb
+        n_o2 = (m_co2 / molar_masses[self.co2] +
+                0.5 * m_h2o / molar_masses[self.h2o]) * lamb
 
         m_air = n_o2 * molar_masses[self.o2] / O_2
         m_fg = m_air + m_fuel
@@ -6319,7 +6471,8 @@ class cogeneration_unit(combustion_chamber):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -6348,7 +6501,8 @@ class cogeneration_unit(combustion_chamber):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -6386,12 +6540,17 @@ class cogeneration_unit(combustion_chamber):
         o1 = self.outl[0].to_flow()
         o2 = self.outl[1].to_flow()
 
+        v_i1 = v_mix_ph(i1, T0=self.inl[0].T.val_SI)
+        v_o1 = v_mix_ph(o1, T0=self.outl[0].T.val_SI)
+        v_i2 = v_mix_ph(i2, T0=self.inl[1].T.val_SI)
+        v_o2 = v_mix_ph(o1, T0=self.outl[1].T.val_SI)
+
         self.pr1.val = o1[1] / i1[1]
         self.pr2.val = o2[1] / i2[1]
         self.zeta1.val = ((i1[1] - o1[1]) * math.pi ** 2 /
-                          (8 * i1[0] ** 2 * (v_mix_ph(i1) + v_mix_ph(o1)) / 2))
+                          (8 * i1[0] ** 2 * (v_i1 + v_o1) / 2))
         self.zeta2.val = ((i2[1] - o2[1]) * math.pi ** 2 /
-                          (8 * i2[0] ** 2 * (v_mix_ph(i2) + v_mix_ph(o2)) / 2))
+                          (8 * i2[0] ** 2 * (v_i2 + v_o2) / 2))
         self.Q1.val = i1[0] * (o1[2] - i1[2])
         self.Q2.val = i2[0] * (o2[2] - i2[2])
         self.P.val = self.calc_P()
@@ -6441,7 +6600,8 @@ class water_electrolyzer(component):
 
             0 = \dot{m}_{H_{2}O,in1} - \dot{m}_{H_{2}O,out1}\\
             0 = O_2 \cdot \dot{m}_{H_{2}O,in2} - \dot{m}_{O_2,out2}\\
-            0 = \left(1 - O_2\right) \cdot \dot{m}_{H_{2}O,in2} - \dot{m}_{H_2,out3}\\
+            0 = \left(1 - O_2\right) \cdot \dot{m}_{H_{2}O,in2} -
+            \dot{m}_{H_2,out3}\\
 
             0 = p_{H_{2}O,in2} - p_{O_2,out2}\\
             0 = p_{H_{2}O,in2} - p_{H_2,out3}
@@ -6467,7 +6627,8 @@ class water_electrolyzer(component):
 
         .. math::
 
-            0 = \dot{Q} - \dot{m}_{in1} \cdot \left(h_{in1} - h_{out1}\right) \\
+            0 = \dot{Q} - \dot{m}_{in1} \cdot \left(h_{in1} -
+            h_{out1}\right) \\
 
             0 = P - \dot{m}_{H_2,out3} \cdot \frac{e_0}{\eta}
 
@@ -6490,9 +6651,6 @@ class water_electrolyzer(component):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -6506,7 +6664,8 @@ class water_electrolyzer(component):
         Heat output of cooling, :math:`Q/\text{W}`
 
     e : float/tespy.helpers.dc_cp
-        Electrolysis specific energy consumption, :math:`e/(\text{J}/\text{m}^3)`.
+        Electrolysis specific energy consumption,
+        :math:`e/(\text{J}/\text{m}^3)`.
 
     eta : float/tespy.helpers.dc_cp
         Electrolysis efficiency, :math:`\eta/1`.
@@ -6518,8 +6677,8 @@ class water_electrolyzer(component):
         Cooling loop pressure ratio, :math:`pr/1`.
 
     zeta : float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient for cooling loop pressure drop,
-        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient for cooling loop pressure
+        drop, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     Note
     ----
@@ -6529,7 +6688,8 @@ class water_electrolyzer(component):
     >>> from tespy import cmp, con, nwk
     >>> import shutil
     >>> fluid_list = ['O2', 'water', 'H2']
-    >>> nw = nwk.network(fluids=fluid_list, T_unit='C', p_unit='bar', h_unit='kJ / kg')
+    >>> nw = nwk.network(fluids=fluid_list, T_unit='C', p_unit='bar',
+    ... h_unit='kJ / kg')
     >>> nw.set_printoptions(print_level='none')
 
     >>> fw = cmp.source('feed water')
@@ -6538,7 +6698,8 @@ class water_electrolyzer(component):
     >>> cw = cmp.source('cooling water')
     >>> cw_hot = cmp.sink('cooling water out')
 
-    >>> el = cmp.water_electrolyzer('electrolyzer 1', eta=0.8, design=['eta'], offdesign=['eta_char'])
+    >>> el = cmp.water_electrolyzer('electrolyzer 1', eta=0.8, design=['eta'],
+    ... offdesign=['eta_char'])
     >>> el.component()
     'water electrolyzer'
     >>> comp = cmp.compressor('compressor', eta_s=0.9)
@@ -6547,7 +6708,8 @@ class water_electrolyzer(component):
     >>> el_o = con.connection(el, 'out2', oxy, 'in1')
     >>> el_cmp = con.connection(el, 'out3', comp, 'in1', T=50)
     >>> cmp_h = con.connection(comp, 'out1', hydro, 'in1', p=50)
-    >>> cw_el = con.connection(cw, 'out1', el, 'in1', fluid={'water': 1, 'H2': 0, 'O2': 0}, p=5, T=15)
+    >>> cw_el = con.connection(cw, 'out1', el, 'in1', p=5, T=15,
+    ... fluid={'water': 1, 'H2': 0, 'O2': 0})
     >>> el_cw = con.connection(el, 'out1', cw_hot, 'in1', T=45, p=4.9)
     >>> nw.add_conns(fw_el, el_o, el_cmp, cmp_h, cw_el, el_cw)
     >>> nw.solve('design')
@@ -6590,28 +6752,34 @@ class water_electrolyzer(component):
 
         component.comp_init(self, nw)
 
-        o2 = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('O2')]]
+        o2 = [x for x in nw.fluids if x in [a.replace(' ', '')
+              for a in CP.get_aliases('O2')]]
         if len(o2) == 0:
-            msg = ('Missing oxygen in network fluids, component ' + self.label + ' '
-                   'of type ' + self.component() + ' requires oxygen in network fluids.')
+            msg = ('Missing oxygen in network fluids, component ' +
+                   self.label + ' of type ' + self.component() +
+                   ' requires oxygen in network fluids.')
             logging.error(msg)
             raise ValueError(msg)
         else:
             self.o2 = o2[0]
 
-        h2o = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('H2O')]]
+        h2o = [x for x in nw.fluids if x in [a.replace(' ', '')
+               for a in CP.get_aliases('H2O')]]
         if len(h2o) == 0:
-            msg = ('Missing water in network fluids, component ' + self.label + ' '
-                   'of type ' + self.component() + ' requires water in network fluids.')
+            msg = ('Missing water in network fluids, component ' +
+                   self.label + ' of type ' + self.component() +
+                   ' requires water in network fluids.')
             logging.error(msg)
             raise ValueError(msg)
         else:
             self.h2o = h2o[0]
 
-        h2 = [x for x in nw.fluids if x in [a.replace(' ', '') for a in CP.get_aliases('H2')]]
+        h2 = [x for x in nw.fluids if x in [a.replace(' ', '')
+              for a in CP.get_aliases('H2')]]
         if len(h2) == 0:
-            msg = ('Missing hydrogen in network fluids, component ' + self.label + ' '
-                   'of type ' + self.component() + ' requires hydrogen in network fluids.')
+            msg = ('Missing hydrogen in network fluids, component ' +
+                   self.label + ' of type ' + self.component() +
+                   ' requires hydrogen in network fluids.')
             logging.error(msg)
             raise ValueError(msg)
         else:
@@ -6637,8 +6805,8 @@ class water_electrolyzer(component):
                 \Delta H_f^0: \text{molar formation enthalpy}
         """
 
-        hf = {} # unexpected indent
-        hf['H2O'] = -286 #kj
+        hf = {}
+        hf['H2O'] = -286
         hf['H2'] = 0
         hf['O2'] = 0
         M = molar_masses['H2']
@@ -6681,7 +6849,8 @@ class water_electrolyzer(component):
         ######################################################################
         # eqations for mass flow balance
         # equation to calculate the ratio of o2 in water
-        o2 = molar_masses[self.o2] / (molar_masses[self.o2] + 2 * molar_masses[self.h2])
+        o2 = molar_masses[self.o2] / (molar_masses[self.o2] +
+                                      2 * molar_masses[self.h2])
 
         # equation for mass flow balance cooling water
         vec_res += [self.inl[0].m.val_SI -  self.outl[0].m.val_SI]
@@ -6701,7 +6870,8 @@ class water_electrolyzer(component):
 
         ######################################################################
         # temperature electrolyzer outlet
-        vec_res += [T_mix_ph(self.outl[1].to_flow()) - T_mix_ph(self.outl[2].to_flow())]
+        vec_res += [T_mix_ph(self.outl[1].to_flow()) -
+                    T_mix_ph(self.outl[2].to_flow())]
 
         ######################################################################
         # power vs hydrogen production
@@ -6711,7 +6881,8 @@ class water_electrolyzer(component):
         ######################################################################
         #pr_c.val = pressure ratio Druckverlust (als Faktor vorgegeben)
         if self.pr_c.is_set:
-            vec_res += [self.inl[0].p.val_SI * self.pr_c.val - self.outl[0].p.val_SI]
+            vec_res += [self.inl[0].p.val_SI * self.pr_c.val -
+                        self.outl[0].p.val_SI]
 
         if self.zeta.is_set:
             vec_res += [self.zeta_func()]
@@ -6719,12 +6890,14 @@ class water_electrolyzer(component):
         # equation for heat transfer
 
         if self.Q.is_set:
-            vec_res += [self.Q.val - self.inl[0].m.val_SI * (self.inl[0].h.val_SI - self.outl[0].h.val_SI)]
+            vec_res += [self.Q.val - self.inl[0].m.val_SI *
+                        (self.inl[0].h.val_SI - self.outl[0].h.val_SI)]
 
         ######################################################################
         # specified efficiency (efficiency definition: e0 / e)
         if self.eta.is_set:
-            vec_res += [self.P.val - self.outl[2].m.val_SI * self.e0 / self.eta.val]
+            vec_res += [self.P.val - self.outl[2].m.val_SI *
+                        self.e0 / self.eta.val]
 
         ######################################################################
         # specified characteristic line for efficiency
@@ -6772,7 +6945,8 @@ class water_electrolyzer(component):
         mat_deriv += deriv.tolist()
 
         # derivatives to ban fluids off inlets/outlets
-        deriv = np.zeros((3 * len(self.inl[1].fluid.val.keys()) - 3, 5 + self.num_vars, self.num_fl + 3))
+        deriv = np.zeros((3 * len(self.inl[1].fluid.val.keys()) - 3,
+                          5 + self.num_vars, self.num_fl + 3))
 
         i = 0
         j = 0
@@ -6800,7 +6974,8 @@ class water_electrolyzer(component):
         deriv[0, 2, 0] = -1
 
         # derivatives for mass flow balance for oxygen output
-        o2 = molar_masses[self.o2] / (molar_masses[self.o2] + 2 * molar_masses[self.h2])
+        o2 = molar_masses[self.o2] / (molar_masses[self.o2] +
+                                      2 * molar_masses[self.h2])
         deriv[1, 1, 0] = o2
         deriv[1, 3, 0] = -1
 
@@ -6920,7 +7095,8 @@ class water_electrolyzer(component):
 
             # derivatives for variable zeta
             if self.zeta.is_var:
-                deriv[0, 5 + self.zeta.var_pos, 0] = self.numeric_deriv(self.zeta_func, 'zeta', i)
+                deriv[0, 5 + self.zeta.var_pos, 0] = (
+                        self.numeric_deriv(self.zeta_func, 'zeta', 5))
 
             mat_deriv += deriv.tolist()
 
@@ -6982,7 +7158,8 @@ class water_electrolyzer(component):
 
     def eta_char_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives of the efficiency characteristic function.
+        Calculates the matrix of partial derivatives of the efficiency
+        characteristic function.
 
         Returns
         -------
@@ -7017,10 +7194,13 @@ class water_electrolyzer(component):
             .. math::
 
                 val = \begin{cases}
-                P \cdot f_{char}\left( \frac{P}{P_{ref}}\right) & \text{key = 'P'}\\
-                \dot{Q} \cdot f_{char}\left( \frac{\dot{Q}}{\dot{Q}_{ref}}\right)& \text{key = 'Q'}\\
+                P \cdot f_{char}\left( \frac{P}{P_{ref}}\right) &
+                \text{key = 'P'}\\
+                \dot{Q} \cdot f_{char}\left( \frac{\dot{Q}}
+                {\dot{Q}_{ref}}\right) & \text{key = 'Q'}\\
                 \end{cases}\\
-                \dot{Q} = - \dot{m}_{1,in} \cdot \left(h_{out,1} - h_{in,1} \right)\\
+                \dot{Q} = - \dot{m}_{1,in} \cdot
+                \left(h_{out,1} - h_{in,1} \right)\\
         """
         ######################################################################
         # equations for power on bus
@@ -7036,7 +7216,8 @@ class water_electrolyzer(component):
         # equations for heat on bus
 
         elif bus.param == 'Q':
-            val = - self.inl[0].m.val_SI * (self.outl[0].h.val_SI - self.inl[0].h.val_SI)
+            val = - self.inl[0].m.val_SI * (self.outl[0].h.val_SI -
+                                            self.inl[0].h.val_SI)
             if np.isnan(bus.P_ref):
                 expr = 1
             else:
@@ -7047,8 +7228,10 @@ class water_electrolyzer(component):
         # missing/invalid bus parameter
 
         else:
-            msg = ('The parameter ' + str(bus.param) + ' is not a valid parameter for a component of type ' +
-                   self.component() + '. Please specify a bus parameter (P/Q) for component ' + self.label + '.')
+            msg = ('The parameter ' + str(bus.param) + ' is not a valid '
+                   'parameter for a component of type ' + self.component() +
+                   '. Please specify a bus parameter (P/Q) for component ' +
+                   self.label + '.')
             logging.error(msg)
             raise ValueError(msg)
 
@@ -7086,7 +7269,8 @@ class water_electrolyzer(component):
             deriv[0, 4, 2] = self.numeric_deriv(self.bus_func, 'h', 4, bus=bus)
             # variable power
             if self.P.is_var:
-                deriv[0, 5 + self.P.var_pos, 0] = self.numeric_deriv(self.bus_func, 'P', 5, bus=bus)
+                deriv[0, 5 + self.P.var_pos, 0] = (
+                        self.numeric_deriv(self.bus_func, 'P', 5, bus=bus))
 
         ######################################################################
         # derivatives for heat on bus
@@ -7102,8 +7286,10 @@ class water_electrolyzer(component):
         # missing/invalid bus parameter
 
         else:
-            msg = ('The parameter ' + str(bus.param) + ' is not a valid parameter for a component of type ' +
-                   self.component() + '. Please specify a bus parameter (P/Q) for component ' + self.label + '.')
+            msg = ('The parameter ' + str(bus.param) + ' is not a valid '
+                   'parameter for a component of type ' + self.component() +
+                   '. Please specify a bus parameter (P/Q) for component ' +
+                   self.label + '.')
             logging.error(msg)
             raise ValueError(msg)
 
@@ -7111,8 +7297,9 @@ class water_electrolyzer(component):
 
     def energy_balance(self):
         r"""
-        Calculates the residual in energy balance of the adiabatic water electrolyzer.
-        The residual is the negative to the necessary power input.
+        Calculates the residual in energy balance of the adiabatic water
+        electrolyzer. The residual is the negative to the necessary power
+        input.
 
         Returns
         -------
@@ -7122,11 +7309,13 @@ class water_electrolyzer(component):
             .. math::
 
                 \begin{split}
-                res = & \dot{m}_{in,2} \cdot \left( h_{in,2} - h_{in,2,ref} \right)\\
-                & - \dot{m}_{out,3} \cdot e_0\\
+                res = & \dot{m}_{in,2} \cdot \left( h_{in,2} - h_{in,2,ref}
+                \right)\\ & - \dot{m}_{out,3} \cdot e_0\\
                 & -\dot{m}_{in,1} \cdot \left( h_{out,1} - h_{in,1} \right)\\
-                & - \dot{m}_{out,2} \cdot \left( h_{out,2} - h_{out,2,ref} \right)\\
-                & - \dot{m}_{out,3} \cdot \left( h_{out,3} - h_{out,3,ref} \right)\\
+                & - \dot{m}_{out,2} \cdot \left( h_{out,2} - h_{out,2,ref}
+                \right)\\
+                & - \dot{m}_{out,3} \cdot \left( h_{out,3} - h_{out,3,ref}
+                \right)\\
                 \end{split}
 
         Note
@@ -7152,14 +7341,15 @@ class water_electrolyzer(component):
 
         val = (self.inl[1].m.val_SI * (self.inl[1].h.val_SI - h_refh2o) -
                self.outl[2].m.val_SI * self.e0 -
-               self.inl[0].m.val_SI * (self.outl[0].h.val_SI - self.inl[0].h.val_SI) -
+               self.inl[0].m.val_SI * (self.outl[0].h.val_SI -
+                                       self.inl[0].h.val_SI) -
                self.outl[1].m.val_SI * (self.outl[1].h.val_SI - h_refo2) -
                self.outl[2].m.val_SI * (self.outl[2].h.val_SI - h_refh2))
         return val
 
     def initialise_fluids(self, nw):
         r"""
-        Calculates reaction balance with given lambda of 3 for good generic starting values at the component's outlet.
+        Sets values to pure fluid on water inlet and gas outlets.
 
         Parameters
         ----------
@@ -7172,7 +7362,8 @@ class water_electrolyzer(component):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -7203,7 +7394,8 @@ class water_electrolyzer(component):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -7236,21 +7428,25 @@ class water_electrolyzer(component):
         r"""
         Postprocessing parameter calculation.
         """
-        self.Q.val = - self.inl[0].m.val_SI * (self.outl[0].h.val_SI - self.inl[0].h.val_SI)
+        self.Q.val = - self.inl[0].m.val_SI * (self.outl[0].h.val_SI -
+                                               self.inl[0].h.val_SI)
         self.pr_c.val = self.outl[0].p.val_SI / self.inl[0].p.val_SI
         self.e.val = self.P.val / self.outl[2].m.val_SI
         self.eta.val = self.e0 / self.e.val
 
         if self.eta.val > 1:
             msg = ('The electrolyzer efficiency is above 1 '
-                   '(specific energy consumption is: ' + str(round(self.e.val / 1e6, 0)) + ' MJ / kg, '
-                   'miniumum energy required is: ' + str(round(self.e0 / 1e6, 0)) + ' MJ / kg) '
+                   '(specific energy consumption is: ' +
+                   str(round(self.e.val / 1e6, 0)) + ' MJ / kg, '
+                   'miniumum energy required is: ' +
+                   str(round(self.e0 / 1e6, 0)) + ' MJ / kg) '
                    'at component ' + self.label)
             logging.warning(msg)
 
         i = self.inl[0].to_flow()
         o = self.outl[0].to_flow()
-        self.zeta.val = (i[1] - o[1]) * math.pi ** 2 / (8 * i[0] ** 2 * (v_mix_ph(i) + v_mix_ph(o)) / 2)
+        self.zeta.val = ((i[1] - o[1]) * math.pi ** 2 /
+                         (8 * i[0] ** 2 * (v_mix_ph(i) + v_mix_ph(o)) / 2))
 
         if self.eta_char.is_set:
             # get bound errors for kA hot side characteristics
@@ -7298,9 +7494,6 @@ class valve(component):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -7311,7 +7504,8 @@ class valve(component):
         Outlet to inlet pressure ratio, :math:`pr/1`
 
     zeta : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     Example
     -------
@@ -7445,11 +7639,13 @@ class valve(component):
         if self.zeta.is_set:
             deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
             deriv[0, 0, 0] = self.numeric_deriv(self.zeta_func, 'm', 0)
-            for i in range(2):
-                deriv[0, i, 1] = self.numeric_deriv(self.zeta_func, 'p', i)
-                deriv[0, i, 2] = self.numeric_deriv(self.zeta_func, 'h', i)
+            deriv[0, 0, 1] = self.numeric_deriv(self.zeta_func, 'p', 0)
+            deriv[0, 0, 2] = self.numeric_deriv(self.zeta_func, 'h', 0)
+            deriv[0, 1, 1] = self.numeric_deriv(self.zeta_func, 'p', 1)
+            deriv[0, 1, 2] = self.numeric_deriv(self.zeta_func, 'h', 1)
             if self.zeta.is_var:
-                deriv[0, 2 + self.zeta.var_pos, 0] = self.numeric_deriv(self.zeta_func, 'zeta', i)
+                deriv[0, 2 + self.zeta.var_pos, 0] = (
+                        self.numeric_deriv(self.zeta_func, 'zeta', 2))
             mat_deriv += deriv.tolist()
 
         return np.asarray(mat_deriv)
@@ -7470,7 +7666,8 @@ class valve(component):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -7499,7 +7696,8 @@ class valve(component):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -7542,7 +7740,8 @@ class valve(component):
 
 class heat_exchanger_simple(component):
     r"""
-    The component heat_exchanger_simple is the parent class for pipe and solar_collector.
+    The component heat_exchanger_simple is the parent class for pipe and
+    solar_collector.
 
     Equations
 
@@ -7561,8 +7760,8 @@ class heat_exchanger_simple(component):
 
         - :func:`tespy.components.components.component.zeta_func`
 
-        - :func:`tespy.components.components.heat_exchanger_simple.darcy_func` or
-          :func:`tespy.components.components.heat_exchanger_simple.hw_func`
+        - :func:`tespy.components.components.heat_exchanger_simple.darcy_func`
+          or :func:`tespy.components.components.heat_exchanger_simple.hw_func`
 
         **additional equations**
 
@@ -7585,9 +7784,6 @@ class heat_exchanger_simple(component):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -7601,7 +7797,8 @@ class heat_exchanger_simple(component):
         Outlet to inlet pressure ratio, :math:`pr/1`.
 
     zeta : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     D : str/float/tespy.helpers.dc_cp
         Diameter of the pipes, :math:`D/\text{m}`.
@@ -7615,14 +7812,16 @@ class heat_exchanger_simple(component):
 
     hydro_group : Sring/tespy.helpers.dc_gcp
         Parametergroup for pressure drop calculation based on pipes dimensions.
-        Choose 'HW' for hazen-williams equation, else darcy friction factor is used.
+        Choose 'HW' for hazen-williams equation, else darcy friction factor is
+        used.
 
     kA : str/float/tespy.helpers.dc_cp
-        Area independent heat transition coefficient, :math:`kA/\frac{\text{W}}{\text{K}}`.
+        Area independent heat transition coefficient,
+        :math:`kA/\frac{\text{W}}{\text{K}}`.
 
     kA_char : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient, provide x and y values
-        or use generic values (e. g. calculated from design case).
+        Characteristic curve for heat transfer coefficient, provide x and y
+        values or use generic values (e. g. calculated from design case).
         Standard method 'HE_COLD', Parameter 'm'.
 
     Tamb : float/tespy.helpers.dc_cp
@@ -7634,8 +7833,8 @@ class heat_exchanger_simple(component):
          parameter in network's temperature unit.
 
     kA_group : tespy.helpers.dc_gcp
-        Parametergroup for heat transfer calculation from ambient temperature and area
-        independent heat transfer coefficient kA.
+        Parametergroup for heat transfer calculation from ambient temperature
+        and area independent heat transfer coefficient kA.
 
     Example
     -------
@@ -7701,8 +7900,10 @@ class heat_exchanger_simple(component):
         self.fl_deriv = self.fluid_deriv()
         self.m_deriv = self.mass_flow_deriv()
 
-        self.Tamb.val_SI = ((self.Tamb.val + nw.T[nw.T_unit][0]) * nw.T[nw.T_unit][1])
-        self.Tamb.design = ((self.Tamb.design + nw.T[nw.T_unit][0]) * nw.T[nw.T_unit][1])
+        self.Tamb.val_SI = ((self.Tamb.val + nw.T[nw.T_unit][0]) *
+                            nw.T[nw.T_unit][1])
+        self.Tamb.design = ((self.Tamb.design + nw.T[nw.T_unit][0]) *
+                            nw.T[nw.T_unit][1])
 
         # parameters for hydro group
         self.hydro_group.set_attr(elements=[self.L, self.ks, self.D])
@@ -7718,7 +7919,8 @@ class heat_exchanger_simple(component):
                 method = 'Hazen-Williams equation.'
             else:
                 method = 'darcy friction factor.'
-            msg = 'Pressure loss calculation from pipe dimensions method is set to ' + method
+            msg = ('Pressure loss calculation from pipe dimensions method is '
+                   'set to ' + method + '.')
             logging.debug(msg)
 
         elif self.hydro_group.is_set:
@@ -7778,7 +7980,8 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equations for specified pressure ratio
         if self.pr.is_set:
-            vec_res += [self.inl[0].p.val_SI * self.pr.val - self.outl[0].p.val_SI]
+            vec_res += [self.inl[0].p.val_SI * self.pr.val -
+                        self.outl[0].p.val_SI]
 
         ######################################################################
         # equations for specified zeta
@@ -7804,7 +8007,8 @@ class heat_exchanger_simple(component):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for this
+        component.
 
         Equations
 
@@ -7866,12 +8070,14 @@ class heat_exchanger_simple(component):
         if self.zeta.is_set:
             zeta_deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
             zeta_deriv[0, 0, 0] = self.numeric_deriv(self.zeta_func, 'm', 0)
-            for i in range(2):
-                zeta_deriv[0, i, 1] = self.numeric_deriv(self.zeta_func, 'p', i)
-                zeta_deriv[0, i, 2] = self.numeric_deriv(self.zeta_func, 'h', i)
+            zeta_deriv[0, 0, 1] = self.numeric_deriv(self.zeta_func, 'p', 0)
+            zeta_deriv[0, 0, 2] = self.numeric_deriv(self.zeta_func, 'h', 0)
+            zeta_deriv[0, 1, 1] = self.numeric_deriv(self.zeta_func, 'p', 1)
+            zeta_deriv[0, 1, 2] = self.numeric_deriv(self.zeta_func, 'h', 1)
             # custom variable zeta
             if self.zeta.is_var:
-                zeta_deriv[0, 2 + self.zeta.var_pos, 0] = self.numeric_deriv(self.zeta_func, 'zeta', i)
+                zeta_deriv[0, 2 + self.zeta.var_pos, 0] = (
+                        self.numeric_deriv(self.zeta_func, 'zeta', 2))
             mat_deriv += zeta_deriv.tolist()
 
         ######################################################################
@@ -7886,13 +8092,15 @@ class heat_exchanger_simple(component):
 
             deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
             deriv[0, 0, 0] = self.numeric_deriv(func, 'm', 0)
-            for i in range(2):
-                deriv[0, i, 1] = self.numeric_deriv(func, 'p', i)
-                deriv[0, i, 2] = self.numeric_deriv(func, 'h', i)
+            deriv[0, 0, 1] = self.numeric_deriv(func, 'p', 0)
+            deriv[0, 0, 2] = self.numeric_deriv(func, 'h', 0)
+            deriv[0, 1, 1] = self.numeric_deriv(func, 'p', 1)
+            deriv[0, 1, 2] = self.numeric_deriv(func, 'h', 1)
             # custom variables of hydro group
             for var in self.hydro_group.elements:
                 if var.is_var:
-                    deriv[0, 2 + var.var_pos, 0] = self.numeric_deriv(func, self.vars[var], i)
+                    deriv[0, 2 + var.var_pos, 0] = (
+                            self.numeric_deriv(func, self.vars[var], 2))
             mat_deriv += deriv.tolist()
 
         ######################################################################
@@ -7903,7 +8111,8 @@ class heat_exchanger_simple(component):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -7917,13 +8126,16 @@ class heat_exchanger_simple(component):
         if self.kA_group.is_set:
             deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
             deriv[0, 0, 0] = self.numeric_deriv(self.kA_func, 'm', 0)
-            for i in range(2):
-                deriv[0, i, 1] = self.numeric_deriv(self.kA_func, 'p', i)
-                deriv[0, i, 2] = self.numeric_deriv(self.kA_func, 'h', i)
+            deriv[0, 0, 1] = self.numeric_deriv(self.kA_func, 'p', 0)
+            deriv[0, 0, 2] = self.numeric_deriv(self.kA_func, 'h', 0)
+            deriv[0, 1, 1] = self.numeric_deriv(self.kA_func, 'p', 1)
+            deriv[0, 1, 2] = self.numeric_deriv(self.kA_func, 'h', 1)
             #
             for var in self.kA_group.elements:
                 if var.is_var:
-                    deriv[0, 2 + var.var_pos, 0] = self.numeric_deriv(self.kA_func, self.vars[var], i)
+                    deriv[0, 2 + var.var_pos, 0] = (
+                            self.numeric_deriv(self.kA_func, self.vars[var], 2)
+                            )
             mat_deriv += deriv.tolist()
 
         return mat_deriv
@@ -7939,9 +8151,11 @@ class heat_exchanger_simple(component):
 
             .. math::
 
-                res = \dot{m}_{in} \cdot \left(h_{out} - h_{in} \right) - \dot{Q}
+                res = \dot{m}_{in} \cdot \left(h_{out} - h_{in} \right) -
+                \dot{Q}
         """
-        return self.inl[0].m.val_SI * (self.outl[0].h.val_SI - self.inl[0].h.val_SI) - self.Q.val
+        return self.inl[0].m.val_SI * (
+                self.outl[0].h.val_SI - self.inl[0].h.val_SI) - self.Q.val
 
     def Q_deriv(self):
         r"""
@@ -7976,9 +8190,9 @@ class heat_exchanger_simple(component):
                 Re = \frac{4 \cdot |\dot{m}_{in}|}{\pi \cdot D \cdot
                 \frac{\eta_{in}+\eta_{out}}{2}}\\
 
-                0 = p_{in} - p_{out} - \frac{8 \cdot |\dot{m}_{in}| \cdot \dot{m}_{in} \cdot
-                \frac{v_{in}+v_{out}}{2} \cdot L \cdot \lambda\left(
-                Re, ks, D\right)}{\pi^2 \cdot D^5}\\
+                0 = p_{in} - p_{out} - \frac{8 \cdot |\dot{m}_{in}| \cdot
+                \dot{m}_{in} \cdot \frac{v_{in}+v_{out}}{2} \cdot L \cdot
+                \lambda\left(Re, ks, D\right)}{\pi^2 \cdot D^5}\\
 
                 \eta: \text{dynamic viscosity}\\
                 v: \text{specific volume}\\
@@ -7989,8 +8203,10 @@ class heat_exchanger_simple(component):
         if abs(i[0]) < 1e-4:
             return i[1] - o[1]
 
-        visc_i, visc_o = visc_mix_ph(i), visc_mix_ph(o)
-        v_i, v_o = v_mix_ph(i), v_mix_ph(o)
+        visc_i = visc_mix_ph(i, T0=self.inl[0].T.val_SI)
+        visc_o = visc_mix_ph(o, T0=self.outl[0].T.val_SI)
+        v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+        v_o = v_mix_ph(o, T0=self.outl[0].T.val_SI)
 
         re = 4 * abs(i[0]) / (math.pi * self.D.val * (visc_i + visc_o) / 2)
 
@@ -8028,7 +8244,8 @@ class heat_exchanger_simple(component):
         if abs(i[0]) < 1e-4:
             return i[1] - o[1]
 
-        v_i, v_o = v_mix_ph(i), v_mix_ph(o)
+        v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+        v_o = v_mix_ph(o, T0=self.outl[0].T.val_SI)
         flow_dir = np.sign(i[0])
 
         return ((i[1] - o[1]) * flow_dir -
@@ -8038,7 +8255,8 @@ class heat_exchanger_simple(component):
 
     def kA_func(self):
         r"""
-        Equation for heat transfer calculation from ambient conditions and heat transfer coefficient.
+        Equation for heat transfer calculation from ambient conditions and heat
+        transfer coefficient.
 
         Returns
         -------
@@ -8070,8 +8288,8 @@ class heat_exchanger_simple(component):
         """
         i, o = self.inl[0].to_flow(), self.outl[0].to_flow()
 
-        ttd_1 = T_mix_ph(i) - self.Tamb.val_SI
-        ttd_2 = T_mix_ph(o) - self.Tamb.val_SI
+        ttd_1 = T_mix_ph(i, T0=self.inl[0].T.val_SI) - self.Tamb.val_SI
+        ttd_2 = T_mix_ph(o, T0=self.outl[0].T.val_SI) - self.Tamb.val_SI
 
         if ttd_1 > ttd_2:
             td_log = (ttd_1 - ttd_2) / math.log(ttd_1 / ttd_2)
@@ -8139,7 +8357,8 @@ class heat_exchanger_simple(component):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -8178,7 +8397,8 @@ class heat_exchanger_simple(component):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -8220,19 +8440,21 @@ class heat_exchanger_simple(component):
         """
         i = self.inl[0].to_flow()
         o = self.outl[0].to_flow()
+        v_i = v_mix_ph(i, T0=self.inl[0].T.val_SI)
+        v_o = v_mix_ph(o, T0=self.outl[0].T.val_SI)
 
         self.SQ1.val = i[0] * (s_mix_ph(o) - s_mix_ph(i))
         self.Q.val = i[0] * (o[2] - i[2])
         self.pr.val = o[1] / i[1]
         self.zeta.val = ((i[1] - o[1]) * math.pi ** 2 /
-                         (8 * i[0] ** 2 * (v_mix_ph(i) + v_mix_ph(o)) / 2))
+                         (8 * i[0] ** 2 * (v_i + v_o) / 2))
 
         if self.Tamb.is_set:
             self.SQ2.val = -i[0] * (o[2] - i[2]) / self.Tamb.val_SI
             self.Sirr.val = self.SQ1.val + self.SQ2.val
 
-            ttd_1 = T_mix_ph(i) - self.Tamb.val_SI
-            ttd_2 = T_mix_ph(o) - self.Tamb.val_SI
+            ttd_1 = T_mix_ph(i, T0=self.inl[0].T.val_SI) - self.Tamb.val_SI
+            ttd_2 = T_mix_ph(o, T0=self.outl[0].T.val_SI) - self.Tamb.val_SI
 
             if ttd_1 > ttd_2:
                 td_log = (ttd_1 - ttd_2) / math.log(ttd_1 / ttd_2)
@@ -8271,8 +8493,8 @@ class pipe(heat_exchanger_simple):
 
         - :func:`tespy.components.components.component.zeta_func`
 
-        - :func:`tespy.components.components.heat_exchanger_simple.darcy_func` or
-          :func:`tespy.components.components.heat_exchanger_simple.hw_func`
+        - :func:`tespy.components.components.heat_exchanger_simple.darcy_func`
+          or :func:`tespy.components.components.heat_exchanger_simple.hw_func`
 
         **additional equations**
 
@@ -8295,9 +8517,6 @@ class pipe(heat_exchanger_simple):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -8311,7 +8530,8 @@ class pipe(heat_exchanger_simple):
         Outlet to inlet pressure ratio, :math:`pr/1`.
 
     zeta : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     D : str/float/tespy.helpers.dc_cp
         Diameter of the pipes, :math:`D/\text{m}`.
@@ -8325,14 +8545,16 @@ class pipe(heat_exchanger_simple):
 
     hydro_group : Sring/tespy.helpers.dc_gcp
         Parametergroup for pressure drop calculation based on pipes dimensions.
-        Choose 'HW' for hazen-williams equation, else darcy friction factor is used.
+        Choose 'HW' for hazen-williams equation, else darcy friction factor is
+        used.
 
     kA : str/float/tespy.helpers.dc_cp
-        Area independent heat transition coefficient, :math:`kA/\frac{\text{W}}{\text{K}}`.
+        Area independent heat transition coefficient,
+        :math:`kA/\frac{\text{W}}{\text{K}}`.
 
     kA_char : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient, provide x and y values
-        or use generic values (e. g. calculated from design case).
+        Characteristic curve for heat transfer coefficient, provide x and y
+        values or use generic values (e. g. calculated from design case).
         Standard method 'HE_COLD', Parameter 'm'.
 
     Tamb : float/tespy.helpers.dc_cp
@@ -8344,8 +8566,8 @@ class pipe(heat_exchanger_simple):
          parameter in network's temperature unit.
 
     kA_group : tespy.helpers.dc_gcp
-        Parametergroup for heat transfer calculation from ambient temperature and area
-        independent heat transfer coefficient kA.
+        Parametergroup for heat transfer calculation from ambient temperature
+        and area independent heat transfer coefficient kA.
 
     Example
     -------
@@ -8404,8 +8626,8 @@ class solar_collector(heat_exchanger_simple):
 
         - :func:`tespy.components.components.component.zeta_func`
 
-        - :func:`tespy.components.components.heat_exchanger_simple.darcy_func` or
-          :func:`tespy.components.components.heat_exchanger_simple.hw_func`
+        - :func:`tespy.components.components.heat_exchanger_simple.darcy_func`
+          or :func:`tespy.components.components.heat_exchanger_simple.hw_func`
 
         **additional equations**
 
@@ -8428,9 +8650,6 @@ class solar_collector(heat_exchanger_simple):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -8444,7 +8663,8 @@ class solar_collector(heat_exchanger_simple):
         Outlet to inlet pressure ratio, :math:`pr/1`.
 
     zeta : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     D : str/float/tespy.helpers.dc_cp
         Diameter of the pipes, :math:`D/\text{m}`.
@@ -8458,16 +8678,20 @@ class solar_collector(heat_exchanger_simple):
 
     hydro_group : Sring/tespy.helpers.dc_gcp
         Parametergroup for pressure drop calculation based on pipes dimensions.
-        Choose 'HW' for hazen-williams equation, else darcy friction factor is used.
+        Choose 'HW' for hazen-williams equation, else darcy friction factor is
+        used.
 
-    E :
-        Absorption on the inclined surface, :math:`E/\frac{\text{W}}{\text{m}^2}`.
+    E : str/float/tespy.helpers.dc_cp
+        Absorption on the inclined surface,
+        :math:`E/\frac{\text{W}}{\text{m}^2}`.
 
     lkf_lin : str/float/tespy.helpers.dc_cp
-        Linear loss key figure, :math:`\alpha_1/\frac{\text{W}}{\text{K} \cdot \text{m}^2}`.
+        Linear loss key figure,
+        :math:`\alpha_1/\frac{\text{W}}{\text{K} \cdot \text{m}^2}`.
 
     lkf_quad : str/float/tespy.helpers.dc_cp
-        Quadratic loss key figure, :math:`\alpha_2/\frac{\text{W}}{\text{K}^2 \cdot \text{m}^2}`.
+        Quadratic loss key figure,
+        :math:`\alpha_2/\frac{\text{W}}{\text{K}^2 \cdot \text{m}^2}`.
 
     A : str/float/tespy.helpers.dc_cp
         Collector surface area :math:`A/\text{m}^2`.
@@ -8481,8 +8705,8 @@ class solar_collector(heat_exchanger_simple):
     Note
     ----
     The solar collector does not take optical losses into accout. The incoming
-    radiation E represents the actual absorption of the solar collector. Optical
-    losses should be handeled in preprocessing.
+    radiation E represents the actual absorption of the solar collector.
+    Optical losses should be handeled in preprocessing.
 
     Example
     -------
@@ -8545,7 +8769,8 @@ class solar_collector(heat_exchanger_simple):
         self.fl_deriv = self.fluid_deriv()
         self.m_deriv = self.mass_flow_deriv()
 
-        self.Tamb.val_SI = ((self.Tamb.val + nw.T[nw.T_unit][0]) * nw.T[nw.T_unit][1])
+        self.Tamb.val_SI = ((self.Tamb.val + nw.T[nw.T_unit][0]) *
+                            nw.T[nw.T_unit][1])
 
         # parameters for hydro group
         self.hydro_group.set_attr(elements=[self.L, self.ks, self.D])
@@ -8568,7 +8793,8 @@ class solar_collector(heat_exchanger_simple):
             self.hydro_group.set_attr(is_set=False)
 
         # parameters for kA group
-        self.energy_group.set_attr(elements=[self.E, self.lkf_lin, self.lkf_quad, self.A, self.Tamb])
+        self.energy_group.set_attr(elements=[self.E, self.lkf_lin,
+                                             self.lkf_quad, self.A, self.Tamb])
 
         is_set = True
         for e in self.energy_group.elements:
@@ -8580,8 +8806,8 @@ class solar_collector(heat_exchanger_simple):
         elif self.energy_group.is_set:
             msg = ('All parameters of the component group have to be '
                    'specified! This component group uses the following '
-                   'parameters: E, lkf_lin, lkf_quad, A, Tamb at ' + self.label
-                   + '. Group will be set to False.')
+                   'parameters: E, lkf_lin, lkf_quad, A, Tamb at ' +
+                   self.label + '. Group will be set to False.')
             logging.info(msg)
             self.energy_group.set_attr(is_set=False)
         else:
@@ -8589,7 +8815,8 @@ class solar_collector(heat_exchanger_simple):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for this
+        component.
 
         Equations
 
@@ -8613,7 +8840,8 @@ class solar_collector(heat_exchanger_simple):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -8627,13 +8855,16 @@ class solar_collector(heat_exchanger_simple):
         if self.energy_group.is_set:
             deriv = np.zeros((1, 2 + self.num_vars, self.num_fl + 3))
             deriv[0, 0, 0] = self.outl[0].h.val_SI - self.inl[0].h.val_SI
-            for i in range(2):
-                deriv[0, i, 1] = self.numeric_deriv(self.energy_func, 'p', i)
-                deriv[0, i, 2] = self.numeric_deriv(self.energy_func, 'h', i)
+            deriv[0, 0, 1] = self.numeric_deriv(self.energy_func, 'p', 0)
+            deriv[0, 0, 2] = self.numeric_deriv(self.energy_func, 'h', 0)
+            deriv[0, 1, 1] = self.numeric_deriv(self.energy_func, 'p', 1)
+            deriv[0, 1, 2] = self.numeric_deriv(self.energy_func, 'h', 1)
             # custom variables for the energy-group
             for var in self.energy_group.elements:
                 if var.is_var:
-                    deriv[0, 2 + var.var_pos, 0] = self.numeric_deriv(self.energy_func, self.vars[var], i)
+                    deriv[0, 2 + var.var_pos, 0] = (
+                            self.numeric_deriv(self.energy_func,
+                                               self.vars[var], 2))
             mat_deriv += deriv.tolist()
 
         return mat_deriv
@@ -8653,18 +8884,21 @@ class solar_collector(heat_exchanger_simple):
 
                 \begin{split}
                 0 = & \dot{m} \cdot \left( h_{out} - h_{in} \right)\\
-                & - A \cdot \left[E - \alpha_1 \cdot \left(T_m - T_{amb} \right)
-                - \alpha_2 \cdot \left(T_m - T_{amb}\right)^2 \right]
+                & - A \cdot \left[E - \alpha_1 \cdot
+                \left(T_m - T_{amb} \right) - \alpha_2 \cdot
+                \left(T_m - T_{amb}\right)^2 \right]
                 \end{split}
         """
 
         i = self.inl[0].to_flow()
         o = self.outl[0].to_flow()
 
-        T_m = (T_mix_ph(i) + T_mix_ph(o)) / 2
+        T_m = (T_mix_ph(i, T0=self.inl[0].T.val_SI) +
+               T_mix_ph(o, T0=self.outl[0].T.val_SI)) / 2
 
-        return (i[0] * (o[2] - i[2]) - self.A.val * (self.E.val - (T_m - self.Tamb.val_SI) *
-                self.lkf_lin.val - self.lkf_quad.val * (T_m - self.Tamb.val_SI) ** 2))
+        return (i[0] * (o[2] - i[2]) - self.A.val * (
+                self.E.val - (T_m - self.Tamb.val_SI) * self.lkf_lin.val -
+                self.lkf_quad.val * (T_m - self.Tamb.val_SI) ** 2))
 
     def calc_parameters(self):
         r"""
@@ -8737,9 +8971,6 @@ class heat_exchanger(component):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -8756,26 +8987,32 @@ class heat_exchanger(component):
         Outlet to inlet pressure ratio at cold side, :math:`pr/1`.
 
     zeta1 : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient at hot side, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient at hot side,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     zeta2 : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient at cold side, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient at cold side,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     kA : str/float/tespy.helpers.dc_cp
-        Area independent heat transition coefficient, :math:`kA/\frac{\text{W}}{\text{K}}`.
+        Area independent heat transition coefficient,
+        :math:`kA/\frac{\text{W}}{\text{K}}`.
 
     kA_char1 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at hot side, provide x and y values
-        or use generic values (e. g. calculated from design case). Standard method 'HE_HOT', Parameter 'm'.
+        Characteristic curve for heat transfer coefficient at hot side, provide
+        x and y values or use generic values (e. g. calculated from design
+        case). Standard method 'HE_HOT', Parameter 'm'.
 
     kA_char2 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at cold side, provide x and y values
-        or use generic values (e. g. calculated from design case). Standard method 'HE_COLD', Parameter 'm'.
+        Characteristic curve for heat transfer coefficient at cold side,
+        provide x and y values or use generic values (e. g. calculated from
+        design case). Standard method 'HE_COLD', Parameter 'm'.
 
     Note
     ---
-    The heat exchanger and subclasses (desuperheater, condenser) are countercurrent heat exchangers.
-    Equations (kA, ttd_u, ttd_l) do not work for directcurrent and crosscurrent or combinations of different types.
+    The heat exchanger and subclasses (desuperheater, condenser) are
+    countercurrent heat exchangers. Equations (kA, ttd_u, ttd_l) do not work
+    for directcurrent and crosscurrent or combinations of different types.
 
     Example
     -------
@@ -8871,7 +9108,9 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified heat transfer
         if self.Q.is_set:
-            vec_res += [self.inl[0].m.val_SI * (self.outl[0].h.val_SI - self.inl[0].h.val_SI) - self.Q.val]
+            vec_res += [self.inl[0].m.val_SI *
+                        (self.outl[0].h.val_SI - self.inl[0].h.val_SI) -
+                        self.Q.val]
 
         ######################################################################
         # equations for specified heat transfer coefficient
@@ -8891,12 +9130,14 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified pressure ratio at hot side
         if self.pr1.is_set:
-            vec_res += [self.pr1.val * self.inl[0].p.val_SI - self.outl[0].p.val_SI]
+            vec_res += [self.pr1.val * self.inl[0].p.val_SI -
+                        self.outl[0].p.val_SI]
 
         ######################################################################
         # equations for specified pressure ratio at cold side
         if self.pr2.is_set:
-            vec_res += [self.pr2.val * self.inl[1].p.val_SI - self.outl[1].p.val_SI]
+            vec_res += [self.pr2.val * self.inl[1].p.val_SI -
+                        self.outl[1].p.val_SI]
 
         ######################################################################
         # equations for specified zeta at hot side
@@ -8916,7 +9157,8 @@ class heat_exchanger(component):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for
+        this component.
 
         Returns
         -------
@@ -9023,7 +9265,8 @@ class heat_exchanger(component):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -9034,7 +9277,8 @@ class heat_exchanger(component):
 
     def fluid_func(self):
         r"""
-        Calculates the vector of residual values for component's fluid balance equations.
+        Calculates the vector of residual values for component's fluid balance
+        equations.
 
         Returns
         -------
@@ -9055,7 +9299,8 @@ class heat_exchanger(component):
 
     def mass_flow_func(self):
         r"""
-        Calculates the residual value for component's mass flow balance equation.
+        Calculates the residual value for component's mass flow balance
+        equation.
 
         Returns
         -------
@@ -9103,7 +9348,8 @@ class heat_exchanger(component):
         Returns
         -------
         deriv : list
-            Matrix with partial derivatives for the mass flow balance equations.
+            Matrix with partial derivatives for the mass flow balance
+            equations.
         """
         deriv = np.zeros((2, 4 + self.num_vars, self.num_fl + 3))
         for i in range(self.num_i):
@@ -9149,7 +9395,8 @@ class heat_exchanger(component):
 
     def energy_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives for energy balance equation.
+        Calculates the matrix of partial derivatives for energy balance
+        equation.
 
         Returns
         -------
@@ -9186,7 +9433,8 @@ class heat_exchanger(component):
 
     def kA_func(self):
         r"""
-        Equation for heat transfer from conditions on both sides of heat exchanger.
+        Equation for heat transfer from conditions on both sides of heat
+        exchanger.
 
         Returns
         -------
@@ -9209,16 +9457,19 @@ class heat_exchanger(component):
         class :func:`tespy.components.characteristics.characteristics`.
 
         - Calculate temperatures at inlets and outlets.
-        - Perform value manipulation, if temperature levels are not physically feasible.
+        - Perform value manipulation, if temperature levels are not physically
+          feasible.
         """
 
         if self.zero_flag.val_set:
             c = self.zero_flag.val
             if c[1] == 2 or c[1] == 4 or c[1] == 5:
-                T_i1 = T_mix_ph(self.inl[0].to_flow())
-                T_i2 = T_mix_ph(self.inl[1].to_flow())
-                T_o1 = T_mix_ph(self.outl[0].to_flow())
-                T_o2 = T_mix_ph(self.outl[1].to_flow())
+                T_i1 = T_mix_ph(self.inl[0].to_flow(), T0=self.inl[0].T.val_SI)
+                T_i2 = T_mix_ph(self.inl[1].to_flow(), T0=self.inl[1].T.val_SI)
+                T_o1 = T_mix_ph(self.outl[0].to_flow(),
+                                T0=self.outl[0].T.val_SI)
+                T_o2 = T_mix_ph(self.outl[1].to_flow(),
+                                T0=self.outl[1].T.val_SI)
                 return T_o1 - T_i2 - T_i1 + T_o2
 
             elif c[0] < 3 and (c[1] == 1 or c[1] == 3):
@@ -9239,10 +9490,10 @@ class heat_exchanger(component):
         i1_d = self.inl[0].to_flow_design()
         i2_d = self.inl[1].to_flow_design()
 
-        T_i1 = T_mix_ph(i1)
-        T_i2 = T_mix_ph(i2)
-        T_o1 = T_mix_ph(o1)
-        T_o2 = T_mix_ph(o2)
+        T_i1 = T_mix_ph(i1, T0=self.inl[0].T.val_SI)
+        T_i2 = T_mix_ph(i2, T0=self.inl[1].T.val_SI)
+        T_o1 = T_mix_ph(o1, T0=self.outl[0].T.val_SI)
+        T_o2 = T_mix_ph(o2, T0=self.outl[1].T.val_SI)
 
         if T_i1 <= T_o2 and not self.inl[0].T.val_set:
             T_i1 = T_o2 + 0.01
@@ -9250,7 +9501,8 @@ class heat_exchanger(component):
             T_o2 = T_i1 - 0.01
         if T_i1 < T_o2 and self.inl[0].T.val_set and self.outl[1].T.val_set:
             msg = ('Infeasibility at ' + str(self.label) + ': Value for upper '
-                   'temperature difference is ' + str(round(T_i1 - T_o2)) + '.')
+                   'temperature difference is ' + str(round(T_i1 - T_o2)) +
+                   '.')
             logging.error(msg)
             raise ValueError(msg)
 
@@ -9260,7 +9512,8 @@ class heat_exchanger(component):
             T_i2 = T_o1 - 0.02
         if T_o1 < T_i2 and self.inl[1].T.val_set and self.outl[0].T.val_set:
             msg = ('Infeasibility at ' + str(self.label) + ': Value for lower '
-                   'temperature difference is ' + str(round(T_o1 - T_i2)) + '.')
+                   'temperature difference is ' + str(round(T_o1 - T_i2)) +
+                   '.')
             logging.error(msg)
             raise ValueError(msg)
 
@@ -9276,7 +9529,8 @@ class heat_exchanger(component):
                 if not i2[0] == 0:
                     fkA2 = self.kA_char2.func.f_x(i2[0] / i2_d[0])
 
-        td_log = (T_o1 - T_i2 - T_i1 + T_o2) / math.log((T_o1 - T_i2) / (T_i1 - T_o2))
+        td_log = ((T_o1 - T_i2 - T_i1 + T_o2) /
+                  math.log((T_o1 - T_i2) / (T_i1 - T_o2)))
         return i1[0] * (o1[2] - i1[2]) + self.kA.val * fkA1 * fkA2 * td_log
 
     def ttd_u_func(self):
@@ -9292,13 +9546,14 @@ class heat_exchanger(component):
 
                 res = ttd_{u} - T_{1,in} + T_{2,out}
         """
-        i1 = self.inl[0].to_flow()
-        o2 = self.outl[1].to_flow()
-        return self.ttd_u.val - T_mix_ph(i1) + T_mix_ph(o2)
+        T_i1 = T_mix_ph(self.inl[0].to_flow(), T0=self.inl[0].T.val_SI)
+        T_o2 = T_mix_ph(self.outl[1].to_flow(), T0=self.outl[1].T.val_SI)
+        return self.ttd_u.val - T_i1 + T_o2
 
     def ttd_u_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives for upper temperature difference equation.
+        Calculates the matrix of partial derivatives for upper temperature
+        difference equation.
 
         Returns
         -------
@@ -9307,8 +9562,10 @@ class heat_exchanger(component):
         """
         deriv = np.zeros((1, 4, len(self.inl[0].fluid.val) + 3))
         for i in range(2):
-            deriv[0, i * 3, 1] = self.numeric_deriv(self.ttd_u_func, 'p', i * 3)
-            deriv[0, i * 3, 2] = self.numeric_deriv(self.ttd_u_func, 'h', i * 3)
+            deriv[0, i * 3, 1] = self.numeric_deriv(self.ttd_u_func,
+                                                    'p', i * 3)
+            deriv[0, i * 3, 2] = self.numeric_deriv(self.ttd_u_func,
+                                                    'h', i * 3)
         return deriv.tolist()
 
     def ttd_l_func(self):
@@ -9326,11 +9583,13 @@ class heat_exchanger(component):
         """
         i2 = self.inl[1].to_flow()
         o1 = self.outl[0].to_flow()
-        return self.ttd_l.val - T_mix_ph(o1) + T_mix_ph(i2)
+        return (self.ttd_l.val - T_mix_ph(o1, T0=self.outl[0].T.val_SI) +
+                T_mix_ph(i2, T0=self.inl[1].T.val_SI))
 
     def ttd_l_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives for lower temperature difference equation.
+        Calculates the matrix of partial derivatives for lower temperature
+        difference equation.
 
         Returns
         -------
@@ -9339,8 +9598,10 @@ class heat_exchanger(component):
         """
         deriv = np.zeros((1, 4, len(self.inl[0].fluid.val) + 3))
         for i in range(2):
-            deriv[0, i + 1, 1] = self.numeric_deriv(self.ttd_l_func, 'p', i + 1)
-            deriv[0, i + 1, 2] = self.numeric_deriv(self.ttd_l_func, 'h', i + 1)
+            deriv[0, i + 1, 1] = self.numeric_deriv(self.ttd_l_func,
+                                                    'p', i + 1)
+            deriv[0, i + 1, 2] = self.numeric_deriv(self.ttd_l_func,
+                                                    'h', i + 1)
         return deriv.tolist()
 
     def bus_func(self, bus):
@@ -9404,8 +9665,9 @@ class heat_exchanger(component):
 
         Note
         ----
-        Manipulate enthalpies/pressure at inlet and outlet if not specified by user to match physically feasible constraints,
-        keep fluid composition within feasible range and then propagates it towards the outlet.
+        Manipulate enthalpies/pressure at inlet and outlet if not specified by
+        user to match physically feasible constraints, keep fluid composition
+        within feasible range and then propagates it towards the outlet.
         """
         i, o = self.inl, self.outl
 
@@ -9449,7 +9711,8 @@ class heat_exchanger(component):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -9485,7 +9748,8 @@ class heat_exchanger(component):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -9530,14 +9794,25 @@ class heat_exchanger(component):
         o2 = self.outl[1].to_flow()
 
         # temperatures
-        T_i2 = T_mix_ph(i2)
-        T_o1 = T_mix_ph(o1)
-        T_o2 = T_mix_ph(o2)
-
         if isinstance(self, condenser):
-            T_i1 = T_mix_ph([i1[0], i1[1], h_mix_pQ(i1, 1), i1[3]])
+            T_i1 = T_bp_p(i1)
         else:
-            T_i1 = T_mix_ph(i1)
+            T_i1 = T_mix_ph(i1, T0=self.inl[0].T.val_SI)
+        T_i2 = T_mix_ph(i2, T0=self.inl[1].T.val_SI)
+        T_o1 = T_mix_ph(o1, T0=self.outl[0].T.val_SI)
+        T_o2 = T_mix_ph(o2, T0=self.outl[1].T.val_SI)
+
+        # specific volume
+        v_i1 = v_mix_ph(i1, T0=T_i1)
+        v_i2 = v_mix_ph(i2, T0=T_i2)
+        v_o1 = v_mix_ph(o1, T0=T_o1)
+        v_o2 = v_mix_ph(o2, T0=T_o2)
+
+        # specific entropy
+        s_i1 = s_mix_ph(i1, T0=T_i1)
+        s_i2 = s_mix_ph(i2, T0=T_i2)
+        s_o1 = s_mix_ph(o1, T0=T_o1)
+        s_o2 = s_mix_ph(o2, T0=T_o2)
 
         # component parameters
         self.ttd_u.val = T_i1 - T_o2
@@ -9547,12 +9822,12 @@ class heat_exchanger(component):
         self.pr1.val = o1[1] / i1[1]
         self.pr2.val = o2[1] / i2[1]
         self.zeta1.val = ((i1[1] - o1[1]) * math.pi ** 2 /
-                          (8 * i1[0] ** 2 * (v_mix_ph(i1) + v_mix_ph(o1)) / 2))
+                          (8 * i1[0] ** 2 * (v_i1 + v_o1) / 2))
         self.zeta2.val = ((i2[1] - o2[1]) * math.pi ** 2 /
-                          (8 * i2[0] ** 2 * (v_mix_ph(i2) + v_mix_ph(o2)) / 2))
+                          (8 * i2[0] ** 2 * (v_i2 + v_o2) / 2))
 
-        self.SQ1.val = self.inl[0].m.val_SI * (s_mix_ph(o1) - s_mix_ph(i1))
-        self.SQ2.val = self.inl[1].m.val_SI * (s_mix_ph(o2) - s_mix_ph(i2))
+        self.SQ1.val = self.inl[0].m.val_SI * (s_o1 - s_i1)
+        self.SQ2.val = self.inl[1].m.val_SI * (s_o2 - s_i2)
         self.Sirr.val = self.SQ1.val + self.SQ2.val
 
         # kA and logarithmic temperature difference
@@ -9644,9 +9919,6 @@ class condenser(heat_exchanger):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -9663,21 +9935,26 @@ class condenser(heat_exchanger):
         Outlet to inlet pressure ratio at cold side, :math:`pr/1`.
 
     zeta1 : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient at hot side, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient at hot side,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     zeta2 : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient at cold side, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient at cold side,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     kA : str/float/tespy.helpers.dc_cp
-        Area independent heat transition coefficient, :math:`kA/\frac{\text{W}}{\text{K}}`.
+        Area independent heat transition coefficient,
+        :math:`kA/\frac{\text{W}}{\text{K}}`.
 
     kA_char1 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at hot side, provide x and y values
-        or use generic values (e. g. calculated from design case). Standard method 'COND_HOT', Parameter 'm'.
+        Characteristic curve for heat transfer coefficient at hot side, provide
+        x and y values or use generic values (e. g. calculated from design
+        case). Standard method 'COND_HOT', Parameter 'm'.
 
     kA_char2 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at cold side, provide x and y values
-        or use generic values (e. g. calculated from design case). Standard method 'COND_COLD', Parameter 'm'.
+        Characteristic curve for heat transfer coefficient at cold side,
+        provide x and y values or use generic values (e. g. calculated from
+        design case). Standard method 'COND_COLD', Parameter 'm'.
 
     subcooling : bool
         Enable/disable subcooling, default value: disabled.
@@ -9748,7 +10025,8 @@ class condenser(heat_exchanger):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for this
+        component.
 
         Equations
 
@@ -9818,7 +10096,8 @@ class condenser(heat_exchanger):
 
     def energy_deriv(self):
         r"""
-        Calculates the matrix of partial derivatives for energy balance equation.
+        Calculates the matrix of partial derivatives for energy balance
+        equation.
 
         Returns
         -------
@@ -9861,7 +10140,8 @@ class condenser(heat_exchanger):
         class :func:`tespy.components.characteristics.characteristics`.
 
         - Calculate temperatures at inlets and outlets.
-        - Perform value manipulation, if temperature levels are not physically feasible.
+        - Perform value manipulation, if temperature levels are physically
+          infeasible.
         """
         if self.zero_flag.val_set:
             return self.inl[0].p.val_SI - self.inl[0].p.design
@@ -9874,10 +10154,10 @@ class condenser(heat_exchanger):
         i1_d = self.inl[0].to_flow_design()
         i2_d = self.inl[1].to_flow_design()
 
-        T_i1 = T_mix_ph([i1[0], i1[1], h_mix_pQ(i1, 1), i1[3]])
-        T_i2 = T_mix_ph(i2)
-        T_o1 = T_mix_ph(o1)
-        T_o2 = T_mix_ph(o2)
+        T_i1 = T_bp_p(i1)
+        T_i2 = T_mix_ph(i2, T0=self.inl[1].T.val_SI)
+        T_o1 = T_mix_ph(o1, T0=self.outl[0].T.val_SI)
+        T_o2 = T_mix_ph(o2, T0=self.outl[1].T.val_SI)
 
         if T_i1 <= T_o2 and not self.inl[0].T.val_set:
             T_i1 = T_o2 + 0.5
@@ -9899,7 +10179,8 @@ class condenser(heat_exchanger):
             if not np.isnan(i2_d[0]):
                 fkA2 = self.kA_char2.func.f_x(i2[0] / i2_d[0])
 
-        td_log = (T_o1 - T_i2 - T_i1 + T_o2) / math.log((T_o1 - T_i2) / (T_i1 - T_o2))
+        td_log = ((T_o1 - T_i2 - T_i1 + T_o2) /
+                  math.log((T_o1 - T_i2) / (T_i1 - T_o2)))
         return i1[0] * (o1[2] - i1[2]) + self.kA.val * fkA1 * fkA2 * td_log
 
     def ttd_u_func(self):
@@ -9917,11 +10198,13 @@ class condenser(heat_exchanger):
 
         Note
         ----
-        The upper terminal temperature difference ttd_u refers to boiling temperature at hot side inlet.
+        The upper terminal temperature difference ttd_u refers to boiling
+        temperature at hot side inlet.
         """
         i1 = self.inl[0].to_flow()
         o2 = self.outl[1].to_flow()
-        return (self.ttd_u.val - T_mix_ph([i1[0], i1[1], h_mix_pQ(i1, 1), i1[3]]) + T_mix_ph(o2))
+        T_o2 = T_mix_ph(o2, T0=self.outl[1].T.val_SI)
+        return self.ttd_u.val - T_bp_p(i1) + T_o2
 
 # %%
 
@@ -9974,9 +10257,6 @@ class desuperheater(heat_exchanger):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -9993,26 +10273,31 @@ class desuperheater(heat_exchanger):
         Outlet to inlet pressure ratio at cold side, :math:`pr/1`.
 
     zeta1 : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient at hot side, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient at hot side,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     zeta2 : str/float/tespy.helpers.dc_cp
-        Geometry independent friction coefficient at cold side, :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
+        Geometry independent friction coefficient at cold side,
+        :math:`\zeta/\frac{\text{Pa}}{\text{m}^4}`.
 
     kA : str/float/tespy.helpers.dc_cp
-        Area independent heat transition coefficient, :math:`kA/\frac{\text{W}}{\text{K}}`.
+        Area independent heat transition coefficient,
+        :math:`kA/\frac{\text{W}}{\text{K}}`.
 
     kA_char1 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at hot side, provide x and y values
-        or use generic values (e. g. calculated from design case). Standard method 'COND_HOT', Parameter 'm'.
+        Characteristic curve for heat transfer coefficient at hot side, provide
+        x and y values or use generic values (e. g. calculated from design
+        case). Standard method 'COND_HOT', Parameter 'm'.
 
     kA_char2 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at cold side, provide x and y values
-        or use generic values (e. g. calculated from design case). Standard method 'COND_COLD', Parameter 'm'.
+        Characteristic curve for heat transfer coefficient at cold side,
+        provide x and y values or use generic values (e. g. calculated from
+        design case). Standard method 'COND_COLD', Parameter 'm'.
 
     Note
     ----
-
-    - The desuperheater has an additional equation for enthalpy at hot side outlet.
+    The desuperheater has an additional equation for enthalpy at hot side
+    outlet.
 
     Example
     -------
@@ -10063,7 +10348,8 @@ class desuperheater(heat_exchanger):
 
     def additional_equations(self):
         r"""
-        Calculates vector vec_res with results of additional equations for this component.
+        Calculates vector vec_res with results of additional equations for this
+        component.
 
         Equations
 
@@ -10090,7 +10376,8 @@ class desuperheater(heat_exchanger):
 
     def additional_derivatives(self):
         r"""
-        Calculates matrix of partial derivatives for given additional equations.
+        Calculates matrix of partial derivatives for given additional
+        equations.
 
         Returns
         -------
@@ -10108,7 +10395,6 @@ class desuperheater(heat_exchanger):
         mat_deriv += deriv.tolist()
 
         return mat_deriv
-
 
 # %%
 
@@ -10153,9 +10439,6 @@ class drum(component):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -10168,8 +10451,9 @@ class drum(component):
     the fluid propagation causes trouble. If this is the case, try to
     specify the fluid composition at another connection of your network.
 
-    This component assumes, that the fluid composition between outlet 1 and inlet 2 does not change,
-    thus there is no equation for the fluid mass fraction at the inlet 2!
+    This component assumes, that the fluid composition between outlet 1 and
+    inlet 2 does not change, thus there is no equation for the fluid mass
+    fraction at the inlet 2!
 
     Example
     -------
@@ -10279,8 +10563,10 @@ class drum(component):
 
         ######################################################################
         # eqations for staturated fluid state at outlets
-        vec_res += [h_mix_pQ(self.outl[0].to_flow(), 0) - self.outl[0].h.val_SI]
-        vec_res += [h_mix_pQ(self.outl[1].to_flow(), 1) - self.outl[1].h.val_SI]
+        vec_res += [h_mix_pQ(self.outl[0].to_flow(), 0) -
+                    self.outl[0].h.val_SI]
+        vec_res += [h_mix_pQ(self.outl[1].to_flow(), 1) -
+                    self.outl[1].h.val_SI]
 
         return vec_res
 
@@ -10323,7 +10609,6 @@ class drum(component):
             j += 1
         mat_deriv += deriv.tolist()
 
-
         ######################################################################
         # derivatives of equations for saturated states at outlets
         x_deriv = np.zeros((2, 4, self.num_fl + 3))
@@ -10337,7 +10622,8 @@ class drum(component):
 
     def fluid_func(self):
         r"""
-        Calculates the vector of residual values for component's fluid balance equations.
+        Calculates the vector of residual values for component's fluid balance
+        equations.
 
         Returns
         -------
@@ -10390,7 +10676,8 @@ class drum(component):
 
     def initialise_source(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's outlet.
+        Returns a starting value for pressure and enthalpy at component's
+        outlet.
 
         Parameters
         ----------
@@ -10423,7 +10710,8 @@ class drum(component):
 
     def initialise_target(self, c, key):
         r"""
-        Returns a starting value for pressure and enthalpy at component's inlet.
+        Returns a starting value for pressure and enthalpy at component's
+        inlet.
 
         Parameters
         ----------
@@ -10477,7 +10765,8 @@ class subsys_interface(component):
 
     Inlets/Outlets
 
-        - Specify number of inlets and outlets with :code:`num_inter`, predefined value: 1.
+        - Specify number of inlets and outlets with :code:`num_inter`,
+          predefined value: 1.
 
     Image
 
@@ -10491,9 +10780,6 @@ class subsys_interface(component):
     label : str
         The label of the component.
 
-    mode : str
-        'auto' for automatic design to offdesign switch, 'man' for manual switch.
-
     design : list
         List containing design parameters (stated as String).
 
@@ -10505,7 +10791,8 @@ class subsys_interface(component):
 
     Note
     ----
-    This component passes all fluid properties and mass flow from its inlet to the outlet.
+    This component passes all fluid properties and mass flow from its inlet to
+    the outlet.
 
     Example
     -------
@@ -10631,7 +10918,8 @@ class subsys_interface(component):
 
     def inout_deriv(self, pos):
         r"""
-        Calculates the partial derivatives for all mass flow, pressure and enthalpy equations.
+        Calculates the partial derivatives for all mass flow, pressure and
+        enthalpy equations.
 
         Parameters
         ----------

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -233,10 +233,13 @@ class component:
                     raise ValueError(msg)
 
             elif key == 'design_path':
-                if isinstance(kwargs[key], str) or kwargs[key] is None:
+                if isinstance(kwargs[key], str):
                     self.__dict__.update({key: kwargs[key]})
+                elif np.isnan(kwargs[key]):
+                    self.design_path = None
                 else:
-                    msg = 'Please provide the ' + key + ' parameter as string!'
+                    msg = ('Please provide the ' + key + ' parameter as '
+                           'string or as nan.')
                     logging.error(msg)
                     raise TypeError(msg)
 

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -9836,13 +9836,13 @@ class heat_exchanger(component):
                                math.log((T_o1 - T_i2) / (T_i1 - T_o2)))
             self.kA.val = -(i1[0] * (o1[2] - i1[2]) / self.td_log.val)
 
-        if self.ttd_u.val < 0:
+        if self.ttd_u.val <= 0:
             msg = ('Invalid value for terminal temperature difference (upper) '
                    'at component ' + self.label + ': ttd_u = ' +
                    str(self.ttd_u.val) + ' K.')
             logging.error(msg)
 
-        if self.ttd_l.val < 0:
+        if self.ttd_l.val <= 0:
             msg = ('Invalid value for terminal temperature difference (lower) '
                    'at component ' + self.label + ': ttd_l = ' +
                    str(self.ttd_l.val) + ' K.')

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -46,6 +46,9 @@ class component:
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
     **kwargs :
         See the class documentation of desired component for available keywords.
 
@@ -86,6 +89,7 @@ class component:
             self.label = label
 
         self.mode = 'auto'
+        self.design_path = None
 
         # set default design and offdesign parameters
         self.design = []
@@ -114,6 +118,9 @@ class component:
 
         offdesign : list
             List containing offdesign parameters (stated as String).
+
+        design_path: str
+            Path to the components design case.
 
         **kwargs :
             See the class documentation of desired component for available keywords.
@@ -225,6 +232,14 @@ class component:
                     msg = ('Mode must be \'man\' or \'auto\' at ' + self.label + '.')
                     logging.error(msg)
                     raise ValueError(msg)
+
+            elif key == 'design_path':
+                if isinstance(kwargs[key], str) or kwargs[key] is None:
+                    self.__dict__.update({key: kwargs[key]})
+                else:
+                    msg = 'Please provide the ' + key + ' parameter as string!'
+                    logging.error(msg)
+                    raise TypeError(msg)
 
             # invalid keyword
             else:
@@ -416,7 +431,6 @@ class component:
                 if isinstance(dc, dc_cp) and key in self.offdesign:
                     switched = True
                     self.get_attr(key).val = self.get_attr(key).design
-
                     msg += key + ', '
 
             msg = msg[:-2] + ' to design value at component ' + self.label + '.'

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -336,12 +336,6 @@ class component:
     def derivatives(self):
         return []
 
-    def bus_func(self, bus):
-        return 0
-
-    def bus_deriv(self, bus):
-        return
-
     def initialise_source(self, c, key):
         r"""
         Returns a starting value for pressure and enthalpy at component's
@@ -9375,26 +9369,26 @@ class heat_exchanger(component):
                 0 = \dot{m}_{1,in} \cdot \left(h_{1,out} - h_{1,in} \right) +
                 \dot{m}_{2,in} \cdot \left(h_{2,out} - h_{2,in} \right)
         """
-        if self.zero_flag.val_set:
-            c = self.zero_flag.val
-            if c[0] > 0 and c[1] < 3:
-                return self.inl[0].m.val_SI
-
-            elif ((c[0] == 0 and c[1] < 3) or
-                  (c[0] > 1 and c[1] > 2 and c[1] < 5)):
-                return self.outl[0].h.val_SI - self.inl[0].h.val_SI
-
-            elif ((c[0] < 2 and c[1] > 2 and c[1] < 5) or
-                  (c[0] == 3 and c[1] == 5)):
-                return self.inl[1].m.val_SI
-            else:
-                return self.outl[1].h.val_SI - self.inl[1].h.val_SI
-
-        else:
-            return (self.inl[0].m.val_SI * (self.outl[0].h.val_SI -
-                                            self.inl[0].h.val_SI) +
-                    self.inl[1].m.val_SI * (self.outl[1].h.val_SI -
-                                            self.inl[1].h.val_SI))
+#        if self.zero_flag.val_set:
+#            c = self.zero_flag.val
+#            if c[0] > 0 and c[1] < 3:
+#                return self.inl[0].m.val_SI
+#
+#            elif ((c[0] == 0 and c[1] < 3) or
+#                  (c[0] > 1 and c[1] > 2 and c[1] < 5)):
+#                return self.outl[0].h.val_SI - self.inl[0].h.val_SI
+#
+#            elif ((c[0] < 2 and c[1] > 2 and c[1] < 5) or
+#                  (c[0] == 3 and c[1] == 5)):
+#                return self.inl[1].m.val_SI
+#            else:
+#                return self.outl[1].h.val_SI - self.inl[1].h.val_SI
+#
+#        else:
+        return (self.inl[0].m.val_SI * (self.outl[0].h.val_SI -
+                                        self.inl[0].h.val_SI) +
+                self.inl[1].m.val_SI * (self.outl[1].h.val_SI -
+                                        self.inl[1].h.val_SI))
 
     def energy_deriv(self):
         r"""
@@ -9408,30 +9402,30 @@ class heat_exchanger(component):
         """
         deriv = np.zeros((1, 4, len(self.inl[0].fluid.val) + 3))
 
-        if self.zero_flag.val_set:
-            c = self.zero_flag.val
-            if c[0] > 0 and c[1] < 3:
-                deriv[0, 0, 0] = 1
+#        if self.zero_flag.val_set:
+#            c = self.zero_flag.val
+#            if c[0] > 0 and c[1] < 3:
+#                deriv[0, 0, 0] = 1
+#
+#            elif ((c[0] == 0 and c[1] < 3) or
+#                  (c[0] > 1 and c[1] > 2 and c[1] < 5)):
+#                deriv[0, 0, 2] = -1
+#                deriv[0, 2, 2] = 1
+#
+#            elif ((c[0] < 2 and c[1] > 2 and c[1] < 5) or
+#                  (c[0] == 3 and c[1] == 5)):
+#                deriv[0, 1, 0] = 1
+#            else:
+#                deriv[0, 1, 2] = -1
+#                deriv[0, 3, 2] = 1
+#
+#        else:
+        for k in range(2):
+            deriv[0, k, 0] = self.outl[k].h.val_SI - self.inl[k].h.val_SI
+            deriv[0, k, 2] = -self.inl[k].m.val_SI
 
-            elif ((c[0] == 0 and c[1] < 3) or
-                  (c[0] > 1 and c[1] > 2 and c[1] < 5)):
-                deriv[0, 0, 2] = -1
-                deriv[0, 2, 2] = 1
-
-            elif ((c[0] < 2 and c[1] > 2 and c[1] < 5) or
-                  (c[0] == 3 and c[1] == 5)):
-                deriv[0, 1, 0] = 1
-            else:
-                deriv[0, 1, 2] = -1
-                deriv[0, 3, 2] = 1
-
-        else:
-            for k in range(2):
-                deriv[0, k, 0] = self.outl[k].h.val_SI - self.inl[k].h.val_SI
-                deriv[0, k, 2] = -self.inl[k].m.val_SI
-
-            deriv[0, 2, 2] = self.inl[0].m.val_SI
-            deriv[0, 3, 2] = self.inl[1].m.val_SI
+        deriv[0, 2, 2] = self.inl[0].m.val_SI
+        deriv[0, 3, 2] = self.inl[1].m.val_SI
         return deriv.tolist()
 
     def kA_func(self):
@@ -9464,26 +9458,26 @@ class heat_exchanger(component):
           feasible.
         """
 
-        if self.zero_flag.val_set:
-            c = self.zero_flag.val
-            if c[1] == 2 or c[1] == 4 or c[1] == 5:
-                T_i1 = T_mix_ph(self.inl[0].to_flow(), T0=self.inl[0].T.val_SI)
-                T_i2 = T_mix_ph(self.inl[1].to_flow(), T0=self.inl[1].T.val_SI)
-                T_o1 = T_mix_ph(self.outl[0].to_flow(),
-                                T0=self.outl[0].T.val_SI)
-                T_o2 = T_mix_ph(self.outl[1].to_flow(),
-                                T0=self.outl[1].T.val_SI)
-                return T_o1 - T_i2 - T_i1 + T_o2
-
-            elif c[0] < 3 and (c[1] == 1 or c[1] == 3):
-                return self.outl[1].h.val_SI - self.inl[1].h.val_SI
-
-            elif ((c[0] < 2 and c[1] == 0) or
-                  (c[0] == 3 and (c[1] == 1 or c[1] == 3))):
-                return self.inl[1].m.val_SI
-
-            else:
-                return self.outl[0].h.val_SI - self.inl[0].h.val_SI
+#        if self.zero_flag.val_set:
+#            c = self.zero_flag.val
+#            if c[1] == 2 or c[1] == 4 or c[1] == 5:
+#                T_i1 = T_mix_ph(self.inl[0].to_flow(), T0=self.inl[0].T.val_SI)
+#                T_i2 = T_mix_ph(self.inl[1].to_flow(), T0=self.inl[1].T.val_SI)
+#                T_o1 = T_mix_ph(self.outl[0].to_flow(),
+#                                T0=self.outl[0].T.val_SI)
+#                T_o2 = T_mix_ph(self.outl[1].to_flow(),
+#                                T0=self.outl[1].T.val_SI)
+#                return T_o1 - T_i2 - T_i1 + T_o2
+#
+#            elif c[0] < 3 and (c[1] == 1 or c[1] == 3):
+#                return self.outl[1].h.val_SI - self.inl[1].h.val_SI
+#
+#            elif ((c[0] < 2 and c[1] == 0) or
+#                  (c[0] == 3 and (c[1] == 1 or c[1] == 3))):
+#                return self.inl[1].m.val_SI
+#
+#            else:
+#                return self.outl[0].h.val_SI - self.inl[0].h.val_SI
 
         i1 = self.inl[0].to_flow()
         i2 = self.inl[1].to_flow()

--- a/tespy/components/subsystems.py
+++ b/tespy/components/subsystems.py
@@ -25,19 +25,24 @@ class subsystem:
         The label of the subsystem.
 
     **kwargs :
-        See the class documentation of desired subsystem for available keywords.
-        If you want to define your own subsystem, provide the keywords in the :func:`tespy.components.subsystems.subystem.attr` method.
+        See the class documentation of desired subsystem for available
+        keywords. If you want to define your own subsystem, provide the
+        keywords in the :func:`tespy.components.subsystems.subystem.attr`
+        method.
 
     Note
     ----
-    The initialisation method (__init__), setter method (set_attr) and getter method (get_attr)
-    are used for instances of class subsystem and its children.
+    The initialisation method (__init__), setter method (set_attr) and getter
+    method (get_attr) are used for instances of class subsystem and its
+    children.
 
-    Keywords for keyword arguments depend on the type of subsystem you want to create/use.
+    Keywords for keyword arguments depend on the type of subsystem you want to
+    create/use.
 
     Example
     -------
-    Basic example for a setting up a tespy.components.subsystems.subsystem object.
+    Basic example for a setting up a tespy.components.subsystems.subsystem
+    object.
     This example does not run a tespy calculation!
 
     >>> from tespy import subsys
@@ -73,7 +78,8 @@ class subsystem:
 
     def set_attr(self, **kwargs):
         r"""
-        Sets, resets or unsets attributes of a component for provided keyword arguments.
+        Sets, resets or unsets attributes of a component for provided keyword
+        arguments.
 
         Parameters
         ----------
@@ -81,13 +87,16 @@ class subsystem:
             The label of the subsystem.
 
         **kwargs :
-            See the class documentation of desired subsystem for available keywords.
-            If you want to define your own subsystem, provide the keywords in the :func:`tespy.components.subsystems.subystem.attr` method.
+            See the class documentation of desired subsystem for available
+            keywords. If you want to define your own subsystem, provide the
+            keywords in the :func:`tespy.components.subsystems.subystem.attr`
+            method.
 
         Note
         ----
         Allowed keywords in kwargs are obtained from class documentation as all
-        subsystems share the :func:`tespy.components.subsystems.subsystem.set_attr` method.
+        subsystems share the
+        :func:`tespy.components.subsystems.subsystem.set_attr` method.
         """
         # set provided values,  check for invalid keys
         for key in kwargs:
@@ -105,7 +114,8 @@ class subsystem:
                 elif isinstance(kwargs[key], str):
                     self.__dict__.update({key: kwargs[key]})
             else:
-                msg = ('Component ' + self.label + ' has no attribute ' + str(key))
+                msg = ('Component ' + self.label + ' has no attribute ' +
+                       str(key) + '.')
                 logging.error(msg)
                 raise KeyError(msg)
 
@@ -333,8 +343,7 @@ class dr_eva_natural(subsystem):
         self.outlet = cmp.subsys_interface(label=self.label + '_outlet',
                                            num_inter=self.num_o)
         self.drum = cmp.drum(label=self.label + '_drum')
-        self.evaporator = cmp.heat_exchanger(label=self.label + '_evaporator',
-                                             mode='man')
+        self.evaporator = cmp.heat_exchanger(label=self.label + '_evaporator')
 
     def set_comps(self):
 
@@ -419,7 +428,7 @@ class ph_desup_cond(subsystem):
                                            num_inter=self.num_o)
         self.desup = cmp.desuperheater(label=self.label + '_desup')
         self.condenser = cmp.condenser(label=self.label + '_condenser')
-        self.valve = cmp.valve(label=self.label + '_valve', mode='man')
+        self.valve = cmp.valve(label=self.label + '_valve')
 
     def set_comps(self):
 
@@ -446,7 +455,8 @@ class ph_desup_cond(subsystem):
 
 class ph_desup_cond_subc(subsystem):
     r"""
-    Preheater with desuperheater and subcooler, subcooled liquid at hot side outlet.
+    Preheater with desuperheater and subcooler, subcooled liquid at hot side
+    outlet.
 
     Inlets/Outlets
 
@@ -512,7 +522,7 @@ class ph_desup_cond_subc(subsystem):
         self.desup = cmp.desuperheater(label=self.label + '_desup')
         self.condenser = cmp.condenser(label=self.label + '_condenser')
         self.subcooler = cmp.heat_exchanger(label=self.label + '_subcooler')
-        self.valve = cmp.valve(label=self.label + '_valve', mode='man')
+        self.valve = cmp.valve(label=self.label + '_valve')
 
     def set_comps(self):
 

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -384,10 +384,13 @@ class connection:
                     raise ValueError(msg)
 
             elif key == 'design_path':
-                if isinstance(kwargs[key], str) or kwargs[key] is None:
+                if isinstance(kwargs[key], str):
                     self.__dict__.update({key: kwargs[key]})
+                elif np.isnan(kwargs[key]):
+                    self.design_path = None
                 else:
-                    msg = 'Please provide the ' + key + ' parameter as string!'
+                    msg = ('Please provide the ' + key + ' parameter as '
+                           'string or as nan.')
                     logging.error(msg)
                     raise TypeError(msg)
 

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -62,7 +62,8 @@ class connection:
         Volumetric flow specification.
 
     state : str
-        State of the pure fluid on this connection: liquid ('l') or gaseous ('g').
+        State of the pure fluid on this connection: liquid ('l') or gaseous
+        ('g').
 
     design : list
         List containing design parameters (stated as string).
@@ -80,10 +81,10 @@ class connection:
       (0 = 1 - a - b - c - d) will be applied.
 
     - The specification of values for design and/or offdesign is used for
-      automatic switch from design to offdesign calculation: All parameters given
-      in 'design', e. g. :code:`design=['T', 'p']`, are unset in any offdesign
-      calculation, parameters given in 'offdesign' are set for offdesign
-      calculation.
+      automatic switch from design to offdesign calculation: All parameters
+      given in 'design', e. g. :code:`design=['T', 'p']`, are unset in any
+      offdesign calculation, parameters given in 'offdesign' are set for
+      offdesign calculation.
 
     Example
     -------
@@ -97,7 +98,8 @@ class connection:
     >>> so_si2 = con.connection(so2, 'out1', si2, 'in1')
     >>> so_si1.set_attr(v=0.012, m0=10, p=5, h=400, fluid={'H2O': 1, 'N2': 0})
     >>> p = hlp.dc_prop(val=50, val_set=True, unit='bar', unit_set=True)
-    >>> so_si2.set_attr(m=con.ref(so_si1, 2, -5), p=p, h0=700, T=200, fluid={'N2': 1}, fluid_balance=True)
+    >>> so_si2.set_attr(m=con.ref(so_si1, 2, -5), p=p, h0=700, T=200,
+    ... fluid={'N2': 1}, fluid_balance=True)
     >>> type(so_si1.p)
     <class 'tespy.tools.helpers.dc_prop'>
     >>> type(so_si1.fluid)
@@ -134,24 +136,30 @@ class connection:
         # check input parameters
         if not (isinstance(comp1, cmp.component) and
                 isinstance(comp2, cmp.component)):
-            msg = ('Error creating connection. Check if comp1, comp2 are of type component.')
+            msg = ('Error creating connection. Check if comp1, comp2 are of '
+                   'type component.')
             logging.error(msg)
             raise TypeError(msg)
 
         if comp1 == comp2:
-            msg = ('Error creating connection. Can\'t connect component ' + comp1.label + ' to itself.')
+            msg = ('Error creating connection. Can\'t connect component ' +
+                   comp1.label + ' to itself.')
             logging.error(msg)
             raise TESPyConnectionError(msg)
 
         if outlet_id not in comp1.outlets():
-            msg = ('Error creating connection. Specified oulet_id (' + outlet_id + ') is not valid for component ' +
-                   comp1.component() + '. Valid ids are: ' + str(comp1.outlets()) + '.')
+            msg = ('Error creating connection. Specified oulet_id (' +
+                   outlet_id + ') is not valid for component ' +
+                   comp1.component() + '. Valid ids are: ' +
+                   str(comp1.outlets()) + '.')
             logging.error(msg)
             raise ValueError(msg)
 
         if inlet_id not in comp2.inlets():
-            msg = ('Error creating connection. Specified inlet_id (' + inlet_id + ') is not valid for component ' +
-                   comp2.component() + '. Valid ids are: ' + str(comp2.inlets()) + '.')
+            msg = ('Error creating connection. Specified inlet_id (' +
+                   inlet_id + ') is not valid for component ' +
+                   comp2.component() + '. Valid ids are: ' +
+                   str(comp2.inlets()) + '.')
             logging.error(msg)
             raise ValueError(msg)
 
@@ -161,6 +169,7 @@ class connection:
         self.t = comp2
         self.t_id = inlet_id
 
+        self.design_path = None
         self.design = []
         self.offdesign = []
 
@@ -172,12 +181,14 @@ class connection:
 
         self.set_attr(**kwargs)
 
-        msg = 'Created connection ' + self.s.label + ' (' + self.s_id + ') -> ' + self.t.label + ' (' + self.t_id + ').'
+        msg = ('Created connection ' + self.s.label + ' (' + self.s_id +
+               ') -> ' + self.t.label + ' (' + self.t_id + ').')
         logging.debug(msg)
 
     def set_attr(self, **kwargs):
         r"""
-        Sets, resets or unsets attributes of a component for provided keyword arguments.
+        Sets, resets or unsets attributes of a component for provided keyword
+        arguments.
 
         Parameters
         ----------
@@ -222,7 +233,8 @@ class connection:
             Volumetric flow specification.
 
         state : str
-            State of the pure fluid on this connection: liquid ('l') or gaseous ('g').
+            State of the pure fluid on this connection: liquid ('l') or gaseous
+            ('g').
 
         design : list
             List containing design parameters (stated as String).
@@ -232,23 +244,23 @@ class connection:
 
         Note
         ----
-        - The fluid balance parameter applies a balancing of the fluid vector on
-          the specified conntion to 100 %. For example, you have four fluid
+        - The fluid balance parameter applies a balancing of the fluid vector
+          on the specified conntion to 100 %. For example, you have four fluid
           components (a, b, c and d) in your vector, you set two of them
-          (a and b) and want the other two (components c and d) to be a result of
-          your calculation. If you set this parameter to True, the equation
+          (a and b) and want the other two (components c and d) to be a result
+          of your calculation. If you set this parameter to True, the equation
           (0 = 1 - a - b - c - d) will be applied.
 
         - The specification of values for design and/or offdesign is used for
-          automatic switch from design to offdesign calculation: All parameters given
-          in 'design', e. g. :code:`design=['T', 'p']`, are unset in any offdesign
-          calculation, parameters given in 'offdesign' are set for offdesign
-          calculation.
+          automatic switch from design to offdesign calculation: All parameters
+          given in 'design', e. g. :code:`design=['T', 'p']`, are unset in any
+          offdesign calculation, parameters given in 'offdesign' are set for
+          offdesign calculation.
 
         - The property state is applied on pure fluids only. If you specify the
           desired state of the fluid at a connection the convergence check will
-          adjust the enthalpy values of that connection for the first iterations
-          in order to meet the state requirement.
+          adjust the enthalpy values of that connection for the first
+          iterations in order to meet the state requirement.
         """
         var = self.attr()
         var0 = [x + '0' for x in var.keys()]
@@ -261,7 +273,9 @@ class connection:
                     if isinstance(kwargs[key], dict):
                         # starting values
                         if key in var0:
-                            self.get_attr(key.replace('0', '')).set_attr(val0=kwargs[key])
+                            self.get_attr(key.replace('0', '')).set_attr(
+                                    val0=kwargs[key]
+                                    )
                         # specified parameters
                         else:
                             self.get_attr(key).set_attr(val=kwargs[key].copy())
@@ -275,7 +289,8 @@ class connection:
 
                     else:
                         # bad datatype
-                        msg = 'Bad datatype for connection keyword ' + key + '.'
+                        msg = ('Bad datatype for connection keyword ' + key +
+                               '.')
                         logging.error(msg)
                         raise TypeError(msg)
 
@@ -290,16 +305,19 @@ class connection:
                                 isinstance(kwargs[key], np.int64) or
                                 isinstance(kwargs[key], int)):
                             if np.isnan(kwargs[key]):
-                                self.state.set_attr(val=kwargs[key], val_set=False)
+                                self.state.set_attr(
+                                        val=kwargs[key], val_set=False
+                                        )
                             else:
-                                msg = 'Datatype for keyword argument ' + str(key) + ' must be str.'
+                                msg = ('Datatype for keyword argument ' +
+                                       str(key) + ' must be str.')
                                 logging.error(msg)
                                 raise TypeError(msg)
                         else:
-                            msg = 'Keyword argument ' + str(key) + ' must be \'l\' or \'g\'.'
+                            msg = ('Keyword argument ' + str(key) +
+                                   ' must be \'l\' or \'g\'.')
                             logging.error(msg)
                             raise ValueError(msg)
-
 
                 elif (isinstance(kwargs[key], float) or
                         isinstance(kwargs[key], np.float64) or
@@ -307,18 +325,26 @@ class connection:
                         isinstance(kwargs[key], int)):
                     # unset
                     if np.isnan(kwargs[key]) and key not in var0:
-                        self.get_attr(key).set_attr(val_set=False, ref_set=False)
+                        self.get_attr(key).set_attr(
+                                val_set=False, ref_set=False
+                                )
                     # starting value
                     elif key in var0:
-                        self.get_attr(key.replace('0', '')).set_attr(val0=kwargs[key])
+                        self.get_attr(key.replace('0', '')).set_attr(
+                                val0=kwargs[key]
+                                )
                     # set/reset
                     else:
-                        self.get_attr(key).set_attr(val_set=True, val=kwargs[key], val0=kwargs[key])
+                        self.get_attr(key).set_attr(
+                                val_set=True, val=kwargs[key], val0=kwargs[key]
+                                )
 
                 # reference object
                 elif isinstance(kwargs[key], ref):
                     if key == 'x' or key == 'v' or key == 'Td_bp':
-                        msg = 'References for volumetric flow, vapour mass fraction and subcooling/superheating not implemented.'
+                        msg = ('References for volumetric flow, vapour mass '
+                               'fraction and subcooling/superheating not '
+                               'implemented.')
                         logging.warning(msg)
                     else:
                         self.get_attr(key).set_attr(ref=kwargs[key])
@@ -339,7 +365,8 @@ class connection:
                 if isinstance(kwargs[key], bool):
                     self.get_attr('fluid').set_attr(balance=kwargs[key])
                 else:
-                    msg = ('Datatype for keyword argument ' + str(key) + ' must be boolean.')
+                    msg = ('Datatype for keyword argument ' + str(key) +
+                           ' must be boolean.')
                     logging.error(msg)
                     raise TypeError(msg)
 
@@ -351,9 +378,18 @@ class connection:
                 if set(kwargs[key]).issubset(var.keys()):
                     self.__dict__.update({key: kwargs[key]})
                 else:
-                    msg = ('Available parameters for (off-)design specification are: ' + str(var.keys()) + '.')
+                    msg = ('Available parameters for (off-)design '
+                           'specification are: ' + str(var.keys()) + '.')
                     logging.error(msg)
                     raise ValueError(msg)
+
+            elif key == 'design_path':
+                if isinstance(kwargs[key], str) or kwargs[key] is None:
+                    self.__dict__.update({key: kwargs[key]})
+                else:
+                    msg = 'Please provide the ' + key + ' parameter as string!'
+                    logging.error(msg)
+                    raise TypeError(msg)
 
             # invalid keyword
             else:

--- a/tespy/network_reader.py
+++ b/tespy/network_reader.py
@@ -33,8 +33,10 @@ def load_nwk(path):
 
     Note
     ----
-    If you save the network structure of an existing TESPy network, it will be saved to the path you specified.
-    The structure of the saved data in that path is the structure you need to provide in the path for loading the network.
+    If you save the network structure of an existing TESPy network, it will be
+    saved to the path you specified. The structure of the saved data in that
+    path is the structure you need to provide in the path for loading the
+    network.
 
     The structure of the path must be as follows:
 
@@ -49,9 +51,13 @@ def load_nwk(path):
 
     The imported network has the following additional features:
 
-    - Connections are accessible by their target's label and id, e. g. for a connection going to 'condenser' at inlet 'in2' use :code:`myimportednetwork.imp_conns['condenser:in2']`.
-    - Components are accessible by label, e. g. for a component 'heat exchanger' :code:`myimportednetwork.imp_comps['heat exchanger']`.
-    - Busses are accessible by label, e. g. for a bus 'power input' :code:`myimportednetwork.imp_busses['power input']`.
+    - Connections are accessible by their target's label and id, e. g. for a
+      connection going to 'condenser' at inlet 'in2' use
+      :code:`myimportednetwork.imp_conns['condenser:in2']`.
+    - Components are accessible by label, e. g. for a component
+      'heat exchanger' :code:`myimportednetwork.imp_comps['heat exchanger']`.
+    - Busses are accessible by label, e. g. for a bus 'power input'
+      :code:`myimportednetwork.imp_busses['power input']`.
 
     Example
     -------
@@ -163,13 +169,15 @@ def load_nwk(path):
                                          'bus_char': ast.literal_eval})
 
             # create components
-            df['instance'] = df.apply(construct_comps, axis=1, args=(chars, char_maps, ))
+            df['instance'] = df.apply(construct_comps, axis=1,
+                                      args=(chars, char_maps, ))
             comps = pd.concat((comps, df[['instance', 'label', 'busses',
                                           'bus_param', 'bus_P_ref',
                                           'bus_char']]), axis=0)
 
             df['inter'] = df.apply(get_interface, axis=1)
-            inter = pd.concat((inter, df[['instance', 'label', 'inter']]), axis=0)
+            inter = pd.concat((inter, df[['instance', 'label', 'inter']]),
+                              axis=0)
 
             msg = 'Reading component data (' + f[:-4] + ') from ' + fn + '.'
             logging.debug(msg)
@@ -204,7 +212,8 @@ def load_nwk(path):
     # add connections to network
     for c in conns['instance']:
         nw.add_conns(c)
-        nw.imp_conns[c.s.label + ':' + c.s_id + '_' + c.t.label + ':' + c.t_id] = c
+        nw.imp_conns[c.s.label + ':' + c.s_id + '_'
+                     + c.t.label + ':' + c.t_id] = c
 
     msg = 'Created connections.'
     logging.info(msg)
@@ -241,7 +250,8 @@ def load_nwk(path):
 
 def construct_comps(c, *args):
     r"""
-    Creates TESPy component from class name provided in the .csv-file and specifies its parameters.
+    Creates TESPy component from class name provided in the .csv-file and
+    specifies its parameters.
 
     Parameters
     ----------
@@ -267,7 +277,7 @@ def construct_comps(c, *args):
     kwargs = {}
 
     # basic properties
-    for key in ['mode', 'design', 'offdesign']:
+    for key in ['design', 'offdesign']:
         kwargs[key] = c[key]
 
     for key, value in instance.attr().items():
@@ -293,10 +303,14 @@ def construct_comps(c, *args):
                     # if characteristics are missing (for compressor map atm)
                     x = cmp_char.characteristics().x
                     y = cmp_char.characteristics().y
-                    msg = 'Could not find x and y values for characteristic line, using defaults instead for function ' + key + ' at component ' + c.label + '.'
+                    msg = ('Could not find x and y values for characteristic '
+                           'line, using defaults instead for function ' + key +
+                           ' at component ' + c.label + '.')
                     logging.warning(msg)
 
-                char = cmp_char.characteristics(x=x, y=y, method=c[key + '_method'], comp=instance.component())
+                char = cmp_char.characteristics(
+                        x=x, y=y, method=c[key + '_method'],
+                        comp=instance.component())
 
                 dc = hlp.dc_cc(is_set=c[key + '_set'],
                                method=c[key + '_method'],
@@ -321,10 +335,13 @@ def construct_comps(c, *args):
                     z1 = cmp_char.char_map().z1
                     z2 = cmp_char.char_map().z2
 
-                    msg = 'Could not find x, y, z1 and z2 values for characteristic map, using defaults instead.'
+                    msg = ('Could not find x, y, z1 and z2 values for '
+                           'characteristic map, using defaults instead.')
                     logging.warning(msg)
 
-                char_map = cmp_char.char_map(x=x, y=y, z1=z1, z2=z2, method=c[key + '_method'], comp=instance.component())
+                char_map = cmp_char.char_map(
+                        x=x, y=y, z1=z1, z2=z2, method=c[key + '_method'],
+                        comp=instance.component())
 
                 dc = hlp.dc_cm(is_set=c[key + '_set'],
                                method=c[key + '_method'],
@@ -401,7 +418,8 @@ def construct_network(path):
 
 def construct_conns(c, *args):
     r"""
-    Creates TESPy connection from data in the .csv-file and specifies its parameters.
+    Creates TESPy connection from data in the .csv-file and specifies its
+    parameters.
 
     Parameters
     ----------
@@ -417,7 +435,8 @@ def construct_conns(c, *args):
         TESPy connection object.
     """
     # create connection
-    conn = con.connection(args[0].instance[c.s], c.s_id, args[0].instance[c.t], c.t_id)
+    conn = con.connection(args[0].instance[c.s], c.s_id,
+                          args[0].instance[c.t], c.t_id)
 
     kwargs = {}
     # read basic properties
@@ -429,8 +448,10 @@ def construct_conns(c, *args):
     for key in ['m', 'p', 'h', 'T', 'x', 'v', 'Td_bp']:
         if key in c:
             if key in c:
-                dc = hlp.dc_prop(val=c[key], val0=c[key + '0'], val_set=c[key + '_set'],
-                                 unit=c[key + '_unit'], unit_set=c[key + '_unit_set'],
+                dc = hlp.dc_prop(val=c[key], val0=c[key + '0'],
+                                 val_set=c[key + '_set'],
+                                 unit=c[key + '_unit'],
+                                 unit_set=c[key + '_unit_set'],
                                  ref=None, ref_set=c[key + '_ref_set'])
                 kwargs[key] = dc
 
@@ -449,7 +470,8 @@ def construct_conns(c, *args):
             val0[key] = c[key + '0']
             val_set[key] = c[key + '_set']
 
-    kwargs['fluid'] = hlp.dc_flu(val=val, val0=val0, val_set=val_set, balance=c['balance'])
+    kwargs['fluid'] = hlp.dc_flu(val=val, val0=val0, val_set=val_set,
+                                 balance=c['balance'])
 
     # write properties to connection and return connection object
     conn.set_attr(**kwargs)
@@ -531,8 +553,10 @@ def busses_add_comps(c, *args):
         p, P_ref, char = c.bus_param[i], c.bus_P_ref[i], c.bus_char[i]
 
         values = char == args[1]['id']
-        char = cmp_char.characteristics(x=args[1][values].x.values[0], y=args[1][values].y.values[0])
+        char = cmp_char.characteristics(x=args[1][values].x.values[0],
+                                        y=args[1][values].y.values[0])
 
         # add component with corresponding details to bus
-        args[0].instance[b == args[0]['label']].values[0].add_comps({'c': c.instance, 'p': p, 'P_ref': P_ref, 'char': char})
+        args[0].instance[b == args[0]['label']].values[0].add_comps(
+                {'c': c.instance, 'p': p, 'P_ref': P_ref, 'char': char})
         i += 1

--- a/tespy/network_reader.py
+++ b/tespy/network_reader.py
@@ -277,8 +277,9 @@ def construct_comps(c, *args):
     kwargs = {}
 
     # basic properties
-    for key in ['design', 'offdesign']:
-        kwargs[key] = c[key]
+    for key in ['design', 'offdesign', 'design_path']:
+        if key in c:
+            kwargs[key] = c[key]
 
     for key, value in instance.attr().items():
         if key in c:
@@ -440,7 +441,7 @@ def construct_conns(c, *args):
 
     kwargs = {}
     # read basic properties
-    for key in ['design', 'offdesign']:
+    for key in ['design', 'offdesign', 'design_path']:
         if key in c:
             kwargs[key] = c[key]
 

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -2480,7 +2480,7 @@ class network:
         Calculate bus, component parameters and connection parameters.
         """
         # components
-        self.comps.apply(network.process_components, axis=1, args=('post',))
+        self.comps.apply(network.process_components, axis=1)
 
         # busses
         for b in self.busses.values():
@@ -2516,8 +2516,8 @@ class network:
         msg = 'Postprocessing complete.'
         logging.info(msg)
 
-    def process_components(cols, mode):
-        cols.name.calc_parameters(mode)
+    def process_components(cols):
+        cols.name.calc_parameters()
 
 # %% printing and plotting
 

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -2715,6 +2715,7 @@ class network:
         # design and offdesign parameters
         df['design'] = self.conns.apply(f, axis=1, args=('design',))
         df['offdesign'] = self.conns.apply(f, axis=1, args=('offdesign',))
+        df['design_path'] = self.conns.apply(f, axis=1, args=('design_path',))
 
         cols = ['m', 'p', 'h', 'T', 'x', 'v', 'Td_bp']
         for key in cols:
@@ -2797,7 +2798,7 @@ class network:
             df = cp_sort[cp_sort['cp'] == c]
 
             # basic information
-            cols = ['label', 'design', 'offdesign', 'interface']
+            cols = ['label', 'design', 'offdesign', 'interface', 'design_path']
             for col in cols:
                 df[col] = df.apply(f, axis=1, args=(col,))
 

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -1958,13 +1958,6 @@ class network:
         if self.iter > 0:
             self.vec_res[0:self.num_comp_eq] = vec_res
 
-    def solve_comp(args):
-        data = args[0]
-        return [
-                data[0].apply(network.solve_comp_eq, axis=1),
-                data[0].apply(network.solve_comp_deriv, axis=1)
-        ]
-
     def solve_comp_eq(cp):
         return cp.name.equations()
 

--- a/tespy/networks.py
+++ b/tespy/networks.py
@@ -824,9 +824,15 @@ class network:
                 c.m.design = df.loc[conn_id].m * self.m[df.loc[conn_id].m_unit]
                 c.p.design = df.loc[conn_id].p * self.p[df.loc[conn_id].p_unit]
                 c.h.design = df.loc[conn_id].h * self.h[df.loc[conn_id].h_unit]
+                c.v.design = df.loc[conn_id].v * self.v[df.loc[conn_id].v_unit]
+                c.x.design = df.loc[conn_id].x
+                c.T.design = ((df.loc[conn_id]['T'] +
+                               self.T[df.loc[conn_id].T_unit][0]) *
+                              self.T[df.loc[conn_id].T_unit][1])
+                c.Td_bp.design = (df.loc[conn_id].Td_bp *
+                                  self.T[df.loc[conn_id].T_unit][1])
                 for fluid in self.fluids:
                     c.fluid.design[fluid] = df.loc[conn_id][fluid]
-
             else:
                 msg = ('Could not find all connections in design case. '
                        'Please, make sure no connections have been modified '
@@ -905,6 +911,14 @@ class network:
                                   self.p[df.loc[conn_id].p_unit])
                     c.h.design = (df.loc[conn_id].h *
                                   self.h[df.loc[conn_id].h_unit])
+                    c.v.design = (df.loc[conn_id].v *
+                                  self.v[df.loc[conn_id].v_unit])
+                    c.x.design = df.loc[conn_id].x
+                    c.T.design = ((df.loc[conn_id]['T'] +
+                                   self.T[df.loc[conn_id].T_unit][0]) *
+                                  self.T[df.loc[conn_id].T_unit][1])
+                    c.Td_bp.design = (df.loc[conn_id].Td_bp *
+                                      self.T[df.loc[conn_id].T_unit][1])
                     for fluid in self.fluids:
                         c.fluid.design[fluid] = df.loc[conn_id][fluid]
 
@@ -956,6 +970,7 @@ class network:
 
             for var in c.offdesign:
                 c.get_attr(var).set_attr(val_set=True)
+                c.get_attr(var).val_SI = c.get_attr(var).design
 
         msg = 'Switched connections from design to offdesign.'
         logging.debug(msg)
@@ -1213,20 +1228,21 @@ class network:
                     c.get_attr(key).val_SI = (
                             c.get_attr(key).val0 * self.get_attr(key)[
                                     c.get_attr(key).unit])
-                elif (key not in ['T', 'x', 'v', 'Td_bp'] and
-                      c.get_attr(key).val_set is True):
-                    c.get_attr(key).val_SI = (
-                            c.get_attr(key).val * self.get_attr(key)[
-                                    c.get_attr(key).unit])
-                elif key == 'T' and c.T.val_set is True:
-                    c.T.val_SI = ((c.T.val + self.T[c.T.unit][0]) *
-                                  self.T[c.T.unit][1])
-                elif key == 'Td_bp' and c.Td_bp.val_set is True:
-                    c.Td_bp.val_SI = c.Td_bp.val * self.T[c.T.unit][1]
-                elif key == 'x' and c.x.val_set is True:
-                    c.x.val_SI = c.x.val
-                elif key == 'v' and c.v.val_set is True:
-                    c.v.val_SI = c.v.val * self.v[c.v.unit]
+                elif key not in c.offdesign:
+                    if (key not in ['T', 'x', 'v', 'Td_bp'] and
+                            c.get_attr(key).val_set is True):
+                        c.get_attr(key).val_SI = (
+                                c.get_attr(key).val * self.get_attr(key)[
+                                        c.get_attr(key).unit])
+                    elif (key == 'T' and c.T.val_set is True):
+                        c.T.val_SI = ((c.T.val + self.T[c.T.unit][0]) *
+                                      self.T[c.T.unit][1])
+                    elif key == 'Td_bp' and c.Td_bp.val_set is True:
+                        c.Td_bp.val_SI = c.Td_bp.val * self.T[c.T.unit][1]
+                    elif key == 'x' and c.x.val_set is True:
+                        c.x.val_SI = c.x.val
+                    elif key == 'v' and c.v.val_set is True:
+                        c.v.val_SI = c.v.val * self.v[c.v.unit]
 
         msg = ('Retrieved generic starting values and specified SI-values of '
                'connection parameters.')

--- a/tespy/tools/helpers.py
+++ b/tespy/tools/helpers.py
@@ -1700,11 +1700,11 @@ def Q_ph(p, h, fluid):
     d : float
         Density d / (kg/:math:`\mathrm{m}^3`).
     """
-    if 'IDGAS::' in fluid:
-        msg = 'Ideal gas calculation not available by now.'
-        logging.warning(msg)
-        return np.nan
-    elif 'TESPy::' in fluid:
+#    if 'IDGAS::' in fluid:
+#        msg = 'Ideal gas calculation not available by now.'
+#        logging.warning(msg)
+#        return np.nan
+    if 'TESPy::' in fluid:
         msg = 'TESPy fluid calculation not available by now.'
         logging.warning(msg)
         return np.nan

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -547,6 +547,14 @@ class component_tests:
                ', is ' + str(instance.kA.val) + '.')
         eq_(677, round(instance.kA.val, 0), msg)
 
+        instance.set_attr(Q='var', kA=np.nan)
+        Q = -5e4
+        b.set_attr(P=Q)
+        self.nw.solve('design')
+        msg = ('Value of heat transfer must be ' + str(Q) +
+               ', is ' + str(instance.Q.val) + '.')
+        eq_(Q, round(instance.Q.val, 0), msg)
+
     def test_solar_collector(self):
         """
         Test component properties of solar collector.

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -203,8 +203,8 @@ class component_tests:
         instance = cmp.turbine('turbine')
         c1, c2 = self.setup_network_11(instance)
         fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
-        c1.set_attr(fluid=fl, m=15, p=10, T=120)
-        c2.set_attr(p=1)
+        c1.set_attr(fluid=fl, m=15, p=10)
+        c2.set_attr(p=1, T=20)
         instance.set_attr(eta_s=0.8)
         self.nw.solve('design')
         self.nw.save('tmp')
@@ -224,9 +224,9 @@ class component_tests:
         self.nw.solve('offdesign', design_path='tmp')
         eq_(round(eta_s_d, 2), round(instance.eta_s.val, 2), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be identical to design case (' + str(eta_s_d) + ').')
         # lowering mass flow, inlet pressure must sink according to cone law
-        c1.set_attr(m=c1.m.val*0.8)
+        c1.set_attr(m=c1.m.val * 0.8)
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.125, round(instance.pr.val, 3), 'Value of pressure ratio (' + str(instance.pr.val) + ') must be at (' + str(0.125) + ').')
+        eq_(0.128, round(instance.pr.val, 3), 'Value of pressure ratio (' + str(instance.pr.val) + ') must be at (' + str(0.128) + ').')
         self.nw.print_results()
         # testing more parameters for eta_s_char
         c1.set_attr(m=10)
@@ -237,11 +237,11 @@ class component_tests:
         # test param specification pr
         instance.eta_s_char.param='pr'
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.769, round(instance.eta_s.val, 3), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be (' + str(0.769) + ').')
+        eq_(0.768, round(instance.eta_s.val, 3), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be (' + str(0.768) + ').')
         # test param specification dh_s
         instance.eta_s_char.param='dh_s'
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.799, round(instance.eta_s.val, 3), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be (' + str(0.799) + ').')
+        eq_(0.798, round(instance.eta_s.val, 3), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be (' + str(0.798) + ').')
         instance.eta_s_char.param=None
         # test for missing parameter declaration
         try:

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -511,7 +511,7 @@ class component_tests:
         he_hs = con.connection(he, 'out1', hsin, 'in1')
         self.nw.add_conns(tes_he, he_tes, hs_he, he_hs)
         # design specification
-        he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5, design=['pr2', 'ttd_u', 'ttd_l'], offdesign=['zeta2', 'kA'])
+        he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5, design=['pr2', 'ttd_u'], offdesign=['zeta2', 'kA'])
         hs_he.set_attr(T=100, p0=0.5, fluid={'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0})
         tes_he.set_attr(T=30, p=5, fluid={'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0})
         he_tes.set_attr(T=40)
@@ -524,7 +524,7 @@ class component_tests:
         p = hs_he.p.val_SI
         eq_(round(ttd_u, 1), round(he.ttd_u.val, 1), 'Value of terminal temperature difference must be ' + str(he.ttd_u.val) + ', is ' + str(ttd_u) + '.')
         # check lower terminal temperature difference
-        he.set_attr(ttd_l=20, ttd_u=np.nan)
+        he.set_attr(ttd_l=20, ttd_u=np.nan, design=['pr2', 'ttd_l'])
         self.nw.solve('design')
         eq_(round(he_hs.T.val - tes_he.T.val, 1), round(he.ttd_l.val, 1), 'Value of terminal temperature difference must be ' + str(he.ttd_l.val) + ', is ' + str(he_hs.T.val - tes_he.T.val) + '.')
         # check kA value
@@ -624,12 +624,12 @@ class component_tests:
         eq_(round(e, 1), round(instance.e.val, 1), 'Value of efficiency must be ' + str(e) + ', is ' + str(instance.e.val) + '.')
 
         pr = 0.95
-        instance.set_attr(pr_c=pr, e=np.nan, zeta='var',  P=2.5e6, design=['pr_c'], offdesign=['zeta'])
+        instance.set_attr(pr_c=pr, e=np.nan, zeta='var',  P=2.5e6, design=['pr_c'])
         self.nw.solve('design')
         self.nw.save('tmp')
         eq_(round(pr, 2), round(instance.pr_c.val, 2), 'Value of pressure ratio must be ' + str(pr) + ', is ' + str(instance.pr_c.val) + '.')
 
-        instance.set_attr(zeta=np.nan)
+        instance.set_attr(zeta=np.nan, offdesign=['zeta'])
         self.nw.solve('offdesign', design_path='tmp')
         eq_(round(pr, 2), round(instance.pr_c.val, 2), 'Value of pressure ratio must be ' + str(pr) + ', is ' + str(instance.pr_c.val) + '.')
         shutil.rmtree('./tmp', ignore_errors=True)

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -10,7 +10,8 @@ import shutil
 class component_tests:
 
     def setup(self):
-        self.nw = nwk.network(['INCOMP::DowQ', 'H2O', 'NH3', 'N2', 'O2', 'Ar', 'CO2', 'CH4'],
+        self.nw = nwk.network(['INCOMP::DowQ', 'H2O', 'NH3', 'N2',
+                               'O2', 'Ar', 'CO2', 'CH4'],
                               T_unit='C', p_unit='bar', v_unit='m3 / s')
         self.source = cmp.source('source')
         self.sink = cmp.sink('sink')
@@ -46,7 +47,8 @@ class component_tests:
 
         instance.set_attr(pr_c=0.99)
 
-        cw_el = con.connection(cw_in, 'out1', instance, 'in1', fluid={'H2O': 1, 'H2': 0, 'O2': 0}, T=20, p=1)
+        cw_el = con.connection(cw_in, 'out1', instance, 'in1',
+                               fluid={'H2O': 1, 'H2': 0, 'O2': 0}, T=20, p=1)
         el_cw = con.connection(instance, 'out1', cw_out, 'in1', T=45)
 
         self.nw.add_conns(cw_el, el_cw)
@@ -63,25 +65,35 @@ class component_tests:
         """
         instance = cmp.turbomachine('turbomachine')
         c1, c2 = self.setup_network_11(instance)
-        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0,
+              'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
         c1.set_attr(fluid=fl, m=10, p=1, h=1e5)
         c2.set_attr(p=1, h=2e5)
         self.nw.solve('design')
         power = c1.m.val_SI * (c2.h.val_SI - c1.h.val_SI)
         pr = c2.p.val_SI / c1.p.val_SI
-        # pressure ratio and power are the basic functions for turbomachines, these are inherited by all children, thus only tested here
-        eq_(power, instance.P.val, 'Value of power must be ' + str(power) + ', is ' + str(instance.P.val) + '.')
-        eq_(pr, instance.pr.val, 'Value of power must be ' + str(pr) + ', is ' + str(instance.pr.val) + '.')
+        # pressure ratio and power are the basic functions for turbomachines,
+        # these are inherited by all children, thus only tested here
+        msg = ()
+        eq_(power, instance.P.val, 'Value of power must be ' + str(power) +
+            ', is ' + str(instance.P.val) + '.')
+        msg = ()
+        eq_(pr, instance.pr.val, 'Value of power must be ' + str(pr) +
+            ', is ' + str(instance.pr.val) + '.')
         c2.set_attr(p=np.nan)
         instance.set_attr(pr=5)
         self.nw.solve('design')
         pr = c2.p.val_SI / c1.p.val_SI
-        eq_(pr, instance.pr.val, 'Value of power must be ' + str(pr) + ', is ' + str(instance.pr.val) + '.')
+        msg = ('Value of power must be ' + str(pr) + ', is ' +
+               str(instance.pr.val) + '.')
+        eq_(pr, instance.pr.val, msg)
         c2.set_attr(h=np.nan)
         instance.set_attr(P=1e5)
         self.nw.solve('design')
         power = c1.m.val_SI * (c2.h.val_SI - c1.h.val_SI)
-        eq_(pr, instance.pr.val, 'Value of power must be ' + str(pr) + ', is ' + str(instance.pr.val) + '.')
+        msg = ('Value of power must be ' + str(pr) + ', is ' +
+               str(instance.pr.val) + '.')
+        eq_(pr, instance.pr.val, msg)
         instance.set_attr(eta_s=0.8)
         c2.set_attr(h=np.nan)
         try:
@@ -99,17 +111,23 @@ class component_tests:
         """
         instance = cmp.pump('pump')
         c1, c2 = self.setup_network_11(instance)
-        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 1, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
-        c1.set_attr(fluid=fl, v=1, p=5,T=50)
+        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 1, 'H2O': 0,
+              'NH3': 0, 'CO2': 0, 'CH4': 0}
+        c1.set_attr(fluid=fl, v=1, p=5, T=50)
         c2.set_attr(p=7)
         instance.set_attr(eta_s=1)
         self.nw.solve('design')
         # calculate isentropic efficiency the old fashioned way
         eta_s = (instance.h_os('') - c1.h.val_SI) / (c2.h.val_SI - c1.h.val_SI)
-        eq_(eta_s, instance.eta_s.val, 'Value of isentropic efficiency must be ' + str(eta_s) + ', is ' + str(instance.eta_s.val) + '.')
+        msg = ('Value of isentropic efficiency must be ' + str(eta_s) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(eta_s, instance.eta_s.val, msg)
         s1 = round(hlp.s_mix_ph(c1.to_flow()), 4)
         s2 = round(hlp.s_mix_ph(c2.to_flow()), 4)
-        eq_(s1, s2, 'Value of entropy must be identical for inlet (' + str(s1) + ') and outlet (' + str(s2) + ') at 100 % isentropic efficiency.')
+        msg = ('Value of entropy must be identical for inlet (' + str(s1) +
+               ') and outlet (' + str(s2) +
+               ') at 100 % isentropic efficiency.')
+        eq_(s1, s2, msg)
         instance.set_attr(eta_s=0.7)
         self.nw.solve('design')
         self.nw.save('tmp')
@@ -119,22 +137,33 @@ class component_tests:
         y = np.array([14, 13.5, 12.5, 11, 9, 6.5, 3.5, 0]) * 1e5
         char = hlp.dc_cc(x=x, y=y, is_set=True)
         # apply flow char and eta_s char
-        instance.set_attr(flow_char=char, eta_s=np.nan, eta_s_char=hlp.dc_cc(method='GENERIC', is_set=True))
+        instance.set_attr(flow_char=char, eta_s=np.nan,
+                          eta_s_char=hlp.dc_cc(method='GENERIC', is_set=True))
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(c2.p.val_SI - c1.p.val_SI, 0), 650000, 'Value of pressure rise must be ' + str(650000) + ', is ' + str(c2.p.val_SI - c1.p.val_SI) + '.')
+        msg = ('Value of pressure rise must be ' + str(650000) + ', is ' +
+               str(c2.p.val_SI - c1.p.val_SI) + '.')
+        eq_(round(c2.p.val_SI - c1.p.val_SI, 0), 650000, msg)
         c1.set_attr(v=0.9)
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(c2.p.val_SI - c1.p.val_SI, 775000.0, 'Value of pressure rise must be ' + str(775000.0) + ', is ' + str(c2.p.val_SI - c1.p.val_SI) + '.')
-        eq_(0.694, round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(0.694) + ', is ' + str(instance.eta_s.val) + '.')
+        msg = ('Value of pressure rise must be ' + str(775000.0) + ', is ' +
+               str(c2.p.val_SI - c1.p.val_SI) + '.')
+        eq_(c2.p.val_SI - c1.p.val_SI, 775000.0, msg)
+        msg = ('Value of isentropic efficiency must be ' + str(0.694) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(0.694, round(instance.eta_s.val, 3), msg)
         instance.eta_s_char.is_set = False
         # test boundaries of characteristic line
         c2.set_attr(T=con.ref(c1, 0, 20))
         c1.set_attr(v=-0.1)
         self.nw.solve('design')
-        eq_(c2.p.val_SI - c1.p.val_SI, 14e5, 'Value of power must be ' + str(14e5) + ', is ' + str(c2.p.val_SI - c1.p.val_SI) + '.')
+        msg = ('Value of power must be ' + str(14e5) + ', is ' +
+               str(c2.p.val_SI - c1.p.val_SI) + '.')
+        eq_(c2.p.val_SI - c1.p.val_SI, 14e5, msg)
         c1.set_attr(v=1.5)
         self.nw.solve('design')
-        eq_(c2.p.val_SI - c1.p.val_SI, 0, 'Value of power must be ' + str(0) + ', is ' + str(c2.p.val_SI - c1.p.val_SI) + '.')
+        msg = ('Value of power must be ' + str(0) + ', is ' +
+               str(c2.p.val_SI - c1.p.val_SI) + '.')
+        eq_(c2.p.val_SI - c1.p.val_SI, 0, msg)
         shutil.rmtree('./tmp', ignore_errors=True)
 
     def test_compressor(self):
@@ -143,51 +172,77 @@ class component_tests:
         """
         instance = cmp.compressor('compressor')
         c1, c2 = self.setup_network_11(instance)
-        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 1, 'CO2': 0, 'CH4': 0}
+        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0,
+              'H2O': 0, 'NH3': 1, 'CO2': 0, 'CH4': 0}
         c1.set_attr(fluid=fl, v=1, p=5, T=100)
         c2.set_attr(p=7)
         instance.set_attr(eta_s=0.8)
         self.nw.solve('design')
         self.nw.save('tmp')
         # calculate isentropic efficiency the old fashioned way
-        eta_s_d = (instance.h_os('') - c1.h.val_SI) / (c2.h.val_SI - c1.h.val_SI)
-        eq_(round(eta_s_d, 3), round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(eta_s_d) + ', is ' + str(instance.eta_s.val) + '.')
+        eta_s_d = ((instance.h_os('') - c1.h.val_SI) /
+                   (c2.h.val_SI - c1.h.val_SI))
+        msg = ('Value of isentropic efficiency must be ' + str(eta_s_d) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(round(eta_s_d, 3), round(instance.eta_s.val, 3), msg)
         # trigger invalid isentropic efficiency
         instance.set_attr(eta_s=1.1)
         self.nw.solve('design')
         # calculate isentropic efficiency the old fashioned way
         eta_s = (instance.h_os('') - c1.h.val_SI) / (c2.h.val_SI - c1.h.val_SI)
-        eq_(round(eta_s, 3), round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(eta_s) + ', is ' + str(instance.eta_s.val) + '.')
+        msg = ('Value of isentropic efficiency must be ' + str(eta_s) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(round(eta_s, 3), round(instance.eta_s.val, 3), msg)
         c2.set_attr(p=np.nan)
-        instance.set_attr(char_map=hlp.dc_cm(method='GENERIC', is_set=True), eta_s=np.nan)
+        instance.set_attr(char_map=hlp.dc_cm(method='GENERIC', is_set=True),
+                          eta_s=np.nan)
         self.nw.solve('offdesign', design_path='tmp')
         eta_s = (instance.h_os('') - c1.h.val_SI) / (c2.h.val_SI - c1.h.val_SI)
-        eq_(round(eta_s, 2), round(instance.eta_s.val, 2), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be identical to design case (' + str(eta_s) + ').')
-        # going above highes available speedline, beneath lowest mass flow at that line
+        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
+               ') must be identical to design case (' + str(eta_s) + ').')
+        eq_(round(eta_s, 2), round(instance.eta_s.val, 2), msg)
+        # going above highes available speedline, beneath lowest mass flow at
+        # that line
         c1.set_attr(v=np.nan, m=c1.m.val*0.8, T=30)
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(eta_s * instance.char_map.z2[6, 0], 4), round(instance.eta_s.val, 4), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be at (' + str(round(eta_s * instance.char_map.z2[6, 0], 4)) + ').')
-        # going below lowest available speedline, above highest mass flow at that line
+        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
+               ') must be at (' +
+               str(round(eta_s * instance.char_map.z2[6, 0], 4)) + ').')
+        eq_(round(eta_s * instance.char_map.z2[6, 0], 4),
+            round(instance.eta_s.val, 4), msg)
+        # going below lowest available speedline, above highest mass flow at
+        # that line
         c1.set_attr(T=300)
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(eta_s * instance.char_map.z2[0, 9], 4), round(instance.eta_s.val, 4), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be at (' + str(round(eta_s * instance.char_map.z2[0, 9], 4)) + ').')
+        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
+               ') must be at (' +
+               str(round(eta_s * instance.char_map.z2[0, 9], 4)) + ').')
+        eq_(round(eta_s * instance.char_map.z2[0, 9], 4),
+            round(instance.eta_s.val, 4), msg)
         # back to design properties, test eta_s_char
         c2.set_attr(p=7)
         c1.set_attr(v=1, T=100, m=np.nan)
         # test param specification m
-        instance.set_attr(eta_s_char=hlp.dc_cc(method='GENERIC', is_set=True, param='m'))
+        instance.set_attr(eta_s_char=hlp.dc_cc(method='GENERIC',
+                                               is_set=True, param='m'))
         instance.char_map.is_set = False
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(eta_s, 3), round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(eta_s) + ', is ' + str(instance.eta_s.val) + '.')
+        msg = ('Value of isentropic efficiency must be ' + str(eta_s) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(round(eta_s, 3), round(instance.eta_s.val, 3), msg)
         c1.set_attr(v=1.5)
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.88, round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(0.88) + ', is ' + str(instance.eta_s.val) + '.')
+        msg = ('Value of isentropic efficiency must be ' + str(0.88) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(0.88, round(instance.eta_s.val, 3), msg)
         # test param specification pr
         instance.eta_s_char.set_attr(param='pr')
         c1.set_attr(v=1)
         c2.set_attr(p=7.5)
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.829, round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(0.829) + ', is ' + str(instance.eta_s.val) + '.')
+        msg = ('Value of isentropic efficiency must be ' + str(0.829) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(0.829, round(instance.eta_s.val, 3), msg)
         instance.eta_s_char.set_attr(param=None)
         # test for missing parameter declaration
         try:
@@ -202,47 +257,63 @@ class component_tests:
         """
         instance = cmp.turbine('turbine')
         c1, c2 = self.setup_network_11(instance)
-        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0,
+              'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
         c1.set_attr(fluid=fl, m=15, p=10)
         c2.set_attr(p=1, T=20)
         instance.set_attr(eta_s=0.8)
         self.nw.solve('design')
         self.nw.save('tmp')
         # calculate isentropic efficiency the old fashioned way
-        eta_s_d = (c2.h.val_SI - c1.h.val_SI) / (instance.h_os('') - c1.h.val_SI)
-        eq_(round(eta_s_d, 3), round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(eta_s_d) + ', is ' + str(instance.eta_s.val) + '.')
+        eta_s_d = ((c2.h.val_SI - c1.h.val_SI) /
+                   (instance.h_os('') - c1.h.val_SI))
+        msg = ('Value of isentropic efficiency must be ' + str(eta_s_d) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(round(eta_s_d, 3), round(instance.eta_s.val, 3), msg)
         # trigger invalid isentropic efficiency
         instance.set_attr(eta_s=1.1)
         self.nw.solve('design')
         # calculate isentropic efficiency the old fashioned way
         eta_s = (c2.h.val_SI - c1.h.val_SI) / (instance.h_os('') - c1.h.val_SI)
-        eq_(round(eta_s, 3), round(instance.eta_s.val, 3), 'Value of isentropic efficiency must be ' + str(eta_s) + ', is ' + str(instance.eta_s.val) + '.')
+        msg = ('Value of isentropic efficiency must be ' + str(eta_s) +
+               ', is ' + str(instance.eta_s.val) + '.')
+        eq_(round(eta_s, 3), round(instance.eta_s.val, 3), msg)
         c1.set_attr(p=np.nan)
         instance.cone.is_set = True
         instance.eta_s_char.is_set = True
         instance.eta_s.is_set = False
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(eta_s_d, 2), round(instance.eta_s.val, 2), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be identical to design case (' + str(eta_s_d) + ').')
+        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
+               ') must be identical to design case (' + str(eta_s_d) + ').')
+        eq_(round(eta_s_d, 2), round(instance.eta_s.val, 2), msg)
         # lowering mass flow, inlet pressure must sink according to cone law
         c1.set_attr(m=c1.m.val * 0.8)
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.128, round(instance.pr.val, 3), 'Value of pressure ratio (' + str(instance.pr.val) + ') must be at (' + str(0.128) + ').')
+        msg = ('Value of pressure ratio (' + str(instance.pr.val) +
+               ') must be at (' + str(0.128) + ').')
+        eq_(0.128, round(instance.pr.val, 3), msg)
         self.nw.print_results()
         # testing more parameters for eta_s_char
         c1.set_attr(m=10)
         # test param specification v
-        instance.eta_s_char.param='v'
+        instance.eta_s_char.param = 'v'
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.8, round(instance.eta_s.val, 3), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be (' + str(0.8) + ').')
+        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
+               ') must be (' + str(0.8) + ').')
+        eq_(0.8, round(instance.eta_s.val, 3), msg)
         # test param specification pr
-        instance.eta_s_char.param='pr'
+        instance.eta_s_char.param = 'pr'
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.768, round(instance.eta_s.val, 3), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be (' + str(0.768) + ').')
+        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
+               ') must be (' + str(0.768) + ').')
+        eq_(0.768, round(instance.eta_s.val, 3), msg)
         # test param specification dh_s
-        instance.eta_s_char.param='dh_s'
+        instance.eta_s_char.param = 'dh_s'
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(0.798, round(instance.eta_s.val, 3), 'Value of isentropic efficiency (' + str(instance.eta_s.val) + ') must be (' + str(0.798) + ').')
-        instance.eta_s_char.param=None
+        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
+               ') must be (' + str(0.798) + ').')
+        eq_(0.798, round(instance.eta_s.val, 3), msg)
+        instance.eta_s_char.param = None
         # test for missing parameter declaration
         try:
             self.nw.solve('offdesign', design_path='tmp')
@@ -256,8 +327,10 @@ class component_tests:
         """
         instance = cmp.combustion_chamber('combustion chamber', fuel='CH4')
         c1, c2, c3 = self.setup_network_21(instance)
-        air = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
-        fuel = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0.04, 'CH4': 0.96}
+        air = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0,
+               'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fuel = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 0,
+                'NH3': 0, 'CO2': 0.04, 'CH4': 0.96}
         c1.set_attr(fluid=air, p=1, T=30)
         c2.set_attr(fluid=fuel, T=30)
         c3.set_attr(T=1200)
@@ -266,7 +339,9 @@ class component_tests:
         self.nw.add_busses(b)
         self.nw.solve('design')
         self.nw.print_results()
-        eq_(round(b.P.val, 1), round(instance.ti.val, 1), 'Value of thermal input must be ' + str(b.P.val) + ', is ' + str(instance.ti.val) + '.')
+        msg = ('Value of thermal input must be ' + str(b.P.val) + ', is ' +
+               str(instance.ti.val) + '.')
+        eq_(round(b.P.val, 1), round(instance.ti.val, 1), msg)
 
         # test unspecified fuel
         instance.set_attr(fuel=np.nan)
@@ -288,16 +363,23 @@ class component_tests:
         """
         instance = cmp.valve('valve')
         c1, c2 = self.setup_network_11(instance)
-        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0,
+              'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
         c1.set_attr(fluid=fl, m=10, p=10, T=120)
         c2.set_attr(p=1)
         instance.set_attr(pr='var')
         self.nw.solve('design')
-        eq_(round(c2.p.val_SI / c1.p.val_SI, 1), round(instance.pr.val, 1), 'Value of pressure ratio must be ' + str(c2.p.val_SI / c1.p.val_SI) + ', is ' + str(instance.pr.val) + '.')
+        msg = ('Value of pressure ratio must be ' +
+               str(c2.p.val_SI / c1.p.val_SI) + ', is ' +
+               str(instance.pr.val) + '.')
+        eq_(round(c2.p.val_SI / c1.p.val_SI, 1),
+            round(instance.pr.val, 1), msg)
         zeta = instance.zeta.val
         instance.set_attr(zeta='var', pr=np.nan)
         self.nw.solve('design')
-        eq_(round(zeta, 1), round(instance.zeta.val, 1), 'Value of pressure ratio must be ' + str(zeta) + ', is ' + str(instance.zeta.val) + '.')
+        msg = ('Value of pressure ratio must be ' + str(zeta) + ', is ' +
+               str(instance.zeta.val) + '.')
+        eq_(round(zeta, 1), round(instance.zeta.val, 1), msg)
 
     def test_cogeneration_unit(self):
         """
@@ -322,12 +404,17 @@ class component_tests:
         chp2_cw = con.connection(chp, 'out2', cw_out2, 'in1')
         self.nw.add_conns(chp1_cw, chp2_cw)
 
-        air = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
-        fuel = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0.04, 'CH4': 0.96}
-        water1 = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0}
-        water2 = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        air = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'INCOMP::DowQ': 0,
+               'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fuel = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 0,
+                'NH3': 0, 'CO2': 0.04, 'CH4': 0.96}
+        water1 = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1,
+                  'NH3': 0, 'CO2': 0, 'CH4': 0}
+        water2 = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1,
+                  'NH3': 0, 'CO2': 0, 'CH4': 0}
 
-        chp.set_attr(fuel='CH4', pr1=0.99, pr2=0.99, lamb=1.2, design=['pr1', 'pr2'], offdesign=['zeta1', 'zeta2'])
+        chp.set_attr(fuel='CH4', pr1=0.99, pr2=0.99, lamb=1.2,
+                     design=['pr1', 'pr2'], offdesign=['zeta1', 'zeta2'])
         amb_comb.set_attr(p=5, T=30, fluid=air)
         sf_comb.set_attr(T=30, fluid=fuel)
         cw1_chp1.set_attr(p=3, T=60, m=50, fluid=water1)
@@ -353,42 +440,60 @@ class component_tests:
         self.nw.solve('design')
         self.nw.save('tmp')
         self.nw.solve('offdesign', init_path='tmp', design_path='tmp')
-        eq_(round(TI.P.val, 1), round(chp.ti.val, 1), 'Value of thermal input must be ' + str(TI.P.val) + ', is ' + str(chp.ti.val) + '.')
+        msg = ('Value of thermal input must be ' + str(TI.P.val) + ', is ' +
+               str(chp.ti.val) + '.')
+        eq_(round(TI.P.val, 1), round(chp.ti.val, 1), msg)
         # ti via component
         TI.set_attr(P=np.nan)
         chp.set_attr(ti=ti)
         self.nw.solve('offdesign', init_path='tmp', design_path='tmp')
-        eq_(round(ti, 1), round(chp.ti.val, 1), 'Value of thermal input must be ' + str(ti) + ', is ' + str(chp.ti.val) + '.')
+        msg = ('Value of thermal input must be ' + str(ti) + ', is ' +
+               str(chp.ti.val) + '.')
+        eq_(round(ti, 1), round(chp.ti.val, 1), msg)
         chp.set_attr(ti=np.nan)
         # Q1 via bus
         Q1.set_attr(P=chp.Q1.val)
         self.nw.solve('offdesign', init_path='tmp', design_path='tmp')
-        eq_(round(ti, 1), round(chp.ti.val, 1), 'Value of thermal input must be ' + str(ti) + ', is ' + str(chp.ti.val) + '.')
+        msg = ('Value of thermal input must be ' + str(ti) + ', is ' +
+               str(chp.ti.val) + '.')
+        eq_(round(ti, 1), round(chp.ti.val, 1), msg)
         heat1 = chp1_cw.m.val_SI * (chp1_cw.h.val_SI - cw1_chp1.h.val_SI)
-        eq_(round(heat1, 1), round(chp.Q1.val, 1), 'Value of thermal input must be ' + str(heat1) + ', is ' + str(chp.Q1.val) + '.')
+        msg = ('Value of thermal input must be ' + str(heat1) + ', is ' +
+               str(chp.Q1.val) + '.')
+        eq_(round(heat1, 1), round(chp.Q1.val, 1), msg)
         Q1.set_attr(P=np.nan)
         # Q2 via bus
         Q2.set_attr(P=1.2 * chp.Q2.val)
         self.nw.solve('offdesign', init_path='tmp', design_path='tmp')
-        # due to characteristic function Q1 is equal to Q2 for this cogeneration unit
+        # due to characteristic function Q1 is equal to Q2 for this
+        # cogeneration unit
         heat1 = chp1_cw.m.val_SI * (chp1_cw.h.val_SI - cw1_chp1.h.val_SI)
-        eq_(round(heat1, 1), round(chp.Q2.val, 1), 'Value of heat output 2 must be ' + str(heat1) + ', is ' + str(chp.Q2.val) + '.')
+        msg = ('Value of heat output 2 must be ' + str(heat1) + ', is ' +
+               str(chp.Q2.val) + '.')
+        eq_(round(heat1, 1), round(chp.Q2.val, 1), msg)
         # Q2 via component
         Q2.set_attr(P=np.nan)
         chp.set_attr(Q2=heat1)
         self.nw.solve('offdesign', init_path='tmp', design_path='tmp')
         heat1 = chp1_cw.m.val_SI * (chp1_cw.h.val_SI - cw1_chp1.h.val_SI)
-        eq_(round(heat1, 1), round(chp.Q2.val, 1), 'Value of heat output 2 must be ' + str(heat1) + ', is ' + str(chp.Q2.val) + '.')
+        msg = ('Value of heat output 2 must be ' + str(heat1) + ', is ' +
+               str(chp.Q2.val) + '.')
+        eq_(round(heat1, 1), round(chp.Q2.val, 1), msg)
         # Q via bus
         chp.set_attr(Q2=np.nan)
         Q.set_attr(P=1.5 * chp.Q1.val)
         self.nw.solve('offdesign', init_path='tmp', design_path='tmp')
-        eq_(round(Q.P.val, 1), round(2 * chp.Q2.val, 1), 'Value of total heat output (' + str(Q.P.val) + ') must be twice as much as value of heat output 2 (' + str(chp.Q2.val) + ').')
+        msg = ('Value of total heat output (' + str(Q.P.val) +
+               ') must be twice as much as value of heat output 2 (' +
+               str(chp.Q2.val) + ').')
+        eq_(round(Q.P.val, 1), round(2 * chp.Q2.val, 1), msg)
         # Qloss via bus
         Q.set_attr(P=np.nan)
         Qloss.set_attr(P=1e5)
         self.nw.solve('offdesign', init_path='tmp', design_path='tmp')
-        eq_(round(Qloss.P.val, 1), round(chp.Qloss.val, 1), 'Value of heat loss must be ' + str(Qloss.P.val) + ', is ' + str(chp.Qloss.val) + '.')
+        msg = ('Value of heat loss must be ' + str(Qloss.P.val) + ', is ' +
+               str(chp.Qloss.val) + '.')
+        eq_(round(Qloss.P.val, 1), round(chp.Qloss.val, 1), msg)
         shutil.rmtree('./tmp', ignore_errors=True)
 
     def test_heat_ex_simple(self):
@@ -397,35 +502,50 @@ class component_tests:
         """
         instance = cmp.heat_exchanger_simple('heat exchanger')
         c1, c2 = self.setup_network_11(instance)
-        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1,
+              'NH3': 0, 'CO2': 0, 'CH4': 0}
         c1.set_attr(fluid=fl, m=1, p=10, T=100)
         # trigger heat exchanger parameter groups
         instance.set_attr(hydro_group='HW', L=100, ks=100, pr=0.99, Tamb=20)
         instance.hydro_group.is_set = True
         instance.kA_group.is_set = True
         self.nw.solve('design', init_only=True)
-        eq_(instance.hydro_group.is_set, False, 'Hydro group must no be set, if one parameter is missing!')
-        eq_(instance.kA_group.is_set, False, 'kA group must no be set, if one parameter is missing!')
-        instance.set_attr(hydro_group='HW', D='var', L=100, ks=100, pr=0.99, Tamb=20)
+        msg = ('Hydro group must no be set, if one parameter is missing!')
+        eq_(instance.hydro_group.is_set, False, msg)
+        msg = ('kA group must no be set, if one parameter is missing!')
+        eq_(instance.kA_group.is_set, False, msg)
+        instance.set_attr(hydro_group='HW', D='var', L=100,
+                          ks=100, pr=0.99, Tamb=20)
         b = con.bus('heat', P=-1e5)
         b.add_comps({'c': instance})
         self.nw.add_busses(b)
         self.nw.solve('design')
-        eq_(round(c2.p.val_SI / c1.p.val_SI, 2), round(instance.pr.val, 2), 'Value of pressure ratio must be ' + str(c2.p.val_SI / c1.p.val_SI) + ', is ' + str(instance.pr.val) + '.')
+        msg = ('Value of pressure ratio must be ' +
+               str(c2.p.val_SI / c1.p.val_SI) + ', is ' +
+               str(instance.pr.val) + '.')
+        eq_(round(c2.p.val_SI / c1.p.val_SI, 2),
+            round(instance.pr.val, 2), msg)
         zeta = instance.zeta.val
         instance.set_attr(D=instance.D.val, zeta='var', pr=np.nan)
         instance.D.is_var = False
         self.nw.solve('design')
-        eq_(round(zeta, 1), round(instance.zeta.val, 1), 'Value of zeta must be ' + str(zeta) + ', is ' + str(instance.zeta.val) + '.')
+        msg = ('Value of zeta must be ' + str(zeta) + ', is ' +
+               str(instance.zeta.val) + '.')
+        eq_(round(zeta, 1), round(instance.zeta.val, 1), msg)
         pr = instance.pr.val
         instance.set_attr(zeta=np.nan, pr='var')
         self.nw.solve('design')
-        eq_(round(pr, 2), round(instance.pr.val, 2), 'Value of pressure ratio must be ' + str(pr) + ', is ' + str(instance.pr.val) + '.')
+        msg = ('Value of pressure ratio must be ' + str(pr) +
+               ', is ' + str(instance.pr.val) + '.')
+        eq_(round(pr, 2), round(instance.pr.val, 2), msg)
         instance.set_attr(kA='var', pr=np.nan)
         b.set_attr(P=-5e4)
         self.nw.solve('design')
-        # due to heat output being half of reference (for Tamb) kA should be somewhere near to that (actual value is 677)
-        eq_(677, round(instance.kA.val, 0), 'Value of heat transfer coefficient must be ' + str(677) + ', is ' + str(instance.kA.val) + '.')
+        # due to heat output being half of reference (for Tamb) kA should be
+        # somewhere near to that (actual value is 677)
+        msg = ('Value of heat transfer coefficient must be ' + str(677) +
+               ', is ' + str(instance.kA.val) + '.')
+        eq_(677, round(instance.kA.val, 0), msg)
 
     def test_solar_collector(self):
         """
@@ -433,15 +553,18 @@ class component_tests:
         """
         instance = cmp.solar_collector('solar collector')
         c1, c2 = self.setup_network_11(instance)
-        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0,
+              'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0}
         c1.set_attr(fluid=fl, m=1, p=10, T=100)
         # trigger solar collector parameter groups (see heat exchanger simple)
         instance.set_attr(hydro_group='HW', L=100, ks=100, pr=0.99, Tamb=20)
         instance.hydro_group.is_set = True
         instance.energy_group.is_set = True
         self.nw.solve('design', init_only=True)
-        eq_(instance.hydro_group.is_set, False, 'Hydro group must no be set, if one parameter is missing!')
-        eq_(instance.energy_group.is_set, False, 'Energy group must no be set, if one parameter is missing!')
+        msg = ('Hydro group must no be set, if one parameter is missing!')
+        eq_(instance.hydro_group.is_set, False, msg)
+        msg = ('Energy group must no be set, if one parameter is missing!')
+        eq_(instance.energy_group.is_set, False, msg)
 
     def test_heat_ex(self):
         """
@@ -458,10 +581,16 @@ class component_tests:
         he_hs = con.connection(he, 'out1', hsin, 'in1')
         self.nw.add_conns(tes_he, he_tes, hs_he, he_hs)
         # design specification
-        he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5, design=['pr1', 'pr2', 'ttd_u'], offdesign=['zeta1', 'zeta2', 'kA'])
-        hs_he.set_attr(T=120, p=3, fluid={'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0})
+        he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5,
+                    design=['pr1', 'pr2', 'ttd_u'],
+                    offdesign=['zeta1', 'zeta2', 'kA'])
+        hs_he.set_attr(T=120, p=3, fluid={'N2': 0, 'O2': 0, 'Ar': 0,
+                                          'INCOMP::DowQ': 0, 'H2O': 1,
+                                          'NH3': 0, 'CO2': 0, 'CH4': 0})
         he_hs.set_attr(T=70)
-        tes_he.set_attr(T=40, p=5, fluid={'N2': 0, 'O2': 0, 'Ar': 1, 'INCOMP::DowQ': 0, 'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0})
+        tes_he.set_attr(T=40, p=5, fluid={'N2': 0, 'O2': 0, 'Ar': 1,
+                                          'INCOMP::DowQ': 0, 'H2O': 0,
+                                          'NH3': 0, 'CO2': 0, 'CH4': 0})
         b = con.bus('heat transfer', P=-80e3)
         b.add_comps({'c': he})
         self.nw.add_busses(b)
@@ -469,16 +598,25 @@ class component_tests:
         # check heat flow
         Q = hs_he.m.val_SI * (he_hs.h.val_SI - hs_he.h.val_SI)
         self.nw.save('tmp')
-        eq_(round(hs_he.T.val - he_tes.T.val, 1), round(he.ttd_u.val, 1), 'Value of terminal temperature difference must be ' + str(he.ttd_u.val) + ', is ' + str(hs_he.T.val - he_tes.T.val) + '.')
+        msg = ('Value of terminal temperature difference must be ' +
+               str(he.ttd_u.val) + ', is ' + str(hs_he.T.val - he_tes.T.val) +
+               '.')
+        eq_(round(hs_he.T.val - he_tes.T.val, 1), round(he.ttd_u.val, 1), msg)
         # check lower terminal temperature difference
         he_hs.set_attr(T=np.nan)
         he.set_attr(ttd_l=20)
         self.nw.solve('design')
-        eq_(round(he_hs.T.val - tes_he.T.val, 1), round(he.ttd_l.val, 1), 'Value of terminal temperature difference must be ' + str(he.ttd_l.val) + ', is ' + str(he_hs.T.val - tes_he.T.val) + '.')
+        msg = ('Value of terminal temperature difference must be ' +
+               str(he.ttd_l.val) + ', is ' + str(he_hs.T.val - tes_he.T.val) +
+               '.')
+        eq_(round(he_hs.T.val - tes_he.T.val, 1), round(he.ttd_l.val, 1), msg)
         # check kA value
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(Q, 1), round(he.Q.val, 1), 'Value of heat flow must be ' + str(he.Q.val) + ', is ' + str(Q) + '.')
-        # trigger errors for negative terminal temperature differences at given kA-value
+        msg = ('Value of heat flow must be ' + str(he.Q.val) +
+               ', is ' + str(Q) + '.')
+        eq_(round(Q, 1), round(he.Q.val, 1), msg)
+        # trigger errors for negative terminal temperature differences at given
+        # kA-value
         he.set_attr(ttd_l=np.nan)
         # ttd_l
         he_hs.set_attr(T=30)
@@ -495,7 +633,6 @@ class component_tests:
             pass
         shutil.rmtree('./tmp', ignore_errors=True)
 
-
     def test_condenser(self):
         """
         Test component properties of condenser.
@@ -511,25 +648,40 @@ class component_tests:
         he_hs = con.connection(he, 'out1', hsin, 'in1')
         self.nw.add_conns(tes_he, he_tes, hs_he, he_hs)
         # design specification
-        he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5, design=['pr2', 'ttd_u'], offdesign=['zeta2', 'kA'])
-        hs_he.set_attr(T=100, p0=0.5, fluid={'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0})
-        tes_he.set_attr(T=30, p=5, fluid={'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'H2O': 1, 'NH3': 0, 'CO2': 0, 'CH4': 0})
+        he.set_attr(pr1=0.98, pr2=0.98, ttd_u=5, design=['pr2', 'ttd_u'],
+                    offdesign=['zeta2', 'kA'])
+        hs_he.set_attr(T=100, p0=0.5, fluid={'N2': 0, 'O2': 0, 'Ar': 0,
+                                             'INCOMP::DowQ': 0, 'H2O': 1,
+                                             'NH3': 0, 'CO2': 0, 'CH4': 0})
+        tes_he.set_attr(T=30, p=5, fluid={'N2': 0, 'O2': 0, 'Ar': 0,
+                                          'INCOMP::DowQ': 0, 'H2O': 1,
+                                          'NH3': 0, 'CO2': 0, 'CH4': 0})
         he_tes.set_attr(T=40)
         he.set_attr(Q=-80e3)
         self.nw.solve('design')
         # check heat flow
         Q = hs_he.m.val_SI * (he_hs.h.val_SI - hs_he.h.val_SI)
+        msg = ('Value ofheat flow be ' +
+               str(he.Q.val) + ', is ' + str(Q) + '.')
+        eq_(round(Q, 1), round(he.Q.val, 1), msg)
         self.nw.save('tmp')
-        ttd_u = hlp.T_mix_ph([0, hs_he.p.val_SI, hlp.h_mix_pQ(hs_he.to_flow(), 1), hs_he.fluid.val]) - he_tes.T.val_SI
+        ttd_u = hlp.T_bp_p(hs_he.to_flow()) - he_tes.T.val_SI
         p = hs_he.p.val_SI
-        eq_(round(ttd_u, 1), round(he.ttd_u.val, 1), 'Value of terminal temperature difference must be ' + str(he.ttd_u.val) + ', is ' + str(ttd_u) + '.')
+        msg = ('Value of terminal temperature difference must be ' +
+               str(he.ttd_u.val) + ', is ' + str(ttd_u) + '.')
+        eq_(round(ttd_u, 1), round(he.ttd_u.val, 1), msg)
         # check lower terminal temperature difference
         he.set_attr(ttd_l=20, ttd_u=np.nan, design=['pr2', 'ttd_l'])
         self.nw.solve('design')
-        eq_(round(he_hs.T.val - tes_he.T.val, 1), round(he.ttd_l.val, 1), 'Value of terminal temperature difference must be ' + str(he.ttd_l.val) + ', is ' + str(he_hs.T.val - tes_he.T.val) + '.')
+        msg = ('Value of terminal temperature difference must be ' +
+               str(he.ttd_l.val) + ', is ' + str(he_hs.T.val - tes_he.T.val) +
+               '.')
+        eq_(round(he_hs.T.val - tes_he.T.val, 1), round(he.ttd_l.val, 1), msg)
         # check kA value
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(p, 1), round(hs_he.p.val_SI, 1), 'Value of condensing pressure be ' + str(p) + ', is ' + str(hs_he.p.val_SI) + '.')
+        msg = ('Value of condensing pressure be ' + str(p) +
+               ', is ' + str(hs_he.p.val_SI) + '.')
+        eq_(round(p, 1), round(hs_he.p.val_SI, 1), msg)
         shutil.rmtree('./tmp', ignore_errors=True)
 
     def test_water_electrolyzer(self):
@@ -574,7 +726,9 @@ class component_tests:
         self.nw.add_busses(power)
 
         self.nw.solve('design')
-        eq_(round(power.P.val, 1), round(instance.P.val), 'Value of power must be ' + str(power.P.val) + ', is ' + str(instance.P.val) + '.')
+        msg = ('Value of power must be ' + str(power.P.val) + ', is ' +
+               str(instance.P.val) + '.')
+        eq_(round(power.P.val, 1), round(instance.P.val), msg)
 
         # check bus functions
         power.set_attr(P=np.nan)
@@ -584,7 +738,17 @@ class component_tests:
         self.nw.add_busses(heat)
 
         self.nw.solve('design')
-        eq_(round(heat.P.val, 1), round(instance.Q.val), 'Value of heat flow must be ' + str(heat.P.val) + ', is ' + str(instance.Q.val) + '.')
+        msg = ('Value of heat flow must be ' + str(heat.P.val) +
+               ', is ' + str(instance.Q.val) + '.')
+        eq_(round(heat.P.val, 1), round(instance.Q.val), msg)
+        self.nw.save('tmp')
+
+        Q = heat.P.val * 0.9
+        heat.set_attr(P=Q)
+        self.nw.solve('offdesign', design_path='tmp')
+        msg = ('Value of heat flow must be ' + str(Q) +
+               ', is ' + str(instance.Q.val) + '.')
+        eq_(round(Q, 1), round(instance.Q.val), msg)
 
         self.nw.del_busses(heat, power)
 
@@ -600,7 +764,7 @@ class component_tests:
 
         # check invald bus parameter error in derivatives
         try:
-            instance.derivatives()
+            instance.bus_deriv(some_bus.comps.loc[instance])
         except ValueError:
             pass
 
@@ -608,28 +772,47 @@ class component_tests:
 
         instance.set_attr(eta=0.9, e='var')
         self.nw.solve('design')
+        msg = ('Value of efficiency must be ' + str(instance.eta.val) +
+               ', is ' + str(instance.e0 / instance.e.val) + '.')
         eq_(round(instance.eta.val, 2), round(instance.e0 / instance.e.val, 2),
-            'Value of efficiency must be ' + str(instance.eta.val) + ', is ' + str(instance.e0 / instance.e.val) + '.')
+            msg)
 
         # isentropic efficiency value > 1
         e = 130e6
         instance.set_attr(e=np.nan, eta=np.nan)
         instance.set_attr(e=e)
         self.nw.solve('design')
+        msg = ('Value of efficiency must be ' + str(instance.e0 / e) +
+               ', is ' + str(instance.eta.val) + '.')
+        eq_(round(instance.e0 / e, 2), round(instance.eta.val, 2), msg)
 
         e = 150e6
         instance.set_attr(e=np.nan, eta=np.nan)
         instance.set_attr(e=e)
         self.nw.solve('design')
-        eq_(round(e, 1), round(instance.e.val, 1), 'Value of efficiency must be ' + str(e) + ', is ' + str(instance.e.val) + '.')
+        msg = ('Value of efficiency must be ' + str(e) + ', is ' +
+               str(instance.e.val) + '.')
+        eq_(round(e, 1), round(instance.e.val, 1), msg)
 
         pr = 0.95
-        instance.set_attr(pr_c=pr, e=np.nan, zeta='var',  P=2.5e6, design=['pr_c'])
+        instance.set_attr(pr_c=pr, e=np.nan, zeta='var',
+                          P=2.5e6, design=['pr_c'])
         self.nw.solve('design')
         self.nw.save('tmp')
-        eq_(round(pr, 2), round(instance.pr_c.val, 2), 'Value of pressure ratio must be ' + str(pr) + ', is ' + str(instance.pr_c.val) + '.')
+        msg = ('Value of pressure ratio must be ' + str(pr) + ', is ' +
+               str(instance.pr_c.val) + '.')
+        eq_(round(pr, 2), round(instance.pr_c.val, 2), msg)
 
         instance.set_attr(zeta=np.nan, offdesign=['zeta'])
         self.nw.solve('offdesign', design_path='tmp')
-        eq_(round(pr, 2), round(instance.pr_c.val, 2), 'Value of pressure ratio must be ' + str(pr) + ', is ' + str(instance.pr_c.val) + '.')
+        msg = ('Value of pressure ratio must be ' + str(pr) + ', is ' +
+               str(instance.pr_c.val) + '.')
+        eq_(round(pr, 2), round(instance.pr_c.val, 2), msg)
+
+        Q = instance.Q.val * 0.9
+        instance.set_attr(Q=Q, P=np.nan)
+        self.nw.solve('offdesign', design_path='tmp')
+        msg = ('Value of heat must be ' + str(Q) + ', is ' +
+               str(instance.Q.val) + '.')
+        eq_(round(Q, 0), round(instance.Q.val, 0), msg)
         shutil.rmtree('./tmp', ignore_errors=True)

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -639,6 +639,23 @@ class component_tests:
             self.nw.solve('offdesign', design_path='tmp')
         except ValueError:
             pass
+
+        # trigger negative upper terminal temperature difference as result
+        he_tes.set_attr(T=np.nan)
+        he_hs.set_attr(T=30)
+        self.nw.solve('design')
+        msg = ('Value of upper terminal temperature differences must be '
+               'smaller than zero, is ' + str(round(he.ttd_u.val, 1)) + '.')
+        eq_(True, he.ttd_u.val < 0, msg)
+
+        # trigger negative lower terminal temperature difference as result
+        he_tes.set_attr(T=130)
+        he_hs.set_attr(T=np.nan)
+        self.nw.solve('design')
+        msg = ('Value of upper terminal temperature differences must be '
+               'smaller than zero, is ' + str(round(he.ttd_l.val, 1)) + '.')
+        eq_(True, he.ttd_l.val < 0, msg)
+
         shutil.rmtree('./tmp', ignore_errors=True)
 
     def test_condenser(self):

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -640,21 +640,24 @@ class component_tests:
         except ValueError:
             pass
 
-        # trigger negative upper terminal temperature difference as result
+        # trigger negative lower terminal temperature difference as result
         he_tes.set_attr(T=np.nan)
         he_hs.set_attr(T=30)
         self.nw.solve('design')
         msg = ('Value of upper terminal temperature differences must be '
-               'smaller than zero, is ' + str(round(he.ttd_u.val, 1)) + '.')
-        eq_(True, he.ttd_u.val < 0, msg)
-
-        # trigger negative lower terminal temperature difference as result
-        he_tes.set_attr(T=130)
-        he_hs.set_attr(T=np.nan)
-        self.nw.solve('design')
-        msg = ('Value of upper terminal temperature differences must be '
                'smaller than zero, is ' + str(round(he.ttd_l.val, 1)) + '.')
         eq_(True, he.ttd_l.val < 0, msg)
+
+        # trigger negative upper terminal temperature difference as result
+        he_tes.set_attr(T=100)
+        hs_he.set_attr(h=200e3, T=np.nan)
+        he.set_attr(design=['pr1', 'pr2'], ttd_u=np.nan)
+        he_hs.set_attr(h=150e3, T=np.nan)
+        tes_he.set_attr(T=40)
+        self.nw.solve('design')
+        msg = ('Value of upper terminal temperature differences must be '
+               'smaller than zero, is ' + str(round(he.ttd_u.val, 1)) + '.')
+        eq_(True, he.ttd_u.val < 0, msg)
 
         shutil.rmtree('./tmp', ignore_errors=True)
 
@@ -841,3 +844,7 @@ class component_tests:
                str(instance.Q.val) + '.')
         eq_(round(Q, 0), round(instance.Q.val, 0), msg)
         shutil.rmtree('./tmp', ignore_errors=True)
+
+a = component_tests()
+a.setup()
+a.test_heat_ex()

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -920,6 +920,12 @@ class component_tests:
         self.sc2.set_attr(E=950)
 
         self.nw.solve('offdesign', design_path='design1')
+        self.sc2_v2.set_attr(design_path=np.nan)
+
+        # volumetric flow comparison
+        msg = ('Design path was set to None, is ' +
+               str(self.sc2_v2.design_path) + '.')
+        eq_(None, self.sc2_v2.design_path, msg)
 
         # volumetric flow comparison
         msg = ('Value of volumetric flow must be ' + str(v1_design) + ', is ' +

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -90,7 +90,6 @@ class specification_error_tests:
             self.cmp_instanciation_ValueError(l)
 
         # ValueErrors
-        self.set_attr_ValueError(self.comp, mode=5)
         self.set_attr_ValueError(self.comp, offdesign=['Q'])
 
         self.set_attr_ValueError(self.conn, offdesign=['f'])

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -145,8 +145,8 @@ class specification_error_tests:
         self.get_attr_KeyError(cmp_char.characteristics(), 'test')
         self.get_attr_KeyError(hlp.data_container(), 'somekey')
 
-# %% Single tests
 
+# %% Single tests
 
 @raises(ValueError)
 def test_interface_ValueError():
@@ -157,14 +157,19 @@ def test_interface_ValueError():
 # networks
 
 
+@raises(hlp.TESPyNetworkError)
+def test_network_instanciation_no_fluids():
+    nw = nwk.network([])
+    so = cmp.source('source')
+    si = cmp.sink('sink')
+    conn = con.connection(so, 'out1', si, 'in1')
+    nw.add_conns(conn)
+    nw.solve('design', init_only=True)
+
+
 @raises(ValueError)
 def test_network_print_level():
     nwk.network(['INCOMP::DowQ']).set_printoptions(print_level='error')
-
-
-@raises(hlp.TESPyNetworkError)
-def test_network_instanciation_no_fluids():
-    nwk.network([]).initialise()
 
 
 @raises(TypeError)

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -109,14 +109,14 @@ class specification_error_tests:
         self.set_attr_TypeError(self.comp, tiP_char=None)
         self.set_attr_TypeError(self.comp, design='f')
         self.set_attr_TypeError(self.comp, fuel=hlp.dc_cp(val='CH4'))
-        self.set_attr_ValueError(self.comp, design_path=7)
+        self.set_attr_TypeError(self.comp, design_path=7)
 
         self.set_attr_TypeError(self.conn, design='h')
         self.set_attr_TypeError(self.conn, fluid_balance=1)
         self.set_attr_TypeError(self.conn, h0=[4])
         self.set_attr_TypeError(self.conn, fluid=5)
         self.set_attr_TypeError(self.conn, state=5)
-        self.set_attr_ValueError(self.conn, design_path=5)
+        self.set_attr_TypeError(self.conn, design_path=5)
 
         self.set_attr_TypeError(self.nw, m_range=5)
         self.set_attr_TypeError(self.nw, p_range=5)

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -109,12 +109,14 @@ class specification_error_tests:
         self.set_attr_TypeError(self.comp, tiP_char=None)
         self.set_attr_TypeError(self.comp, design='f')
         self.set_attr_TypeError(self.comp, fuel=hlp.dc_cp(val='CH4'))
+        self.set_attr_ValueError(self.comp, design_path=7)
 
         self.set_attr_TypeError(self.conn, design='h')
         self.set_attr_TypeError(self.conn, fluid_balance=1)
         self.set_attr_TypeError(self.conn, h0=[4])
         self.set_attr_TypeError(self.conn, fluid=5)
         self.set_attr_TypeError(self.conn, state=5)
+        self.set_attr_ValueError(self.conn, design_path=5)
 
         self.set_attr_TypeError(self.nw, m_range=5)
         self.set_attr_TypeError(self.nw, p_range=5)

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -242,18 +242,6 @@ def test_network_offdesign_path():
     nw.solve('offdesign')
 
 
-@raises(KeyError)
-def test_network_init_file():
-    nw = nwk.network(['water'])
-    nw.solve('design', init_file='tmp')
-
-
-@raises(KeyError)
-def test_network_design_file():
-    nw = nwk.network(['water'])
-    nw.solve('offdesign', design_file='tmp')
-
-
 @raises(ValueError)
 def test_network_mode():
     nw = nwk.network(['water'])

--- a/tests/heat_pump_test.py
+++ b/tests/heat_pump_test.py
@@ -111,11 +111,6 @@ class test_heat_pump_ebsilon:
 
         self.nw.add_conns(cp1_he, he_cp2, ic_in_he, he_ic_out, cp2_c_out)
 
-        # helping connection to reference boiling temperature
-
-        ref_Ts_su = con.connection(cmp.source('so'), 'out1', cmp.sink('si'), 'in1')
-        ref_Ts_cd = con.connection(cmp.source('socd'), 'out1', cmp.sink('sicd'), 'in1')
-        self.nw.add_conns(ref_Ts_su, ref_Ts_cd)
         # %% component parametrization
 
         # condenser system
@@ -159,22 +154,19 @@ class test_heat_pump_ebsilon:
         cb_rp.set_attr(T=60, p=10, fluid={'water': 1, 'NH3': 0})
         self.cd_cons.set_attr(T=105)
         cons_cf.set_attr(h=con.ref(cb_rp, 1, 0), p=con.ref(cb_rp, 1, 0))
-        cd_va.set_attr(p=con.ref(c_in_cd, 1, -1000), T=con.ref(ref_Ts_cd, 1, -5), h0=500, design=['T'])
+        cd_va.set_attr(p=con.ref(c_in_cd, 1, -1000), Td_bp=-5, h0=500, design=['Td_bp'])
 
         # evaporator system cold side
 
         pu_ev.set_attr(m=con.ref(va_dr, 10, 0), p0=5)
         dr_su.set_attr(p0=5, T=5)
-        su_cp1.set_attr(p=con.ref(dr_su, 1, -5000), T=con.ref(ref_Ts_su , 1, 5), h0=1700, design=['T', 'p'])
+        su_cp1.set_attr(p=con.ref(dr_su, 1, -5000), Td_bp=5, h0=1700, design=['Td_bp', 'p'])
 
         # evaporator system hot side
 
         self.amb_in_su.set_attr(m=20, T=12, p=1, fluid={'water': 1, 'NH3': 0})
         su_ev.set_attr(p=con.ref(self.amb_in_su, 1, -100), design=['p'])
         ev_amb_out.set_attr()
-
-        ref_Ts_su.set_attr(m=5, fluid={'water': 0, 'NH3': 1}, p=con.ref(su_cp1, 1, 0), x=1)
-        ref_Ts_cd.set_attr(m=5, fluid={'water': 0, 'NH3': 1}, p=con.ref(cd_va, 1, 0), x=0)
 
         # compressor-system
 


### PR DESCRIPTION
This PR will allow to have separate design cases for different parts of your network.

E. g. using a extraction steam turbine, the back pressure turbine part and the condenser can be designed for no extraction while the extraction condenser is designed for full extraction.

Other changes:
- documentation updates
- new feature T0 (starting value) for fluid property functions using fluid mixtures (fast root finding)
- code realignment for PEP

TODO:
- [x] update what's new section

Missing tests:
- [x] components
  - specification of design_path
   error test for wrong specification
- [x] connections
  - specification of design_path
   error test for wrong specification
- [x] water electrolyzer
  -  specification of Q
  - specification on bus in offdesign
  - error test for wrong bus parameter in bus derivatives
- [x] heat exchanger simple
  - Q as variable
- [x] heat exchanger
  - negative terminal temperature differences
- [x] network
  - error test for missing fluids in network