### PR TITLE
Passing dictionaries as connection parameters may cause trouble

### DIFF
--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -379,10 +379,10 @@ class connection:
                     if isinstance(kwargs[key], dict):
                         # starting values
                         if key in self.variables0:
-                            self.fluid.set_attr(val0=kwargs[key])
+                            self.fluid.set_attr(val0=kwargs[key].copy())
                         # specified parameters
                         else:
-                            self.fluid.set_attr(val=kwargs[key])
+                            self.fluid.set_attr(val=kwargs[key].copy())
                             self.fluid.set_attr(
                                 val_set={f: True for f in kwargs[key].keys()})
 
@@ -946,7 +946,7 @@ class bus:
                         else:
                             msg = (
                                 'Char must be a number or a TESPy '
-                                'characteristics.')
+                                'characteristics char line.')
                             logging.error(msg)
                             raise TypeError(msg)
 
@@ -971,8 +971,9 @@ class bus:
                             raise ValueError(msg)
 
             else:
-                msg = ('Provide arguments as dicts. See the documentation of '
-                       'bus.add_comps() for more information.')
+                msg = (
+                    'Provide arguments as dictionaries. See the documentation '
+                    'of bus.add_comps() for more information.')
                 logging.error(msg)
                 raise TypeError(msg)
 


### PR DESCRIPTION
As manipulations to the values of a dictionary containing the fluid composition of connections are performed, somewhat unpredictable issues/behavior will appear, if the same dictionary is passed multiple times. To avoid this issue, the connection will receive copies of the dictionary instead.