### PR TITLE
Add import shortcuts

### DIFF
--- a/doc/whats_new/v0-2-0.rst
+++ b/doc/whats_new/v0-2-0.rst
@@ -12,6 +12,7 @@ New Features
 - Added optical efficiency to the "solar_collector". The incoming radiation E no longer represents 
   the actual absorption but the radiation on the collector surface area (`PR #110 <https://github.com/oemof/tespy/pull/110>`_).
 - Implemented difference pressure vs mass flow characteristic line for valve (`c4eec6d <https://github.com/oemof/tespy/commit/c4eec6d17ce7c8ce260a44757d37aa26214ae2b0>`_).
+- Parameters :code:`local_design` and :code:`local_offdesign` are now also available for network exports and imports (`PR #109 <https://github.com/oemof/tespy/pull/109>`_).
 
 Documentation
 #############
@@ -21,13 +22,17 @@ Parameter renaming
 ##################
 - New name for *cogeneration_unit*: **combustion_engine** (`PR #105 <https://github.com/oemof/tespy/pull/105>`_).
 - New name for *subsys_interface*: **subsystem_interface** (`PR #107 <https://github.com/oemof/tespy/pull/107>`_).
-- The module import shortcuts (:code:`from tespy import ...`) for components (cmp), connections (con), helpers (hlp), logger (logger),
-  networks (nwk), network_reader (nwkr) are **no longer supported**! Please read the :ref:`example section below <tespy_v020_examples_label>` for more information
-  (`PR #108 <https://github.com/oemof/tespy/pull/108>`_).
-- The method :code:`set_printoptions` for the :py:class:`tespy.networks.networks.network` class is not available anymore. Use :code:`yournetwork.set_attr(iterinfo=True/False)`
-  in future (`PR #109 <https://github.com/oemof/tespy/pull/109>`_).
+- The module import shortcuts (:code:`from tespy import ...`) for components (cmp), connections (con),
+  helpers (hlp), logger (logger), networks (nwk), network_reader (nwkr) are **no longer supported**
+  (`PR #108 <https://github.com/oemof/tespy/pull/108>`_)!
+  We implemented new shortcuts instead for tespy.networks and tespy.components modules
+  (`PR #118 <https://github.com/oemof/tespy/pull/118>`_).
+  Please refer the :ref:`example section below <tespy_v020_examples_label>` for more information
+- The method :code:`set_printoptions` for the :py:class:`tespy.networks.networks.network` class is not available anymore.
+  Use :code:`yournetwork.set_attr(iterinfo=True/False)` in future (`PR #109 <https://github.com/oemof/tespy/pull/109>`_).
 - Parameter :code:`interface` for sinks and sources has been removed (`PR #109 <https://github.com/oemof/tespy/pull/109>`_).
-- Parameters :code:`local_design` and :code:`local_offdesign` are now also available for network exports and imports (`PR #109 <https://github.com/oemof/tespy/pull/109>`_).
+- The method for loading networks from the network_reader module has been renamed from :code:`load_nwk` to
+  :code:`load_network` (`PR #118 <https://github.com/oemof/tespy/pull/118>`_).
 
 Testing
 #######

--- a/tespy/components/__init__.py
+++ b/tespy/components/__init__.py
@@ -1,1 +1,21 @@
 # -*- coding: utf-8
+
+from tespy.components.basics import (
+    cycle_closer, sink, source, subsystem_interface
+    )
+from tespy.components.commbustion import (
+    combustion_chamber, combustion_chamber_stoich, combustion_engine
+    )
+from tespy.components.heat_exchangers import (
+    heat_exchanger_simple, solar_collector,
+    condenser, desuperheater, heat_exchanger
+    )
+from tespy.components.nodes import (
+    drum, merge, node, separator, splitter
+    )
+from tespy.components.piping import pipe, valve
+from tespy.components.reactors import  water_electrolyzer
+from tespy.components.subsystems import subsystem
+from tespy.components.turbomachinery import (
+    compressor, pump, turbine
+    )

--- a/tespy/components/__init__.py
+++ b/tespy/components/__init__.py
@@ -3,7 +3,7 @@
 from tespy.components.basics import (
     cycle_closer, sink, source, subsystem_interface
     )
-from tespy.components.commbustion import (
+from tespy.components.combustion import (
     combustion_chamber, combustion_chamber_stoich, combustion_engine
     )
 from tespy.components.heat_exchangers import (

--- a/tespy/components/basics.py
+++ b/tespy/components/basics.py
@@ -67,9 +67,7 @@ class cycle_closer(component):
     pump (but negative), as there is no other in- or outputs of energy in the
     system.
 
-    >>> from tespy.components.basics import cycle_closer
-    >>> from tespy.components.piping import pipe
-    >>> from tespy.components.turbomachinery import pump
+    >>> from tespy.components import cycle_closer, pipe, pump
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> nw = network(['water'], p_unit='bar', T_unit='C', iterinfo=False)
@@ -174,7 +172,7 @@ class sink(component):
     -------
     Create a sink and specify a label.
 
-    >>> from tespy.components.basics import sink
+    >>> from tespy.components import sink
     >>> si = sink('a labeled sink')
     >>> si.component()
     'sink'
@@ -213,7 +211,7 @@ class source(component):
     -------
     Create a source and specify a label.
 
-    >>> from tespy.components.basics import source
+    >>> from tespy.components import source
     >>> so = source('a labeled source')
     >>> so.component()
     'source'
@@ -288,7 +286,7 @@ class subsystem_interface(component):
     not go in depth of subsystem usage in this example. Please refer to
     TODO: PLACELINKHERE for more information on building your own subsystems.
 
-    >>> from tespy.components.basics import sink, source, subsystem_interface
+    >>> from tespy.components import sink, source, subsystem_interface
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> fluids = ['H2O', 'N2']

--- a/tespy/components/basics.py
+++ b/tespy/components/basics.py
@@ -69,7 +69,7 @@ class cycle_closer(component):
 
     >>> from tespy.components import cycle_closer, pipe, pump
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> nw = network(['water'], p_unit='bar', T_unit='C', iterinfo=False)
     >>> pi = pipe('pipe')
     >>> pu = pump('pump')
@@ -288,7 +288,7 @@ class subsystem_interface(component):
 
     >>> from tespy.components import sink, source, subsystem_interface
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> fluids = ['H2O', 'N2']
     >>> nw = network(fluids=fluids)
     >>> nw.set_attr(p_unit='bar', T_unit='C', h_unit='kJ / kg', iterinfo=False)

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -115,7 +115,7 @@ class combustion_chamber(component):
 
     >>> from tespy.components import sink, source, combustion_chamber
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p
     >>> import shutil
     >>> fluid_list = ['Ar', 'N2', 'H2', 'O2', 'CO2', 'CH4', 'H2O']
@@ -1221,7 +1221,7 @@ class combustion_chamber_stoich(combustion_chamber):
 
     >>> from tespy.components import sink, source, combustion_chamber_stoich
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p
     >>> import shutil
     >>> fluid_list = ['TESPy::myAir', 'TESPy::myFuel', 'TESPy::myFuel_fg']
@@ -2064,7 +2064,7 @@ class combustion_engine(combustion_chamber):
     >>> from tespy.components import (sink, source, combustion_engine, merge,
     ... splitter)
     >>> from tespy.connections import connection, ref
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> fluid_list = ['Ar', 'N2', 'O2', 'CO2', 'CH4', 'H2O']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -113,8 +113,7 @@ class combustion_chamber(component):
     when using combustion, as these stabilize the calculation. In this example
     a mixture of methane, hydrogen and carbondioxide is used as fuel.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.combustion import combustion_chamber
+    >>> from tespy.components import sink, source, combustion_chamber
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p
@@ -1220,8 +1219,7 @@ class combustion_chamber_stoich(combustion_chamber):
     chamber example
     (see :func:`tespy.components.combustion.combustion_chamber`).
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.combustion import combustion_chamber_stoich
+    >>> from tespy.components import sink, source, combustion_chamber_stoich
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p
@@ -2063,9 +2061,8 @@ class combustion_engine(combustion_chamber):
     a mixture of methane, hydrogen and carbondioxide is used as fuel. There are
     two cooling ports, the cooling water will flow through them in parallel.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.combustion import combustion_engine
-    >>> from tespy.components.nodes import merge, splitter
+    >>> from tespy.components import (sink, source, combustion_engine, merge,
+    ... splitter)
     >>> from tespy.connections import connection, ref
     >>> from tespy.networks.networks import network
     >>> import shutil

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -144,8 +144,7 @@ class heat_exchanger_simple(component):
     Also, given ambient temperature and the heat transfer coeffiecient, it is
     possible to predict heat transfer.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.heat_exchangers import heat_exchanger_simple
+    >>> from tespy.components import sink, source, heat_exchanger_simple
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -902,8 +901,7 @@ class solar_collector(heat_exchanger_simple):
     of heat at a given radiation. The collector parameters are the linear and
     the quadratic loss keyfigure as well as the optical effifiency.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.heat_exchangers import solar_collector
+    >>> from tespy.components import sink, source, solar_collector
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -1234,8 +1232,7 @@ class heat_exchanger(component):
     From this, it is possible to calculate the heat transfer coefficient and
     predict water and air outlet temperature in offdesign operation.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.heat_exchangers import heat_exchanger
+    >>> from tespy.components import sink, source, heat_exchanger
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -2204,8 +2201,7 @@ class condenser(heat_exchanger):
     Air is used to condensate water in a condenser. 1 kg/s waste steam is
     chilled with a terminal temperature difference of 15 K.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.heat_exchangers import condenser
+    >>> from tespy.components import sink, source, condenser
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p
@@ -2560,8 +2556,7 @@ class desuperheater(heat_exchanger):
     Overheated enthanol is cooled with water in a heat exchanger until it
     reaches the state of saturated gas.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.heat_exchangers import desuperheater
+    >>> from tespy.components import sink, source, desuperheater
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -146,7 +146,7 @@ class heat_exchanger_simple(component):
 
     >>> from tespy.components import sink, source, heat_exchanger_simple
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> fluids = ['N2']
     >>> nw = network(fluids=fluids)
@@ -903,7 +903,7 @@ class solar_collector(heat_exchanger_simple):
 
     >>> from tespy.components import sink, source, solar_collector
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> fluids = ['H2O']
     >>> nw = network(fluids=fluids)
@@ -1234,7 +1234,7 @@ class heat_exchanger(component):
 
     >>> from tespy.components import sink, source, heat_exchanger
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> nw = network(fluids=['water', 'air'], T_unit='C', p_unit='bar',
     ... h_unit='kJ / kg', iterinfo=False)
@@ -2203,7 +2203,7 @@ class condenser(heat_exchanger):
 
     >>> from tespy.components import sink, source, condenser
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p
     >>> import shutil
     >>> nw = network(fluids=['water', 'air'], T_unit='C', p_unit='bar',
@@ -2558,7 +2558,7 @@ class desuperheater(heat_exchanger):
 
     >>> from tespy.components import sink, source, desuperheater
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.fluid_properties import T_bp_p
     >>> import shutil
     >>> nw = network(fluids=['water', 'ethanol'], T_unit='C', p_unit='bar',

--- a/tespy/components/nodes.py
+++ b/tespy/components/nodes.py
@@ -105,7 +105,7 @@ class node(component):
 
     >>> from tespy.components import sink, source, node
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> import numpy as np
     >>> fluid_list = ['O2', 'N2']
@@ -560,7 +560,7 @@ class drum(component):
 
     >>> from tespy.components import sink, source, drum, pump, heat_exchanger
     >>> from tespy.connections import connection, ref
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> import numpy as np
     >>> nw = network(fluids=['NH3', 'air'], T_unit='C', p_unit='bar',
@@ -906,7 +906,7 @@ class merge(node):
 
     >>> from tespy.components import sink, source, merge
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> import numpy as np
     >>> fluid_list = ['O2', 'N2']
@@ -1125,7 +1125,7 @@ class separator(node):
 
     >>> from tespy.components import sink, source, separator
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> import numpy as np
     >>> fluid_list = ['O2', 'N2']
@@ -1349,7 +1349,7 @@ class splitter(node):
 
     >>> from tespy.components import sink, source, splitter
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> import numpy as np
     >>> fluid_list = ['O2', 'N2']

--- a/tespy/components/nodes.py
+++ b/tespy/components/nodes.py
@@ -103,8 +103,7 @@ class node(component):
     fractions and enthalpy). All outgoing fluids have the composition of the
     mixture at the mixtures enthalpy/temperature.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.nodes import node
+    >>> from tespy.components import sink, source, node
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -559,10 +558,7 @@ class drum(component):
     transported to an evaporator, the staturated gas phase is extracted from
     the drum. In this example ammonia is evaporated using ambient air.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.nodes import drum
-    >>> from tespy.components.turbomachinery import pump
-    >>> from tespy.components.heat_exchangers import heat_exchanger
+    >>> from tespy.components import sink, source, drum, pump, heat_exchanger
     >>> from tespy.connections import connection, ref
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -908,8 +904,7 @@ class merge(node):
     At the outlet, fluid composition and enthalpy are calculated by mass
     weighted fluid composition and enthalpy of the inlets.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.nodes import merge
+    >>> from tespy.components import sink, source, merge
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -1128,8 +1123,7 @@ class separator(node):
     number of different parts at identical pressure and temperature but
     different fluid composition. Fluids can be separated from each other.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.nodes import separator
+    >>> from tespy.components import sink, source, separator
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -1353,8 +1347,7 @@ class splitter(node):
     A splitter is used to split up a single mass flow into a specified number
     of different parts at identical pressure, enthalpy and fluid composition.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.nodes import splitter
+    >>> from tespy.components import sink, source, splitter
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil

--- a/tespy/components/piping.py
+++ b/tespy/components/piping.py
@@ -132,7 +132,7 @@ class pipe(heat_exchanger_simple):
 
     >>> from tespy.components import sink, source, pipe
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> fluid_list = ['ethanol']
     >>> nw = network(fluids=fluid_list)
@@ -226,7 +226,7 @@ class valve(component):
 
     >>> from tespy.components import sink, source, valve
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> fluid_list = ['CH4']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',

--- a/tespy/components/piping.py
+++ b/tespy/components/piping.py
@@ -130,8 +130,7 @@ class pipe(heat_exchanger_simple):
     the required diameter, we can predict pressure loss at a different mass
     flow through the pipeline.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.piping import pipe
+    >>> from tespy.components import sink, source, pipe
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -225,8 +224,7 @@ class valve(component):
     valve. The inlet temperature is at 50 °C. It is possible to determine the
     outlet temperature as the throttling does not change enthalpy.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.piping import valve
+    >>> from tespy.components import sink, source, valve
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil

--- a/tespy/components/reactors.py
+++ b/tespy/components/reactors.py
@@ -155,7 +155,7 @@ class water_electrolyzer(component):
     >>> from tespy.components import (sink, source, compressor,
     ... water_electrolyzer)
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.data_containers import dc_cc
     >>> import shutil
     >>> fluid_list = ['O2', 'H2O', 'H2']

--- a/tespy/components/reactors.py
+++ b/tespy/components/reactors.py
@@ -152,9 +152,8 @@ class water_electrolyzer(component):
     Create a water electrolyzer and compress the hydrogen, e. g. for a hydrogen
     storage.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.turbomachinery import compressor
-    >>> from tespy.components.reactors import water_electrolyzer
+    >>> from tespy.components import (sink, source, compressor,
+    ... water_electrolyzer)
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> from tespy.tools.data_containers import dc_cc

--- a/tespy/components/subsystems.py
+++ b/tespy/components/subsystems.py
@@ -50,7 +50,7 @@ class subsystem:
     Basic example for a setting up a tespy.components.subsystems.subsystem
     object. This example does not run a tespy calculation!
 
-    >>> from tespy.components.subsystems import subsystem
+    >>> from tespy.components import subsystem
     >>> mysub = subsystem('mySubsystem')
     >>> type(mysub)
     <class 'tespy.components.subsystems.subsystem'>

--- a/tespy/components/turbomachinery.py
+++ b/tespy/components/turbomachinery.py
@@ -438,7 +438,7 @@ class compressor(turbomachine):
 
     >>> from tespy.components import sink, source, compressor
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> import shutil
     >>> fluid_list = ['air']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
@@ -951,7 +951,7 @@ class pump(turbomachine):
 
     >>> from tespy.components import sink, source, pump
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.data_containers import dc_cc
     >>> import shutil
     >>> fluid_list = ['water']
@@ -1382,7 +1382,7 @@ class turbine(turbomachine):
 
     >>> from tespy.components import sink, source, turbine
     >>> from tespy.connections import connection
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.data_containers import dc_cc
     >>> import shutil
     >>> fluid_list = ['water']

--- a/tespy/components/turbomachinery.py
+++ b/tespy/components/turbomachinery.py
@@ -436,8 +436,7 @@ class compressor(turbomachine):
     map how does the efficiency change in different operation mode (e. g. 90 %
     of nominal volumetric flow)?
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.turbomachinery import compressor
+    >>> from tespy.components import sink, source, compressor
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> import shutil
@@ -950,8 +949,7 @@ class pump(turbomachine):
     given isentropic efficiency it is possible to calculate power consumption
     and pressure at the pump.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.turbomachinery import pump
+    >>> from tespy.components import sink, source, pump
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> from tespy.tools.data_containers import dc_cc
@@ -1382,8 +1380,7 @@ class turbine(turbomachine):
     to 0,5 bar at the outlet. For example, it is possible to calulate the power
     output and vapour content at the outlet for a given isentropic efficiency.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.turbomachinery import turbine
+    >>> from tespy.components import sink, source, turbine
     >>> from tespy.connections import connection
     >>> from tespy.networks.networks import network
     >>> from tespy.tools.data_containers import dc_cc

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -114,7 +114,7 @@ class connection:
     create the required components and connect them in the next step. After
     that, it is possible specify parameters with the :code:`set_attr` method.
 
-    >>> from tespy.components.basics import sink, source
+    >>> from tespy.components import sink, source
     >>> from tespy.connections import connection, ref
     >>> from tespy.tools.data_containers import dc_flu, dc_prop
     >>> import numpy as np
@@ -567,13 +567,10 @@ class bus:
     busses for heat output, thermal input and electricity output are
     implementd.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.combustion import combustion_engine
-    >>> from tespy.components.heat_exchangers import heat_exchanger
-    >>> from tespy.components.nodes import merge, splitter
-    >>> from tespy.components.turbomachinery import pump
+    >>> from tespy.components import (sink, source, combustion_engine,
+    ... heat_exchanger, merge, splitter, pump)
     >>> from tespy.connections import connection, ref, bus
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> from tespy.tools.characteristics import characteristics
     >>> import numpy as np
     >>> import shutil

--- a/tespy/networks/__init__.py
+++ b/tespy/networks/__init__.py
@@ -1,1 +1,3 @@
 # -*- coding: utf-8
+from tespy.networks.network_reader import load_network
+from tespy.networks.networks import network

--- a/tespy/networks/network_reader.py
+++ b/tespy/networks/network_reader.py
@@ -62,7 +62,7 @@ target_classes = {
 # %% network loading
 
 
-def load_nwk(path):
+def load_network(path):
     r"""
     Load a network from a base path.
 
@@ -114,12 +114,10 @@ def load_nwk(path):
     example setup is simple gas turbine setup with compressor, combustion
     chamber and turbine.
 
-    >>> from tespy.components.basics import sink, source
-    >>> from tespy.components.combustion import combustion_chamber
-    >>> from tespy.components.turbomachinery import compressor, turbine
+    >>> from tespy.components import (sink, source, combustion_chamber,
+    ... compressor, turbine)
     >>> from tespy.connections import connection, ref
-    >>> from tespy.networks.network_reader import load_nwk
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import load_network, network
     >>> import shutil
     >>> fluid_list = ['CH4', 'O2', 'N2', 'CO2', 'H2O', 'Ar']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
@@ -183,7 +181,7 @@ def load_nwk(path):
     network and recalculate. Check if the results match with the previous
     calculation in design and offdesign case.
 
-    >>> imported_nwk = load_nwk('exported_nwk')
+    >>> imported_nwk = load_network('exported_nwk')
     >>> imported_nwk.set_attr(iterinfo=False)
     >>> imported_nwk.solve('design')
     >>> round(imported_nwk.imp_comps['turbine'].eta_s.val, 3)

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -106,7 +106,7 @@ class network:
     progress to the console. You can suop the printouts by setting this
     property to false.
 
-    >>> from tespy.networks.networks import network
+    >>> from tespy.networks import network
     >>> fluid_list = ['water', 'air', 'R134a']
     >>> mynetwork = network(fluids=fluid_list, p_unit='bar', T_unit='C')
     >>> mynetwork.set_attr(p_range=[1, 10])

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -6,7 +6,7 @@ from tespy.connections import connection, bus, ref
 from tespy.components import (basics, combustion, components, heat_exchangers,
                               nodes, piping, reactors, subsystems,
                               turbomachinery)
-from tespy.networks.network_reader import load_nwk
+from tespy.networks.network_reader import load_network
 from tespy.networks.networks import network
 from tespy.tools.helpers import (TESPyComponentError, TESPyConnectionError,
                                  TESPyNetworkError)


### PR DESCRIPTION
I added shortcuts for tespy.components and tespy.networks imports, e. g.:

```
from tespy.components import sink, source, turbine, heat_exchanger
from tespy.networks import network, load_network
```
Note: The load_nwk method was renamed to load_network for clarity!