### PR TITLE
Initialise calculation from previous calculation

### DIFF
--- a/doc/tespy_modules/networks.rst
+++ b/doc/tespy_modules/networks.rst
@@ -124,6 +124,8 @@ available keywords:
  * :code:`max_iter` is the maximum amount of iterations performed by the
    solver.
  * :code:`init_only` stop after initialisation (True/False).
+ * :code:`init_previous` use starting values from previous simulation
+   (True/False).
 
 There are two calculation modes available (:code:`'design'` and
 :code:`'offdesign'`), which are explained in the subsections below. If you
@@ -137,6 +139,11 @@ initialisation from priorly saved results will be skipped.
 :code:`init_only=True` usually is used for debugging. Or, you could use this
 feature to export a not solved network, if you want to do the parametrisation
 in .csv-files rather than your python script.
+
+The :code:`init_previous` parameter can be used in design and offdesign
+calculations and works very similar to specifying an :code:`init_path`.
+In contrast, starting values are taken from the previous calculation. Specifying
+the :code:`ìnit_path` overwrites :code:`init_previous`.
 
 Design mode
 +++++++++++
@@ -229,8 +236,9 @@ The initialisation is performed in the following steps.
 
  * fluid propagation.
  * fluid property initialisation.
- * initialisation from .csv (setting starting values from
-   :code:`init_path` argument).
+ * initialisation from previous simulation run (:code:`ìnit_previous`).
+ * initialisation from .csv (setting starting values from :code:`init_path`
+   argument).
 
 The network check is used to find errors in the network topology, the
 calulation can not start without a successful check. For components, a
@@ -261,9 +269,11 @@ starting value for the fluid at every point of the network.
     fluid property database can not find a value, because the fluid is 'nan'.
     Providing starting values manually can fix this problem.
 
-The fluid property initialisation takes the user specified starting values, if
-available, and otherwise uses generic starting values on the bases of which
-components the connection is linked to.
+If available, the fluid property initialisation uses the user specified starting
+values or the results from the previous simulation. Otherwise generic starting
+values are generated on basis of which components a connection is linked to.
+If you do not want to use the results of a previous calculation, you need to
+specify :code:`init_previous=False` on the :code:`network.solve` method call.
 
 Last step in starting value generation is the initialisation from a saved
 network structure. In order to initialise your calculation from the
@@ -280,8 +290,7 @@ file.
     network from the :code:`init_path`. Be aware that a change within the fluid
     vector does not alow this practice! If you plan to use additional fluids in
     parts of the network you have not touched until now, you will need to state
-    all fluids from the beginning. Generally, initialisation from a converged
-    calculation yields the best performance and is highly receommended.
+    all fluids from the beginning.
 
 
 Algorithm

--- a/doc/whats_new/v0-2-2.rst
+++ b/doc/whats_new/v0-2-2.rst
@@ -3,6 +3,12 @@ v0.2.2 - (someday in 2020)
 
 New Features
 ############
+- Allow initialisation for the primary variables from previous calculation.
+  Until now, the user needed to save the network's state and reload that state
+  for his next simulation. This feature is enabled as default. If you want to
+  disable this feature, you need to state
+  :code:`mynetwork.solve(..., init_previous=False)`
+  (`PR #156 <https://github.com/oemof/tespy/pull/156>`_).
 
 Documentation
 #############
@@ -20,6 +26,11 @@ Testing
 
 Bug fixes
 #########
+- Fix the bugged tests for compressor characteristic maps
+  (:py:meth:`tespy.components.turbomachinery.compressor.char_map_func`). The
+  pressure ratio factor of the lowest speedline available in the default data
+  ranges from about 0.2 to 0.5. Therefore the design pressure ratio should be
+  higher than 5 (`PR #156 <https://github.com/oemof/tespy/pull/156>`_).
 
 Other changes
 #############

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -986,7 +986,7 @@ class combustion_chamber(component):
 
         m = 0
         for i in inl:
-            if i.init_csv is False:
+            if i.good_starting_values is False:
                 if i.m.val_SI < 0 and not i.m.val_set:
                     i.m.val_SI = 0.01
                 m += i.m.val_SI
@@ -994,7 +994,7 @@ class combustion_chamber(component):
         ######################################################################
         # check fluid composition
         for o in outl:
-            if o.init_csv is False:
+            if o.good_starting_values is False:
                 fluids = [f for f in o.fluid.val.keys()
                           if not o.fluid.val_set[f]]
                 for f in fluids:
@@ -1031,7 +1031,7 @@ class combustion_chamber(component):
         ######################################################################
         # flue gas propagation
         for o in outl:
-            if o.init_csv is False:
+            if o.good_starting_values is False:
                 if o.m.val_SI < 0 and not o.m.val_set:
                     o.m.val_SI = 10
                 nw.init_target(o, o.t)
@@ -1045,7 +1045,7 @@ class combustion_chamber(component):
             # search fuel and air inlet
             for i in inl:
                 fuel_found = False
-                if i.init_csv is False:
+                if i.good_starting_values is False:
                     fuel = 0
                     for f in self.fuel_list:
                         fuel += i.fluid.val[f]

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -759,7 +759,6 @@ class combustion_chamber(component):
                 try:
                     flow = [0, p, 0, {self.h2o: 1}]
                     h_steam = h_mix_pQ(flow, 1)
-                    # CP.PropsSI('H', 'P', p, 'Q', 1, self.h2o)
                 except ValueError:
                     flow = [0, 615, 0, {self.h2o: 1}]
                     h_steam = h_mix_pQ(flow, 1)

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -381,7 +381,8 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equation for specified kA-group paremeters
         if self.kA_group.is_set:
-            self.vec_res[k] = self.kA_func()
+            if np.absolute(self.vec_res[k]) > err ** 2 or self.it % 4 == 0:
+                self.vec_res[k] = self.kA_func()
             k += 1
 
     def derivatives(self, vec_z):
@@ -1384,7 +1385,8 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified heat transfer coefficient
         if self.kA.is_set:
-            self.vec_res[k] = self.kA_func()
+            if np.absolute(self.vec_res[k]) > err ** 2 or self.it % 4 == 0:
+                self.vec_res[k] = self.kA_func()
             k += 1
 
         ######################################################################
@@ -1416,13 +1418,15 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified zeta at hot side
         if self.zeta1.is_set:
-            self.vec_res[k] = self.zeta_func(zeta='zeta1', conn=0)
+            if np.absolute(self.vec_res[k]) > err ** 2 or self.it % 4 == 0:
+                self.vec_res[k] = self.zeta_func(zeta='zeta1', conn=0)
             k += 1
 
         ######################################################################
         # equations for specified zeta at cold side
         if self.zeta2.is_set:
-            self.vec_res[k] = self.zeta_func(zeta='zeta2', conn=1)
+            if np.absolute(self.vec_res[k]) > err ** 2 or self.it % 4 == 0:
+                self.vec_res[k] = self.zeta_func(zeta='zeta2', conn=1)
             k += 1
 
         ######################################################################

--- a/tespy/components/turbomachinery.py
+++ b/tespy/components/turbomachinery.py
@@ -725,18 +725,16 @@ class compressor(turbomachine):
         """
         i, o = self.inl, self.outl
 
-        if o[0].init_csv is False:
-            if not o[0].p.val_set and o[0].p.val_SI < i[0].p.val_SI:
-                o[0].p.val_SI = o[0].p.val_SI * 2
+        if not o[0].p.val_set and o[0].p.val_SI < i[0].p.val_SI:
+            o[0].p.val_SI = o[0].p.val_SI * 1.1
 
-            if not o[0].h.val_set and o[0].h.val_SI < i[0].h.val_SI:
-                o[0].h.val_SI = o[0].h.val_SI * 1.1
+        if not o[0].h.val_set and o[0].h.val_SI < i[0].h.val_SI:
+            o[0].h.val_SI = o[0].h.val_SI * 1.1
 
-        if i[0].init_csv is False:
-            if not i[0].p.val_set and o[0].p.val_SI < i[0].p.val_SI:
-                i[0].p.val_SI = o[0].p.val_SI * 0.5
-            if not i[0].h.val_set and o[0].h.val_SI < i[0].h.val_SI:
-                i[0].h.val_SI = o[0].h.val_SI * 0.9
+        if not i[0].p.val_set and o[0].p.val_SI < i[0].p.val_SI:
+            i[0].p.val_SI = o[0].p.val_SI * 0.9
+        if not i[0].h.val_set and o[0].h.val_SI < i[0].h.val_SI:
+            i[0].h.val_SI = o[0].h.val_SI * 0.9
 
     @staticmethod
     def initialise_source(c, key):
@@ -1623,22 +1621,21 @@ class turbine(turbomachine):
         """
         i, o = self.inl, self.outl
 
-        if i[0].init_csv is False:
+        if i[0].good_starting_values is False:
             if i[0].p.val_SI <= 1e5 and not i[0].p.val_set:
                 i[0].p.val_SI = 1e5
 
             if i[0].h.val_SI < 10e5 and not i[0].h.val_set:
                 i[0].h.val_SI = 10e5
 
-        if o[0].init_csv is False:
-            if i[0].h.val_SI <= o[0].h.val_SI and not o[0].h.val_set:
-                o[0].h.val_SI = i[0].h.val_SI * 0.75
-
-            if i[0].p.val_SI <= o[0].p.val_SI and not o[0].p.val_set:
-                o[0].p.val_SI = i[0].p.val_SI / 2
-
             if o[0].h.val_SI < 5e5 and not o[0].h.val_set:
                 o[0].h.val_SI = 5e5
+
+        if i[0].h.val_SI <= o[0].h.val_SI and not o[0].h.val_set:
+            o[0].h.val_SI = i[0].h.val_SI * 0.9
+
+        if i[0].p.val_SI <= o[0].p.val_SI and not o[0].p.val_set:
+            o[0].p.val_SI = i[0].p.val_SI * 0.9
 
     @staticmethod
     def initialise_source(c, key):

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -1557,7 +1557,11 @@ class network:
             Maximum number of iterations before calculation stops, default: 50.
 
         init_only : boolean
-            Perform initialisation only? default: :code:`False`.
+            Perform initialisation only, default: :code:`False`.
+
+        init_previous : boolean
+            Initialise the calculation with values from the previous
+            calculation, default: :code:`True`.
 
         Note
         ----

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -1245,7 +1245,7 @@ class network:
                         outconn.good_starting_values is False):
                     outconn.fluid.val[fluid] = x
 
-            self.init_target(outc, start)
+            self.init_target(outconn, start)
 
         if isinstance(c.t, splitter):
             for outconn in self.comps.loc[c.t].o:
@@ -1312,14 +1312,14 @@ class network:
             inc['t'] = self.conns.t == c.s
             inc['t_id'] = self.conns.t_id == c.s_id.replace('out', 'in')
             conn, cid = inc['t'] == True, inc['t_id'] == True
-            inc = inc.index[conn & cid][0]
+            inconn = inc.index[conn & cid][0]
 
             for fluid, x in c.fluid.val.items():
                 if (inconn.fluid.val_set[fluid] is False and
                         inconn.good_starting_values is False):
                     inconn.fluid.val[fluid] = x
 
-            self.init_source(inc, start)
+            self.init_source(inconn, start)
 
         if isinstance(c.s, splitter):
             for inconn in self.comps.loc[c.s].i:

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -1886,14 +1886,14 @@ class network:
         i = 0
         for c in self.conns.index:
             # mass flow, pressure and enthalpy
-            if not c.m.val_set:
+            if c.m.val_set is False:
                 c.m.val_SI += self.vec_z[i * (self.num_conn_vars)]
-            if not c.p.val_set:
+            if c.p.val_set is False:
                 # this prevents negative pressures
                 relax = max(1, -self.vec_z[i * (self.num_conn_vars) + 1] /
                             (0.5 * c.p.val_SI))
                 c.p.val_SI += self.vec_z[i * (self.num_conn_vars) + 1] / relax
-            if not c.h.val_set:
+            if c.h.val_set is False:
                 c.h.val_SI += self.vec_z[i * (self.num_conn_vars) + 2]
 
             # fluid vector (only if number of fluids is greater than 1)
@@ -1901,7 +1901,7 @@ class network:
                 j = 0
                 for fluid in self.fluids:
                     # add increment
-                    if not c.fluid.val_set[fluid]:
+                    if c.fluid.val_set[fluid] is False:
                         c.fluid.val[fluid] += (
                                 self.vec_z[i * (self.num_conn_vars) + 3 + j])
 
@@ -2011,7 +2011,7 @@ class network:
                     c.h.val_SI = hmin * 1.05
                 logging.debug(self.property_range_message(c, 'h'))
             if c.h.val_SI > hmax and not c.h.val_set:
-                c.h.val_SI = hmax * 0.99
+                c.h.val_SI = hmax * 0.95
                 logging.debug(self.property_range_message(c, 'h'))
 
             if ((c.Td_bp.val_set is True or c.state.is_set is True) and

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -1238,18 +1238,20 @@ class network:
             outc['s'] = self.conns.s == c.t
             outc['s_id'] = self.conns.s_id == c.t_id.replace('in', 'out')
             conn, cid = outc['s'] == True, outc['s_id'] == True
-            outc = outc.index[conn & cid][0]
+            outconn = outc.index[conn & cid][0]
 
             for fluid, x in c.fluid.val.items():
-                if not outc.fluid.val_set[fluid]:
-                    outc.fluid.val[fluid] = x
+                if (outconn.fluid.val_set[fluid] is False and
+                        outconn.good_starting_values is False):
+                    outconn.fluid.val[fluid] = x
 
             self.init_target(outc, start)
 
         if isinstance(c.t, splitter):
             for outconn in self.comps.loc[c.t].o:
                 for fluid, x in c.fluid.val.items():
-                    if not outconn.fluid.val_set[fluid]:
+                    if (outconn.fluid.val_set[fluid] is False and
+                            outconn.good_starting_values is False):
                         outconn.fluid.val[fluid] = x
 
                 self.init_target(outconn, start)
@@ -1259,13 +1261,15 @@ class network:
                 outconn = self.comps.loc[c.t].o[0]
 
                 for fluid, x in c.fluid.val.items():
-                    if not outconn.fluid.val_set[fluid]:
+                    if (outconn.fluid.val_set[fluid] is False and
+                            outconn.good_starting_values is False):
                         outconn.fluid.val[fluid] = x
 
         if isinstance(c.t, combustion_engine):
             for outconn in self.comps.loc[c.t].o[:2]:
                 for fluid, x in c.fluid.val.items():
-                    if not outconn.fluid.val_set[fluid]:
+                    if (outconn.fluid.val_set[fluid] is False and
+                            outconn.good_starting_values is False):
                         outconn.fluid.val[fluid] = x
 
                 self.init_target(outconn, start)
@@ -1274,7 +1278,8 @@ class network:
             start = c.t
             for outconn in self.comps.loc[c.t].o:
                 for fluid, x in c.fluid.val.items():
-                    if not outconn.fluid.val_set[fluid]:
+                    if (outconn.fluid.val_set[fluid] is False and
+                            outconn.good_starting_values is False):
                         outconn.fluid.val[fluid] = x
 
                 self.init_target(outconn, start)
@@ -1310,15 +1315,17 @@ class network:
             inc = inc.index[conn & cid][0]
 
             for fluid, x in c.fluid.val.items():
-                if not inc.fluid.val_set[fluid]:
-                    inc.fluid.val[fluid] = x
+                if (inconn.fluid.val_set[fluid] is False and
+                        inconn.good_starting_values is False):
+                    inconn.fluid.val[fluid] = x
 
             self.init_source(inc, start)
 
         if isinstance(c.s, splitter):
             for inconn in self.comps.loc[c.s].i:
                 for fluid, x in c.fluid.val.items():
-                    if not inconn.fluid.val_set[fluid]:
+                    if (inconn.fluid.val_set[fluid] is False and
+                            inconn.good_starting_values is False):
                         inconn.fluid.val[fluid] = x
 
                 self.init_source(inconn, start)
@@ -1326,7 +1333,8 @@ class network:
         if isinstance(c.s, merge):
             for inconn in self.comps.loc[c.s].i:
                 for fluid, x in c.fluid.val.items():
-                    if not inconn.fluid.val_set[fluid]:
+                    if (inconn.fluid.val_set[fluid] is False and
+                            inconn.good_starting_values is False):
                         inconn.fluid.val[fluid] = x
 
                 self.init_source(inconn, start)
@@ -1334,7 +1342,8 @@ class network:
         if isinstance(c.s, combustion_engine):
             for inconn in self.comps.loc[c.s].i[:2]:
                 for fluid, x in c.fluid.val.items():
-                    if not inconn.fluid.val_set[fluid]:
+                    if (inconn.fluid.val_set[fluid] is False and
+                            inconn.good_starting_values is False):
                         inconn.fluid.val[fluid] = x
 
                 self.init_source(inconn, start)
@@ -1343,7 +1352,8 @@ class network:
             start = c.s
             for inconn in self.comps.loc[c.s].i:
                 for fluid, x in c.fluid.val.items():
-                    if not inconn.fluid.val_set[fluid]:
+                    if (inconn.fluid.val_set[fluid] is False and
+                            inconn.good_starting_values is False):
                         inconn.fluid.val[fluid] = x
 
                 self.init_source(inconn, start)

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -1360,6 +1360,8 @@ class network:
         """
         # fluid properties
         for c in self.conns.index:
+            if self.init_previous is False:
+                c.good_starting_values = False
             for key in ['m', 'p', 'h', 'T', 'x', 'v', 'Td_bp']:
                 if c.get_attr(key).unit_set is False and key != 'x':
                     if key == 'Td_bp':

--- a/tests/component_tests/turbomachinery_tests.py
+++ b/tests/component_tests/turbomachinery_tests.py
@@ -48,9 +48,9 @@ class turbomachinery_tests:
         self.setup_network(instance)
 
         # compress NH3, other fluids in network are for turbine, pump, ...
-        fl = {'N2': 0, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'NH3': 1}
-        self.c1.set_attr(fluid=fl, v=1, p=5, T=100)
-        self.c2.set_attr(p=7)
+        fl = {'N2': 1, 'O2': 0, 'Ar': 0, 'INCOMP::DowQ': 0, 'NH3': 0}
+        self.c1.set_attr(fluid=fl, v=1, p=1, T=5)
+        self.c2.set_attr(p=6)
         instance.set_attr(eta_s=0.8)
         self.nw.solve('design')
         convergence_check(self.nw.lin_dep)
@@ -91,9 +91,10 @@ class turbomachinery_tests:
 
         # move to highest available speedline, mass flow below lowest value
         # at that line
-        self.c1.set_attr(v=np.nan, m=self.c1.m.val * 0.8, T=30)
+        self.c1.set_attr(v=np.nan, m=self.c1.m.val * 0.8, T=-30)
         self.nw.solve('offdesign', design_path='tmp')
         convergence_check(self.nw.lin_dep)
+
         # should be value
         eta_s = eta_s_d * instance.char_map.func.z2[6, 0]
         msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
@@ -102,7 +103,7 @@ class turbomachinery_tests:
 
         # going below lowest available speedline, above highest mass flow at
         # that line
-        self.c1.set_attr(T=300)
+        self.c1.set_attr(T=175)
         self.nw.solve('offdesign', design_path='tmp', init_path='tmp')
         convergence_check(self.nw.lin_dep)
         # should be value
@@ -112,8 +113,8 @@ class turbomachinery_tests:
         eq_(round(eta_s, 4), round(instance.eta_s.val, 4), msg)
 
         # back to design properties, test eta_s_char
-        self.c2.set_attr(p=7)
-        self.c1.set_attr(v=1, T=100, m=np.nan)
+        self.c2.set_attr(p=6)
+        self.c1.set_attr(v=1, T=5, m=np.nan)
 
         # test parameter specification for eta_s_char with unset char map
         instance.set_attr(eta_s_char=dc_cc(func=ldc(
@@ -139,7 +140,7 @@ class turbomachinery_tests:
         # test parameter specification for pr
         instance.eta_s_char.set_attr(param='pr')
         self.c1.set_attr(v=1)
-        self.c2.set_attr(p=7.5)
+        self.c2.set_attr(p=6)
         self.nw.solve('offdesign', design_path='tmp')
         convergence_check(self.nw.lin_dep)
         expr = (self.c2.p.val_SI * self.c1.p.design /


### PR DESCRIPTION
This PR allows an initialisation from the previous calculation without saving the results and reloading them. This should save a considerable amount of time.

Additionally, the component test of the compressor regarding the compressor map was bugged (pressure ratio < 1 in some offdesign cases). This has been fixed. 