### PR TITLE
Add python 3.6 and 3.8 support for software tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
       python: 3.7
       dist: xenial
       sudo: true
-    - name: "python 3.8 on xenial Linux"
-      python: 3.8
-      dist: xenial
-      sudo: true
+#    - name: "python 3.8 on xenial Linux"
+#      python: 3.8
+#      dist: xenial
+#      sudo: true
 #    - name: "Python 3.7.2 on macOS"
 #      os: osx
 #      osx_image: xcode10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 
 matrix:
   include:
+    - name: "python 3.6 on xenial Linux"
+      python: 3.6
+      dist: xenial
+      sudo: true
     - name: "python 3.7 on xenial Linux"
       python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: python
 
 matrix:
   include:
-    - name: "python 3.5 on xenial Linux"
-      python: 3.5
-      dist: xenial
-      sudo: true
     - name: "python 3.7 on xenial Linux"
       python: 3.7
+      dist: xenial
+      sudo: true
+    - name: "python 3.8 on xenial Linux"
+      python: 3.8
       dist: xenial
       sudo: true
 #    - name: "Python 3.7.2 on macOS"

--- a/tespy/__init__.py
+++ b/tespy/__init__.py
@@ -8,7 +8,6 @@ from tespy.networks import (
     networks
     )
 
-
 # tespy connection imports
 from tespy import connections
 


### PR DESCRIPTION
Replace python 3.5 with 3.6 and add 3.8.