### PR TITLE
Fix ZeroDivisionError in iteration speed calculation

### DIFF
--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -1886,7 +1886,7 @@ class network:
                            '+----------+----------+---------')
                 print(msg)
 
-            msg = (('Total iterations: ' + str(self.iter + 1) + ', '
+            msg = ('Total iterations: ' + str(self.iter + 1) + ', '
                    'Calculation time: ' +
                    str(round(self.end_time - self.start_time, 1)) + ' s, '
                    'Iterations per second: ')

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -1886,12 +1886,15 @@ class network:
                            '+----------+----------+---------')
                 print(msg)
 
-            msg = ('Total iterations: ' + str(self.iter + 1) + ', '
+            msg = (('Total iterations: ' + str(self.iter + 1) + ', '
                    'Calculation time: ' +
                    str(round(self.end_time - self.start_time, 1)) + ' s, '
-                   'Iterations per second: ' +
-                   str(round((self.iter + 1) /
-                             (self.end_time - self.start_time), 2)))
+                   'Iterations per second: ')
+            ips = 'inf'
+            if self.end_time != self.start_time:
+                ips = str(round(
+                    (self.iter + 1) / (self.end_time - self.start_time), 2))
+            msg += ips
             logging.debug(msg)
             if self.iterinfo:
                 print(msg)


### PR DESCRIPTION
Resolve #188 

This fix resolves ZeroDivisionErrors which occur in the calculation of iterations per second. When division by zero occurs the iterations per second are set to their limit of infinity.