### PR TITLE
Remove deprecated fields for characteristics data containers

### DIFF
--- a/doc/whats_new/v0-2-1.rst
+++ b/doc/whats_new/v0-2-1.rst
@@ -6,6 +6,8 @@ New Features
 
 Documentation
 #############
+- Update the class documentations of component and connection classes
+(`PR #146 <https://github.com/oemof/tespy/pull/146>`_).
 
 Parameter renaming
 ##################
@@ -15,6 +17,12 @@ Testing
 
 Bug fixes
 #########
+- Prevent pandas 1.0.0 installation due to bug in the :code:`to_csv()` method
+  (bug will be fixed in
+  `PR #31513 <https://github.com/pandas-dev/pandas/pull/31513>`_ of pandas).
+  Additionally,the version requirements of third party packages have been
+  updated to prevent future bugs resulting from possible API changes
+  (`PR #146 <https://github.com/oemof/tespy/pull/146>`_).
 
 Other changes
 #############

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(name='TESPy',
       data_files=[('tespy/data', ['tespy/data/char_lines.json',
                                   'tespy/data/char_maps.json'])],
       python_requires='>=3',
-      install_requires=['CoolProp >= 6.0.0',
-                        'numpy >= 1.13.3',
-                        'pandas <= 1.0.0',
-                        'scipy >= 0.19.1',
-                        'tabulate >= 0.8.2'])
+      install_requires=['CoolProp >= 6.3.0',
+                        'numpy >= 1.16.2',
+                        'pandas < 1.0.0',
+                        'scipy >= 1.4.1',
+                        'tabulate >= 0.8.6'])

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(name='TESPy',
       python_requires='>=3',
       install_requires=['CoolProp >= 6.0.0',
                         'numpy >= 1.13.3',
-                        'pandas >= 0.19.2',
+                        'pandas <= 1.0.0',
                         'scipy >= 0.19.1',
                         'tabulate >= 0.8.2'])

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(name='TESPy',
       data_files=[('tespy/data', ['tespy/data/char_lines.json',
                                   'tespy/data/char_maps.json'])],
       python_requires='>=3',
-      install_requires=['CoolProp >= 6.3.0',
-                        'numpy >= 1.16.2',
-                        'pandas < 1.0.0',
-                        'scipy >= 1.4.1',
-                        'tabulate >= 0.8.6'])
+      install_requires=['CoolProp>=6,<7',
+                        'numpy>=1.13.3,<2',
+                        'pandas>=0.19.2,<1',
+                        'scipy>=0.19.1,<2',
+                        'tabulate>=0.8.2,<0.9'])

--- a/tespy/components/basics.py
+++ b/tespy/components/basics.py
@@ -51,6 +51,21 @@ class cycle_closer(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     Note
     ----
     This component can be used to close a cycle process. The system of
@@ -188,6 +203,21 @@ class sink(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     Example
     -------
     Create a sink and specify a label.
@@ -228,6 +258,21 @@ class source(component):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     Example
     -------
@@ -292,6 +337,21 @@ class subsystem_interface(component):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     num_inter : float/tespy.helpers.dc_simple
         Number of interfaces for subsystem.

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -2142,10 +2142,10 @@ class combustion_engine(combustion_chamber):
                 'pr2': dc_cp(max_val=1),
                 'zeta1': dc_cp(min_val=0),
                 'zeta2': dc_cp(min_val=0),
-                'tiP_char': dc_cc(method='TI'),
-                'Q1_char': dc_cc(method='Q1'),
-                'Q2_char': dc_cc(method='Q2'),
-                'Qloss_char': dc_cc(method='QLOSS'),
+                'tiP_char': dc_cc(),
+                'Q1_char': dc_cc(),
+                'Q2_char': dc_cc(),
+                'Qloss_char': dc_cc(),
                 'S': dc_simple()}
 
     @staticmethod

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -89,6 +89,21 @@ class combustion_chamber(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     lamb : float/tespy.helpers.dc_cp
         Actual oxygen to stoichiometric oxygen ratio, :math:`\lambda/1`.
 
@@ -1163,6 +1178,21 @@ class combustion_chamber_stoich(combustion_chamber):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     fuel : dict
         Fuel composition, e. g. :code:`{'CH4': 0.96, 'CO2': 0.04}`.
 
@@ -2005,6 +2035,21 @@ class combustion_engine(combustion_chamber):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     lamb : float/tespy.helpers.dc_cp
         Air to stoichiometric air ratio, :math:`\lambda/1`.

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -44,6 +44,18 @@ class component:
     design_path: str
         Path to the components design case.
 
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     **kwargs :
         See the class documentation of desired component for available
         keywords.

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -175,13 +175,10 @@ class component:
 
                 elif (isinstance(self.get_attr(key), dc_cc) or
                       isinstance(self.get_attr(key), dc_cm)):
-                    # value specification for characteristic lines
-                    if isinstance(kwargs[key], char_line):
-                        self.get_attr(key).func = kwargs[key]
-
-                    # value specification for characteristic maps
-                    elif (isinstance(kwargs[key], char_map) or
-                          isinstance(kwargs[key], compressor_map)):
+                    # value specification for characteristics
+                    if (isinstance(kwargs[key], char_line) or
+                            isinstance(kwargs[key], char_map) or
+                            isinstance(kwargs[key], compressor_map)):
                         self.get_attr(key).func = kwargs[key]
 
                     # invalid datatype for keyword

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -245,7 +245,7 @@ class component:
                     raise ValueError(msg)
 
             elif key == 'local_design' or key == 'local_offdesign':
-                logging.info(str(type(kwargs[key])))
+                logging.info(str(type(kwargs[key])) + ' ' + str(kwargs[key]))
                 if not isinstance(kwargs[key], bool):
                     msg = ('Please provide the parameter ' + key +
                            ' as boolean at component' + self.label + '.')

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -245,10 +245,9 @@ class component:
                     raise ValueError(msg)
 
             elif key == 'local_design' or key == 'local_offdesign':
-                logging.info(str(type(kwargs[key])) + ' ' + str(kwargs[key]))
                 if not isinstance(kwargs[key], bool):
                     msg = ('Please provide the parameter ' + key +
-                           ' as boolean at component' + self.label + '.')
+                           ' as boolean at component ' + self.label + '.')
                     logging.error(msg)
                     raise TypeError(msg)
 

--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -245,9 +245,10 @@ class component:
                     raise ValueError(msg)
 
             elif key == 'local_design' or key == 'local_offdesign':
+                logging.info(str(type(kwargs[key])))
                 if not isinstance(kwargs[key], bool):
-                    msg = ('Please provide the ' + key + ' as boolean '
-                           'at ' + self.label + '.')
+                    msg = ('Please provide the parameter ' + key +
+                           ' as boolean at component' + self.label + '.')
                     logging.error(msg)
                     raise TypeError(msg)
 

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -121,7 +121,7 @@ class heat_exchanger_simple(component):
     kA_char : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient, provide x and y
         values or use generic values (e. g. calculated from design case).
-        Standard method 'HE_COLD', Parameter 'm'.
+        Standard parameter 'm'.
 
     Tamb : float/tespy.helpers.dc_cp
         Ambient temperature, provide parameter in network's temperature
@@ -1211,12 +1211,12 @@ class heat_exchanger(component):
     kA_char1 : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient at hot side, provide
         x and y values or use generic values (e. g. calculated from design
-        case). Standard method 'HE_HOT', Parameter 'm'.
+        Standard parameter 'm'.
 
     kA_char2 : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient at cold side,
         provide x and y values or use generic values (e. g. calculated from
-        design case). Standard method 'HE_COLD', Parameter 'm'.
+        design case). Standard parameter 'm'.
 
     Note
     ----
@@ -2177,12 +2177,12 @@ class condenser(heat_exchanger):
     kA_char1 : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient at hot side, provide
         x and y values or use generic values (e. g. calculated from design
-        case). Standard method 'COND_HOT', Parameter 'm'.
+        case). Standard parameter 'm'.
 
     kA_char2 : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient at cold side,
         provide x and y values or use generic values (e. g. calculated from
-        design case). Standard method 'COND_COLD', Parameter 'm'.
+        design case). Standard parameter 'm'.
 
     subcooling : bool
         Enable/disable subcooling, default value: disabled.
@@ -2544,12 +2544,12 @@ class desuperheater(heat_exchanger):
     kA_char1 : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient at hot side, provide
         x and y values or use generic values (e. g. calculated from design
-        case). Standard method 'COND_HOT', Parameter 'm'.
+        case). Standard parameter 'm'.
 
     kA_char2 : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient at cold side,
         provide x and y values or use generic values (e. g. calculated from
-        design case). Standard method 'COND_COLD', Parameter 'm'.
+        design case). Standard parameter 'm'.
 
     Note
     ----

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -89,6 +89,21 @@ class heat_exchanger_simple(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
@@ -846,6 +861,21 @@ class solar_collector(heat_exchanger_simple):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
@@ -1185,6 +1215,21 @@ class heat_exchanger(component):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
@@ -2150,6 +2195,21 @@ class condenser(heat_exchanger):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
@@ -2514,6 +2574,21 @@ class desuperheater(heat_exchanger):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -89,10 +89,10 @@ class heat_exchanger_simple(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    Q : String/float/tespy.helpers.dc_cp
+    Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
-    pr : String/float/tespy.helpers.dc_cp
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`.
 
     zeta : str/float/tespy.helpers.dc_cp
@@ -109,7 +109,7 @@ class heat_exchanger_simple(component):
         Pipes roughness, :math:`ks/\text{m}` for darcy friction,
         :math:`ks/\text{1}` for hazen-williams equation.
 
-    hydro_group : String/tespy.helpers.dc_gcp
+    hydro_group : str/tespy.helpers.dc_gcp
         Parametergroup for pressure drop calculation based on pipes dimensions.
         Choose 'HW' for hazen-williams equation, else darcy friction factor is
         used.
@@ -118,10 +118,9 @@ class heat_exchanger_simple(component):
         Area independent heat transition coefficient,
         :math:`kA/\frac{\text{W}}{\text{K}}`.
 
-    kA_char : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient, provide x and y
-        values or use generic values (e. g. calculated from design case).
-        Standard parameter 'm'.
+    kA_char : tespy.helpers.dc_cc
+        Characteristic curve for heat transfer coefficient, provide
+        char_line as function :code:`func`. Standard parameter 'm'.
 
     Tamb : float/tespy.helpers.dc_cp
         Ambient temperature, provide parameter in network's temperature
@@ -847,10 +846,10 @@ class solar_collector(heat_exchanger_simple):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    Q : String/float/tespy.helpers.dc_cp
+    Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
-    pr : String/float/tespy.helpers.dc_cp
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`.
 
     zeta : str/float/tespy.helpers.dc_cp
@@ -867,7 +866,7 @@ class solar_collector(heat_exchanger_simple):
         Pipes roughness, :math:`ks/\text{m}` for darcy friction,
         :math:`ks/\text{1}` for hazen-williams equation.
 
-    hydro_group : String/tespy.helpers.dc_gcp
+    hydro_group : str/tespy.helpers.dc_gcp
         Parametergroup for pressure drop calculation based on pipes dimensions.
         Choose 'HW' for hazen-williams equation, else darcy friction factor is
         used.
@@ -1187,13 +1186,13 @@ class heat_exchanger(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    Q : String/float/tespy.helpers.dc_cp
+    Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
-    pr1 : String/float/tespy.helpers.dc_cp
+    pr1 : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio at hot side, :math:`pr/1`.
 
-    pr2 : String/float/tespy.helpers.dc_cp
+    pr2 : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio at cold side, :math:`pr/1`.
 
     zeta1 : str/float/tespy.helpers.dc_cp
@@ -1208,15 +1207,13 @@ class heat_exchanger(component):
         Area independent heat transition coefficient,
         :math:`kA/\frac{\text{W}}{\text{K}}`.
 
-    kA_char1 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at hot side, provide
-        x and y values or use generic values (e. g. calculated from design
-        Standard parameter 'm'.
+    kA_char1 : tespy.helpers.dc_cc
+        Characteristic curve for hot side heat transfer coefficient, provide
+        char_line as function :code:`func`. Standard parameter 'm'.
 
-    kA_char2 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at cold side,
-        provide x and y values or use generic values (e. g. calculated from
-        design case). Standard parameter 'm'.
+    kA_char2 : tespy.helpers.dc_cc
+        Characteristic curve for cold side heat transfer coefficient, provide
+        char_line as function :code:`func`. Standard parameter 'm'.
 
     Note
     ----
@@ -2153,13 +2150,13 @@ class condenser(heat_exchanger):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    Q : String/float/tespy.helpers.dc_cp
+    Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
-    pr1 : String/float/tespy.helpers.dc_cp
+    pr1 : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio at hot side, :math:`pr/1`.
 
-    pr2 : String/float/tespy.helpers.dc_cp
+    pr2 : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio at cold side, :math:`pr/1`.
 
     zeta1 : str/float/tespy.helpers.dc_cp
@@ -2174,15 +2171,13 @@ class condenser(heat_exchanger):
         Area independent heat transition coefficient,
         :math:`kA/\frac{\text{W}}{\text{K}}`.
 
-    kA_char1 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at hot side, provide
-        x and y values or use generic values (e. g. calculated from design
-        case). Standard parameter 'm'.
+    kA_char1 : tespy.helpers.dc_cc
+        Characteristic curve for hot side heat transfer coefficient, provide
+        char_line as function :code:`func`. Standard parameter 'm'.
 
-    kA_char2 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at cold side,
-        provide x and y values or use generic values (e. g. calculated from
-        design case). Standard parameter 'm'.
+    kA_char2 : tespy.helpers.dc_cc
+        Characteristic curve for cold side heat transfer coefficient, provide
+        char_line as function :code:`func`. Standard parameter 'm'.
 
     subcooling : bool
         Enable/disable subcooling, default value: disabled.
@@ -2520,13 +2515,13 @@ class desuperheater(heat_exchanger):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    Q : String/float/tespy.helpers.dc_cp
+    Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
-    pr1 : String/float/tespy.helpers.dc_cp
+    pr1 : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio at hot side, :math:`pr/1`.
 
-    pr2 : String/float/tespy.helpers.dc_cp
+    pr2 : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio at cold side, :math:`pr/1`.
 
     zeta1 : str/float/tespy.helpers.dc_cp
@@ -2541,15 +2536,13 @@ class desuperheater(heat_exchanger):
         Area independent heat transition coefficient,
         :math:`kA/\frac{\text{W}}{\text{K}}`.
 
-    kA_char1 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at hot side, provide
-        x and y values or use generic values (e. g. calculated from design
-        case). Standard parameter 'm'.
+    kA_char1 : tespy.helpers.dc_cc
+        Characteristic curve for hot side heat transfer coefficient, provide
+        char_line as function :code:`func`. Standard parameter 'm'.
 
-    kA_char2 : str/tespy.helpers.dc_cc
-        Characteristic curve for heat transfer coefficient at cold side,
-        provide x and y values or use generic values (e. g. calculated from
-        design case). Standard parameter 'm'.
+    kA_char2 : tespy.helpers.dc_cc
+        Characteristic curve for cold side heat transfer coefficient, provide
+        char_line as function :code:`func`. Standard parameter 'm'.
 
     Note
     ----

--- a/tespy/components/nodes.py
+++ b/tespy/components/nodes.py
@@ -75,6 +75,21 @@ class node(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     num_in : float/tespy.helpers.dc_simple
         Number of inlets for this component, default value: 2.
 
@@ -546,6 +561,21 @@ class drum(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     Note
     ----
     If you are using a drum in a network with multiple fluids, it is likely
@@ -914,6 +944,21 @@ class merge(node):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     num_in : float/tespy.helpers.dc_simple
         Number of inlets for this component, default value: 2.
 
@@ -1135,6 +1180,21 @@ class separator(node):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     num_out : float/tespy.helpers.dc_simple
         Number of outlets for this component, default value: 2.
@@ -1364,6 +1424,21 @@ class splitter(node):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     num_out : float/tespy.helpers.dc_simple
         Number of outlets for this component, default value: 2.

--- a/tespy/components/piping.py
+++ b/tespy/components/piping.py
@@ -108,7 +108,7 @@ class pipe(heat_exchanger_simple):
     kA_char : str/tespy.helpers.dc_cc
         Characteristic curve for heat transfer coefficient, provide x and y
         values or use generic values (e. g. calculated from design case).
-        Standard method 'HE_COLD', Parameter 'm'.
+        Standard parameter 'm'.
 
     Tamb : float/tespy.helpers.dc_cp
         Ambient temperature, provide parameter in network's temperature

--- a/tespy/components/piping.py
+++ b/tespy/components/piping.py
@@ -76,10 +76,25 @@ class pipe(heat_exchanger_simple):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    Q : String/float/tespy.helpers.dc_cp
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
+    Q : str/float/tespy.helpers.dc_cp
         Heat transfer, :math:`Q/\text{W}`.
 
-    pr : String/float/tespy.helpers.dc_cp
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`.
 
     zeta : str/float/tespy.helpers.dc_cp
@@ -215,7 +230,22 @@ class valve(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    pr : String/float/tespy.helpers.dc_cp
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`
 
     zeta : str/float/tespy.helpers.dc_cp

--- a/tespy/components/reactors.py
+++ b/tespy/components/reactors.py
@@ -224,7 +224,7 @@ class water_electrolyzer(component):
                 'e': dc_cp(),
                 'pr_c': dc_cp(max_val=1),
                 'zeta': dc_cp(min_val=0),
-                'eta_char': dc_cc(method='GENERIC'),
+                'eta_char': dc_cc(),
                 'S': dc_simple()}
 
     @staticmethod

--- a/tespy/components/turbomachinery.py
+++ b/tespy/components/turbomachinery.py
@@ -25,7 +25,7 @@ from tespy.components.components import component
 from tespy.tools.characteristics import load_default_char as ldc
 from tespy.tools.characteristics import compressor_map
 
-from tespy.tools.data_containers import dc_cc, dc_cp, dc_cm, dc_simple
+from tespy.tools.data_containers import dc_cc, dc_cm, dc_cp, dc_simple
 from tespy.tools.fluid_properties import (
         h_ps, s_ph, T_mix_ph, h_mix_ps, s_mix_ph, s_mix_pT, v_mix_ph,
         num_fluids, err)
@@ -81,18 +81,18 @@ class turbomachine(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    P : String/float/tespy.helpers.dc_cp
+    P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`
 
-    eta_s : String/float/tespy.helpers.dc_cp
+    eta_s : str/float/tespy.helpers.dc_cp
         Isentropic efficiency, :math:`\eta_s/1`
 
-    pr : String/float/tespy.helpers.dc_cp
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`
 
-    eta_s_char : str/tespy.helpers.dc_cc
-        Characteristic curve for isentropic efficiency, provide x and y values
-        or use generic values (e. g. calculated from design case).
+    eta_s_char : tespy.helpers.dc_cc
+        Characteristic curve for isentropic efficiency, provide char_line as
+        function :code:`func`.
 
     Example
     -------
@@ -413,23 +413,24 @@ class compressor(turbomachine):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    P : String/float/tespy.helpers.dc_cp
+    P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`
 
-    eta_s : String/float/tespy.helpers.dc_cp
+    eta_s : str/float/tespy.helpers.dc_cp
         Isentropic efficiency, :math:`\eta_s/1`
 
-    pr : String/float/tespy.helpers.dc_cp
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`
 
-    eta_s_char : str/tespy.helpers.dc_cc
-        Characteristic curve for isentropic efficiency, provide x and y values
-        or use generic values (e. g. calculated from design case).
+    eta_s_char : tespy.helpers.dc_cc
+        Characteristic curve for isentropic efficiency, provide char_line as
+        function :code:`func`.
 
-    char_map : str/tespy.helpers.dc_cm
+    char_map : tespy.helpers.dc_cm
         Characteristic map for pressure rise and isentropic efficiency vs.
         nondimensional mass flow, see
-        tespy.components.characteristics.compressor for further information.
+        tespy.tools.characteristics.compressor_map for further information.
+        Provide a compressor_map as function :code:`func`.
 
     igva : str/float/tespy.helpers.dc_cp
         Inlet guide vane angle, :math:`igva/^\circ`.
@@ -927,23 +928,23 @@ class pump(turbomachine):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    P : String/float/tespy.helpers.dc_cp
+    P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`
 
-    eta_s : String/float/tespy.helpers.dc_cp
+    eta_s : str/float/tespy.helpers.dc_cp
         Isentropic efficiency, :math:`\eta_s/1`
 
-    pr : String/float/tespy.helpers.dc_cp
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`
 
-    eta_s_char : str/tespy.helpers.dc_cc
-        Characteristic curve for isentropic efficiency, provide x and y values
-        or use generic values (e. g. calculated from design case).
+    eta_s_char : tespy.helpers.dc_cc
+        Characteristic curve for isentropic efficiency, provide char_line as
+        function :code:`func`.
 
-    flow_char : str/tespy.helpers.dc_cc
+    flow_char : tespy.helpers.dc_cc
         Characteristic curve for pressure rise vs. volumetric flow rate,
-        provide data: :math:`x/\frac{\text{m}^3}{\text{s}} \,
-        y/\text{Pa}`
+        provide char_line as function :code:`func`.
+        :math:`x/\frac{\text{m}^3}{\text{s}} \, y/\text{Pa}`.
 
     Example
     -------
@@ -1367,21 +1368,21 @@ class turbine(turbomachine):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
-    P : String/float/tespy.helpers.dc_cp
+    P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`
 
-    eta_s : String/float/tespy.helpers.dc_cp
+    eta_s : str/float/tespy.helpers.dc_cp
         Isentropic efficiency, :math:`\eta_s/1`
 
-    pr : String/float/tespy.helpers.dc_cp
+    pr : str/float/tespy.helpers.dc_cp
         Outlet to inlet pressure ratio, :math:`pr/1`
 
-    eta_s_char : str/tespy.helpers.dc_cc
-        Characteristic curve for isentropic efficiency, provide x and y values
-        or use generic values (e. g. calculated from design case).
+    eta_s_char : tespy.helpers.dc_cc
+        Characteristic curve for isentropic efficiency, provide char_line as
+        function :code:`func`.
 
-    cone : tespy.helpers.dc_cc
-        Characteristics for stodolas cone law.
+    cone : tespy.helpers.dc_simple
+        Apply Stodola's cone law.
 
     Example
     -------

--- a/tespy/components/turbomachinery.py
+++ b/tespy/components/turbomachinery.py
@@ -81,6 +81,21 @@ class turbomachine(component):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`
 
@@ -412,6 +427,21 @@ class compressor(turbomachine):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`
@@ -928,6 +958,21 @@ class pump(turbomachine):
     offdesign : list
         List containing offdesign parameters (stated as String).
 
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
+
     P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`
 
@@ -1367,6 +1412,21 @@ class turbine(turbomachine):
 
     offdesign : list
         List containing offdesign parameters (stated as String).
+
+    design_path: str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings: boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout: boolean
+        Include this component in the network's results printout.
 
     P : str/float/tespy.helpers.dc_cp
         Power, :math:`P/\text{W}`

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -93,6 +93,9 @@ class connection:
     local_design : boolean
         Treat this connection in design mode in an offdesign calculation.
 
+    printout: boolean
+        Include this connection in the network's results printout.
+
     Note
     ----
     - The fluid balance parameter applies a balancing of the fluid vector on
@@ -320,6 +323,9 @@ class connection:
 
         local_design : boolean
             Treat this connection in design mode in an offdesign calculation.
+
+        printout: boolean
+            Include this connection in the network's results printout.
 
         Note
         ----

--- a/tespy/tools/data_containers.py
+++ b/tespy/tools/data_containers.py
@@ -104,6 +104,12 @@ class data_container:
         for key in kwargs:
             if key in var.keys():
                 self.__dict__.update({key: kwargs[key]})
+            
+            else:
+                msg = ('Data container of type ' + self.__class__.__name__ +
+                       ' has no attribute ' + key + '.')
+                logging.error(msg)
+                raise KeyError(msg)
 
     def get_attr(self, key):
         r"""

--- a/tespy/tools/data_containers.py
+++ b/tespy/tools/data_containers.py
@@ -154,26 +154,9 @@ class dc_cc(data_container):
     is_set : boolean
         Should this equation be applied?, default: is_set=False.
 
-    method : str
-        Which default method for this characteristic function should be used?
-        default: method='default'.
-
     param : str
         Which parameter should be applied as the x value?
         default: method='default'.
-
-    x : numpy.array
-        Array for the x-values of the characteristic line, default x=None.
-
-    y : numpy.array
-        Array for the y-values of the characteristic line, default y=None.
-
-    Note
-    ----
-    If you do not specify x-values or y-values, default values according to the
-    specified method will be used. If you specify a method as well as x-values
-    and/or y-values, these will override the defaults values of the chosen
-    method.
     """
     @staticmethod
     def attr():
@@ -186,8 +169,7 @@ class dc_cc(data_container):
             Dictionary of available attributes (dictionary keys) with default
             values.
         """
-        return {'func': None, 'is_set': False, 'param': None,
-                'x': None, 'y': None}
+        return {'func': None, 'is_set': False, 'param': None}
 
 # %%
 
@@ -203,32 +185,9 @@ class dc_cm(data_container):
     is_set : boolean
         Should this equation be applied?, default: is_set=False.
 
-    method : str
-        Which default method for this characteristic function should be used?
-        default: method='default'.
-
     param : str
         Which parameter should be applied as the x value?
         default: method='default'.
-
-    x : numpy.array
-        Array for the x-values of the characteristic line, default x=None.
-
-    y : numpy.array
-        Array for the y-values of the characteristic line, default y=None.
-
-    z1 : numpy.array
-        Array for the y-values of the characteristic line, default y=None.
-
-    z2 : numpy.array
-        Array for the y-values of the characteristic line, default y=None.
-
-    Note
-    ----
-    If you do not specify any interpolation points (x, y, z1, z2), default
-    values according to the specified method will be used. If you specify a
-    method as well as interpolation points, these will override the defaults
-    values of the chosen method.
     """
     @staticmethod
     def attr():
@@ -241,8 +200,7 @@ class dc_cm(data_container):
             Dictionary of available attributes (dictionary keys) with default
             values.
         """
-        return {'func': None, 'is_set': False, 'param': None,
-                'x': None, 'y': None, 'z1': None, 'z2': None}
+        return {'func': None, 'is_set': False, 'param': None}
 
 # %%
 

--- a/tespy/tools/data_containers.py
+++ b/tespy/tools/data_containers.py
@@ -59,7 +59,7 @@ class data_container:
     >>> from tespy.components.piping import pipe
     >>> type(dc_cm(is_set=True))
     <class 'tespy.tools.data_containers.dc_cm'>
-    >>> type(dc_cc(x=[1, 2, 3, 4], y=[1, 4, 9, 16], is_set=True))
+    >>> type(dc_cc(is_set=True, param='m'))
     <class 'tespy.tools.data_containers.dc_cc'>
     >>> type(dc_cp(val=100, is_set=True, is_var=True, printout=True,
     ...      max_val=1000, min_val=1))

--- a/tespy/tools/data_containers.py
+++ b/tespy/tools/data_containers.py
@@ -104,7 +104,7 @@ class data_container:
         for key in kwargs:
             if key in var.keys():
                 self.__dict__.update({key: kwargs[key]})
-            
+
             else:
                 msg = ('Data container of type ' + self.__class__.__name__ +
                        ' has no attribute ' + key + '.')

--- a/tests/component_tests/turbomachinery_tests.py
+++ b/tests/component_tests/turbomachinery_tests.py
@@ -99,7 +99,7 @@ class turbomachinery_tests:
         # test parameter specification for eta_s_char with unset char map
         instance.set_attr(eta_s_char=dc_cc(func=ldc(
             'compressor', 'eta_s_char', 'DEFAULT', char_line),
-            is_set=True))
+            is_set=True, param='m'))
         instance.char_map.is_set = False
         self.nw.solve('offdesign', design_path='tmp')
         msg = ('Value of isentropic efficiency must be ' + str(eta_s_d) +

--- a/tests/component_tests/turbomachinery_tests.py
+++ b/tests/component_tests/turbomachinery_tests.py
@@ -97,6 +97,9 @@ class turbomachinery_tests:
         self.c1.set_attr(v=1, T=100, m=np.nan)
 
         # test parameter specification for eta_s_char with unset char map
+        instance.set_attr(eta_s_char=dc_cc(func=ldc(
+            'compressor', 'eta_s_char', 'DEFAULT', char_line),
+            is_set=True))
         instance.char_map.is_set = False
         self.nw.solve('offdesign', design_path='tmp')
         msg = ('Value of isentropic efficiency must be ' + str(eta_s_d) +

--- a/tests/component_tests/turbomachinery_tests.py
+++ b/tests/component_tests/turbomachinery_tests.py
@@ -9,7 +9,8 @@ from tespy.connections import connection, bus, ref
 from tespy.networks.networks import network
 from tespy.tools.data_containers import dc_cc, dc_cm
 from tespy.tools.fluid_properties import s_mix_ph
-from tespy.tools.characteristics import char_line
+from tespy.tools.characteristics import char_line, compressor_map
+from tespy.tools.characteristics import load_default_char as ldc
 import numpy as np
 import shutil
 
@@ -61,8 +62,9 @@ class turbomachinery_tests:
         # remove pressure at outlet, use characteristic map for pressure
         # rise calculation
         self.c2.set_attr(p=np.nan)
-        instance.set_attr(char_map=dc_cm(method='GENERIC', is_set=True),
-                          eta_s=np.nan)
+        instance.set_attr(char_map=dc_cm(func=ldc(
+            'compressor', 'char_map', 'DEFAULT', compressor_map),
+            is_set=True), eta_s=np.nan)
 
         # offdesign test, efficiency value should be at design value
         self.nw.solve('offdesign', design_path='tmp')
@@ -94,9 +96,7 @@ class turbomachinery_tests:
         self.c2.set_attr(p=7)
         self.c1.set_attr(v=1, T=100, m=np.nan)
 
-        # test parameter specification for eta_s_char, unset char map
-        instance.set_attr(eta_s_char=dc_cc(method='GENERIC',
-                                           is_set=True, param='m'))
+        # test parameter specification for eta_s_char with unset char map
         instance.char_map.is_set = False
         self.nw.solve('offdesign', design_path='tmp')
         msg = ('Value of isentropic efficiency must be ' + str(eta_s_d) +
@@ -168,7 +168,9 @@ class turbomachinery_tests:
         char = dc_cc(func=char_line(x, y), is_set=True)
         # apply flow char and eta_s char
         instance.set_attr(flow_char=char, eta_s=np.nan,
-                          eta_s_char=dc_cc(method='GENERIC', is_set=True))
+                          eta_s_char=dc_cc(func=ldc('pump', 'eta_s_char',
+                                                    'DEFAULT', char_line),
+                                           is_set=True))
         self.nw.solve('offdesign', design_path='tmp')
 
         # value for difference pressure

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -620,7 +620,7 @@ def test_compressor_missing_char_parameter():
     c1 = connection(so, 'out1', instance, 'in1')
     c2 = connection(instance, 'out1', si, 'in1')
     nw.add_conns(c1, c2)
-    instance.set_attr(eta_s_char=dc_cc(method='GENERIC',
+    instance.set_attr(eta_s_char=dc_cc(func=char_line([0, 1], [1, 2]),
                                        is_set=True, param=None))
     nw.solve('design', init_only=True)
     instance.eta_s_char_func()
@@ -638,7 +638,7 @@ def test_turbine_missing_char_parameter():
     c1 = connection(so, 'out1', instance, 'in1')
     c2 = connection(instance, 'out1', si, 'in1')
     nw.add_conns(c1, c2)
-    instance.set_attr(eta_s_char=dc_cc(method='GENERIC',
+    instance.set_attr(eta_s_char=dc_cc(func=char_line([0, 1], [1, 2]),
                                        is_set=True, param=None))
     nw.solve('design', init_only=True)
     instance.eta_s_char_func()

--- a/tests/error_tests.py
+++ b/tests/error_tests.py
@@ -153,6 +153,7 @@ class specification_error_tests:
         self.create_ref_TypeError([self.comp, 1, 0])
 
         # KeyErrors
+        self.set_attr_KeyError(dc_cc(), x=7)
         self.set_attr_KeyError(self.comp, wow=5)
         self.set_attr_KeyError(self.conn, jey=5)
         self.set_attr_KeyError(self.bus, power_output=100000)


### PR DESCRIPTION
No warning/error is issued, when specifying x, y or x. y, z1 and z2 values for the datacontainers although these data are not used in any way.