### PR TITLE
Fix warning logging: Avoid messages due to bad rounding

### DIFF
--- a/tespy/components/components.py
+++ b/tespy/components/components.py
@@ -554,14 +554,14 @@ class component:
         for p, data in self.variables.items():
             if isinstance(data, dc_cp):
                 val = self.get_attr(p).val
-                if val > data.max_val:
+                if round(val, 6) > data.max_val:
                     msg = ('Invalid value for ' + p + ': ' + p + ' = ' +
                            str(val) + ' above maximum value (' +
                            str(data.max_val) + ') at component ' +
                            self.label + '.')
                     logging.warning(msg)
 
-                elif val < data.min_val:
+                elif round(val, 6) < data.min_val:
                     msg = ('Invalid value for ' + p + ': ' + p + ' = ' +
                            str(val) + ' below minimum value (' +
                            str(data.min_val) + ') at component ' +


### PR DESCRIPTION
In the component parameter checks after calculation, warning messages are triggered, when the result is expected to be at the minimum or the maximum value but has floating point numbers at the very end. For example, if the pressure ratio of a valve is higher than 1 a warning is prompted. Specifying the value of 1 might yield an actual value of 1.0000000000000001 or similar. In this case no warning should be displayed.