### PR TITLE
Heat exchanger parameter adjusting: Rename kA to kA_char and add kA as independent parameter

### DIFF
--- a/doc/tespy_modules/components.rst
+++ b/doc/tespy_modules/components.rst
@@ -119,10 +119,16 @@ There are three components using parameter groups:
 - heat_exchanger_simple and pipe
     * :code:`hydro_group` (:code:`D`, :code:`L`, :code:`ks`)
     * :code:`kA_group` (:code:`kA`, :code:`Tamb`)
+    * :code:`kA_char_group` (:code:`kA_char`, :code:`Tamb`)
 - solar_collector
     * :code:`hydro_group` (:code:`D`, :code:`L`, :code:`ks`)
     * :code:`energy_group` (:code:`E`, :code:`eta_opt`, :code:`lkf_lin`,
       :code:`lkf_quad`, :code:`A`, :code:`Tamb`)
+- parabolic_trough
+    * :code:`hydro_group` (:code:`D`, :code:`L`, :code:`ks`)
+    * :code:`energy_group` (:code:`E`, :code:`eta_opt`, :code:`aoi`,
+      :code:`doc`, :code:`c_1`, :code:`c_2`, :code:`iam_1`, :code:`iam_2`,
+      :code:`A`, :code:`Tamb`)
 
 Custom variables
 ^^^^^^^^^^^^^^^^
@@ -181,33 +187,38 @@ your own characteristic functions.
 
     The characteristic function can be an auxiliary parameter of a different
     component property. This is the case for :code:`kA_char1`
-    and :code:`kA_char2` of heat exchangers, :code:`kA_char` of simple
-    heat exchangers and pipes as well as the characteristics of a combustion
-    engine: :code:`tiP_char`, :code:`Q1_char`, :code:`Q2_char`
+    and :code:`kA_char2` of heat exchangers as well as the characteristics of a
+    combustion engine: :code:`tiP_char`, :code:`Q1_char`, :code:`Q2_char`
     and :code:`Qloss_char`.
 
-    The characteristic function is an individual parameter of the component.
-    This is the case for all other components!
+    For all other components, the characteristic function is an individual
+    parameter of the component.
 
     **What does this mean?**
 
-    For the auxiliary functionality the main parameter,
-    e. g. :code:`kA` of a heat exchanger must be set :code:`.kA.is_set=True`.
+    For the auxiliary functionality the main parameter, e.g. :code:`kA_char`
+    of a heat exchanger must be set :code:`.kA_char.is_set=True`.
 
     For the other functionality the characteristics parameter must be
-    set e. g. :code:`.eta_s_char.is_set=True`.
+    set e.g. :code:`.eta_s_char.is_set=True`.
 
-For example, :code:`kA` specification for heat exchangers:
+For example, :code:`kA_char` specification for heat exchangers:
 
 .. code-block:: python
 
     from tespy.components import heat_exchanger
-    from tespy.tools import dc_cc
+    from tespy.tools import dc_cc, dc_cp
     from tespy.tools.characteristics import load_default_char as ldc
     from tespy.tools.characteristics import char_line
     import numpy as np
 
-    he = heat_exchanger('evaporator', kA=1e5)
+    he = heat_exchanger('evaporator')
+
+    # the characteristic function requires the design value of the property,
+    # therefore the design value of kA must be set and additonally we set
+    # the kA_char method. This is performed automatically, if you specify the
+    # kA_char as offdesign parameter (usual case).
+    he.set_attr(kA=dc_cp(design=1e5), kA_char=dc_simple(is_set=True))
 
     # use a characteristic line from the defaults: specify the component, the
     # parameter and the name of the characteristic function. Also, specify, what
@@ -216,10 +227,10 @@ For example, :code:`kA` specification for heat exchangers:
     kA_char2 = ldc('heat exchanger', 'kA_char2', 'EVAPORATING FLUID', char_line)
     he.set_attr(kA_char1=kA_char1, kA_char2=kA_char2)
 
-    # specification of a data container yields same result. It is aditionally
-    # possible to specify the characteristics parameter, mass flow in this case
-    # the specification parameters available are stated in the components
-    # class documentation
+    # specification of a data container yields the same result. It is
+    # aditionally possible to specify the characteristics parameter, mass flow
+    # in this case the specification parameters available are stated in the
+    # components class documentation
     he.set_attr(kA_char1=dc_cc(param='m', func=kA_char1),
                 kA_char2=dc_cc(param='m', func=kA_char2))
 
@@ -293,12 +304,12 @@ Characteristics are available for the following components and parameters:
     * :py:meth:`char_map <tespy.components.turbomachinery.compressor.char_map_func>`: component map for isentropic efficiency and pressure rise.
     * :py:meth:`eta_s_char <tespy.components.turbomachinery.compressor.eta_s_char_func>`: isentropic efficiency vs. pressure ratio.
 - heat exchangers:
-    * :py:meth:`kA1_char, kA2_char <tespy.components.heat_exchangers.heat_exchanger.kA_func>`: heat transfer coefficient vs. mass flow.
+    * :py:meth:`kA1_char, kA2_char <tespy.components.heat_exchangers.heat_exchanger.kA_char_func>`: heat transfer coefficient vs. mass flow.
 - pump
     * :py:meth:`eta_s_char <tespy.components.turbomachinery.pump.eta_s_char_func>`: isentropic efficiency vs. volumetric flow rate.
     * :py:meth:`flow_char <tespy.components.turbomachinery.pump.flow_char_func>`: pressure rise vs. volumetric flow.
 - simple heat exchangers
-    * :py:meth:`kA_char <tespy.components.heat_exchangers.heat_exchanger_simple.kA_func>`: heat transfer coefficient vs. mass flow.
+    * :py:meth:`kA_char <tespy.components.heat_exchangers.heat_exchanger_simple.kA_char_func>`: heat transfer coefficient vs. mass flow.
 - turbine
     * :py:meth:`eta_s_char <tespy.components.turbomachinery.turbine.eta_s_char_func>`: isentropic efficiency vs. isentropic enthalpy difference/pressure ratio/volumetric flow/mass flow.
 - valve

--- a/doc/whats_new/v0-3-0.rst
+++ b/doc/whats_new/v0-3-0.rst
@@ -97,6 +97,11 @@ Parameter renaming
 - Adding components to a bus now requires :code:`'comp'` instead of :code:`'c'`
   and :code:`'param'` instead of :code:`'p'`
   (`PR #157 <https://github.com/oemof/tespy/pull/157>`_).
+- The former parameter :code:`kA` has been renamed to :code:`kA_char` as the
+  behavior in offdesign was following a characteristic instead of a constant
+  value. Additionally a new parameter :code:`kA` has been implemented, which
+  represents a specified constant value for :code:`kA` in both design and
+  offdesign cases (`PR #199 <https://github.com/oemof/tespy/pull/199>`_).
 
 Testing
 #######

--- a/tespy/components/basics.py
+++ b/tespy/components/basics.py
@@ -109,8 +109,10 @@ class cycle_closer(component):
 
     @staticmethod
     def attr():
-        return {'mass_deviation': dc_cp(val=0, max_val=1e-3, printout=False),
-                'fluid_deviation': dc_cp(val=0, max_val=1e-5, printout=False)}
+        return {
+            'mass_deviation': dc_cp(val=0, max_val=1e-3, printout=False),
+            'fluid_deviation': dc_cp(val=0, max_val=1e-5, printout=False)
+        }
 
     @staticmethod
     def inlets():

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -168,9 +168,11 @@ class combustion_chamber(component):
 
     @staticmethod
     def attr():
-        return {'lamb': dc_cp(min_val=1),
-                'ti': dc_cp(min_val=0),
-                'S': dc_simple()}
+        return {
+            'lamb': dc_cp(min_val=1),
+            'ti': dc_cp(min_val=0),
+            'S': dc_simple()
+        }
 
     @staticmethod
     def inlets():

--- a/tespy/components/customs.py
+++ b/tespy/components/customs.py
@@ -222,15 +222,17 @@ class orc_evaporator(component):
 
     @staticmethod
     def attr():
-        return {'Q': dc_cp(max_val=0),
-                'pr1': dc_cp(max_val=1), 'pr2': dc_cp(max_val=1),
-                'pr3': dc_cp(max_val=1),
-                'zeta1': dc_cp(min_val=0), 'zeta2': dc_cp(min_val=0),
-                'zeta3': dc_cp(min_val=0),
-                'subcooling': dc_simple(val=False),
-                'overheating': dc_simple(val=False),
-                'SQ1': dc_simple(), 'SQ2': dc_simple(), 'SQ3': dc_simple(),
-                'Sirr': dc_simple()}
+        return {
+            'Q': dc_cp(max_val=0),
+            'pr1': dc_cp(max_val=1), 'pr2': dc_cp(max_val=1),
+            'pr3': dc_cp(max_val=1),
+            'zeta1': dc_cp(min_val=0), 'zeta2': dc_cp(min_val=0),
+            'zeta3': dc_cp(min_val=0),
+            'subcooling': dc_simple(val=False),
+            'overheating': dc_simple(val=False),
+            'SQ1': dc_simple(), 'SQ2': dc_simple(), 'SQ3': dc_simple(),
+            'Sirr': dc_simple()
+        }
 
     @staticmethod
     def inlets():

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -1181,6 +1181,8 @@ class parabolic_trough(heat_exchanger_simple):
                 self.jacobian[k, 1, 2] = self.numeric_deriv(f, 'h', 1)
             # custom variables for the energy-group
             for var in self.energy_group.elements:
+                if var == self.Tamb:
+                    continue
                 if var.is_var:
                     self.jacobian[k, 2 + var.var_pos, 0] = (
                         self.numeric_deriv(f, self.vars[var], 2))
@@ -1533,6 +1535,8 @@ class solar_collector(heat_exchanger_simple):
                 self.jacobian[k, 1, 2] = self.numeric_deriv(f, 'h', 1)
             # custom variables for the energy-group
             for var in self.energy_group.elements:
+                if var == self.Tamb:
+                    continue
                 if var.is_var:
                     self.jacobian[k, 2 + var.var_pos, 0] = (
                         self.numeric_deriv(f, self.vars[var], 2))

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -2123,13 +2123,9 @@ class heat_exchanger(component):
             .. math::
 
                 res = \dot{m}_{1,in} \cdot \left( h_{1,out} - h_{1,in}\right) +
-                kA \cdot f_{kA} \cdot \frac{T_{1,out} -
+                kA \cdot \frac{T_{1,out} -
                 T_{2,in} - T_{1,in} + T_{2,out}}
                 {\ln{\frac{T_{1,out} - T_{2,in}}{T_{1,in} - T_{2,out}}}}
-
-                f_{kA} = \frac{2}{
-                \frac{1}{f_1\left(\frac{m_1}{m_{1,ref}}\right)} +
-                \frac{1}{f_2\left(\frac{m_2}{m_{2,ref}}\right)}}
 
         Note
         ----
@@ -2198,6 +2194,9 @@ class heat_exchanger(component):
         o1 = self.outl[0].to_flow()
         o2 = self.outl[1].to_flow()
 
+        i1_d = self.inl[0].to_flow_design()
+        i2_d = self.inl[1].to_flow_design()
+
         T_i1 = T_mix_ph(i1, T0=self.inl[0].T.val_SI)
         T_i2 = T_mix_ph(i2, T0=self.inl[1].T.val_SI)
         T_o1 = T_mix_ph(o1, T0=self.outl[0].T.val_SI)
@@ -2214,15 +2213,11 @@ class heat_exchanger(component):
 
         fkA1 = 1
         if self.kA_char1.param == 'm':
-            if not np.isnan(i1_d[0]):
-                if not i1[0] == 0:
-                    fkA1 = self.kA_char1.func.evaluate(i1[0] / i1_d[0])
+            fkA1 = self.kA_char1.func.evaluate(i1[0] / i1_d[0])
 
         fkA2 = 1
         if self.kA_char2.param == 'm':
-            if not np.isnan(i2_d[0]):
-                if not i2[0] == 0:
-                    fkA2 = self.kA_char2.func.evaluate(i2[0] / i2_d[0])
+            fkA2 = self.kA_char2.func.evaluate(i2[0] / i2_d[0])
 
         fkA = 2 / (1 / fkA1 + 1 / fkA2)
 
@@ -2787,7 +2782,7 @@ class condenser(heat_exchanger):
             .. math::
 
                 res = \dot{m}_{1,in} \cdot \left( h_{1,out} - h_{1,in}\right) +
-                kA \cdot \cdot \frac{T_{1,out} -
+                kA \cdot \frac{T_{1,out} -
                 T_{2,in} - T_s \left(p_{1,in}\right) +
                 T_{2,out}}
                 {\ln{\frac{T_{1,out} - T_{2,in}}
@@ -2798,9 +2793,6 @@ class condenser(heat_exchanger):
         i2 = self.inl[1].to_flow()
         o1 = self.outl[0].to_flow()
         o2 = self.outl[1].to_flow()
-
-        i1_d = self.inl[0].to_flow_design()
-        i2_d = self.inl[1].to_flow_design()
 
         T_i1 = T_bp_p(i1)
         T_i2 = T_mix_ph(i2, T0=self.inl[1].T.val_SI)
@@ -2834,7 +2826,7 @@ class condenser(heat_exchanger):
             .. math::
 
                 res = \dot{m}_{1,in} \cdot \left( h_{1,out} - h_{1,in}\right) +
-                kA \cdot f_{kA} \cdot \frac{T_{1,out} -
+                kA_{ref} \cdot f_{kA} \cdot \frac{T_{1,out} -
                 T_{2,in} - T_s \left(p_{1,in}\right) +
                 T_{2,out}}
                 {\ln{\frac{T_{1,out} - T_{2,in}}
@@ -2879,13 +2871,11 @@ class condenser(heat_exchanger):
 
         fkA1 = 1
         if self.kA_char1.param == 'm':
-            if not np.isnan(i1_d[0]):
-                fkA1 = self.kA_char1.func.evaluate(i1[0] / i1_d[0])
+            fkA1 = self.kA_char1.func.evaluate(i1[0] / i1_d[0])
 
         fkA2 = 1
         if self.kA_char2.param == 'm':
-            if not np.isnan(i2_d[0]):
-                fkA2 = self.kA_char2.func.evaluate(i2[0] / i2_d[0])
+            fkA2 = self.kA_char2.func.evaluate(i2[0] / i2_d[0])
 
         fkA = 2 / (1 / fkA1 + 1 / fkA2)
 

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -232,8 +232,6 @@ class heat_exchanger_simple(component):
 
         self.Tamb.val_SI = ((self.Tamb.val + nw.T[nw.T_unit][0]) *
                             nw.T[nw.T_unit][1])
-        self.Tamb.design = ((self.Tamb.design + nw.T[nw.T_unit][0]) *
-                            nw.T[nw.T_unit][1])
 
         # parameters for hydro group
         self.hydro_group.set_attr(elements=[self.L, self.ks, self.D])

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -29,6 +29,7 @@ from tespy.tools.fluid_properties import (
         )
 from tespy.tools.global_vars import err
 from tespy.tools.helpers import lamb, single_fluid
+import warnings
 
 # %%
 

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -302,6 +302,16 @@ class heat_exchanger_simple(component):
             if var.is_set is True:
                 self.num_eq += 1
 
+        if self.kA.is_set:
+            msg = (
+                'The usage of the parameter kA has changed for offdesign '
+                'calculation. Specifying kA will keep a constant value for kA '
+                'in the calculation. If you want to use the value adaption of '
+                'kA by the characteristic line, please use kA_char as '
+                'parameter instead (occurred at ' + self.label + '). This '
+                'warning will disappear in TESPy version 0.3.2.')
+            warnings.warn(msg, FutureWarning, stacklevel=2)
+
         self.jacobian = np.zeros((
             self.num_eq,
             self.num_i + self.num_o + self.num_vars,
@@ -1803,6 +1813,16 @@ class heat_exchanger(component):
             if var.is_set is True:
                 self.num_eq += 1
 
+        if self.kA.is_set:
+            msg = (
+                'The usage of the parameter kA has changed for offdesign '
+                'calculation. Specifying kA will keep a constant value for kA '
+                'in the calculation. If you want to use the value adaption of '
+                'kA by the characteristic line, please use kA_char as '
+                'parameter instead (occurred at ' + self.label + '). This '
+                'warning will disappear in TESPy version 0.3.2.')
+            warnings.warn(msg, FutureWarning, stacklevel=2)
+
         self.jacobian = np.zeros((
             self.num_eq,
             self.num_i + self.num_o + self.num_vars,
@@ -2725,6 +2745,16 @@ class condenser(heat_exchanger):
             if var.is_set is True:
                 self.num_eq += 1
 
+        if self.kA.is_set:
+            msg = (
+                'The usage of the parameter kA has changed for offdesign '
+                'calculation. Specifying kA will keep a constant value for kA '
+                'in the calculation. If you want to use the value adaption of '
+                'kA by the characteristic line, please use kA_char as '
+                'parameter instead (occurred at ' + self.label + '). This '
+                'warning will disappear in TESPy version 0.3.2.')
+            warnings.warn(msg, FutureWarning, stacklevel=2)
+
         self.jacobian = np.zeros((
             self.num_eq,
             self.num_i + self.num_o + self.num_vars,
@@ -3082,6 +3112,16 @@ class desuperheater(heat_exchanger):
                     self.pr1, self.pr2, self.zeta1, self.zeta2]:
             if var.is_set is True:
                 self.num_eq += 1
+
+        if self.kA.is_set:
+            msg = (
+                'The usage of the parameter kA has changed for offdesign '
+                'calculation. Specifying kA will keep a constant value for kA '
+                'in the calculation. If you want to use the value adaption of '
+                'kA by the characteristic line, please use kA_char as '
+                'parameter instead (occurred at ' + self.label + '). This '
+                'warning will disappear in TESPy version 0.3.2.')
+            warnings.warn(msg, FutureWarning, stacklevel=2)
 
         self.jacobian = np.zeros((
             self.num_eq,

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -653,7 +653,7 @@ class heat_exchanger_simple(component):
                 \end{cases}
 
                 0 = \dot{m}_{in} \cdot \left( h_{out} - h_{in}\right) +
-                kA \cdot f_{kA} \cdot \frac{ttd_u - ttd_l}
+                kA_{ref} \cdot f_{kA} \cdot \frac{ttd_u - ttd_l}
                 {\ln{\frac{ttd_u}{ttd_l}}}
 
                 f_{kA} = \frac{2}{1 + \frac{1}

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -2145,9 +2145,6 @@ class heat_exchanger(component):
         o1 = self.outl[0].to_flow()
         o2 = self.outl[1].to_flow()
 
-        i1_d = self.inl[0].to_flow_design()
-        i2_d = self.inl[1].to_flow_design()
-
         T_i1 = T_mix_ph(i1, T0=self.inl[0].T.val_SI)
         T_i2 = T_mix_ph(i2, T0=self.inl[1].T.val_SI)
         T_o1 = T_mix_ph(o1, T0=self.outl[0].T.val_SI)
@@ -2200,9 +2197,6 @@ class heat_exchanger(component):
         i2 = self.inl[1].to_flow()
         o1 = self.outl[0].to_flow()
         o2 = self.outl[1].to_flow()
-
-        i1_d = self.inl[0].to_flow_design()
-        i2_d = self.inl[1].to_flow_design()
 
         T_i1 = T_mix_ph(i1, T0=self.inl[0].T.val_SI)
         T_i2 = T_mix_ph(i2, T0=self.inl[1].T.val_SI)

--- a/tespy/components/nodes.py
+++ b/tespy/components/nodes.py
@@ -937,7 +937,7 @@ class drum(component):
     ... char_line)
     >>> ev.set_attr(pr1=0.999, pr2=0.99, ttd_l=5, kA_char1=char1,
     ...     kA_char2=char2, design=['pr1', 'ttd_l'],
-    ...     offdesign=['zeta1', 'kA'])
+    ...     offdesign=['zeta1', 'kA_char'])
     >>> ev.set_attr(Q=-1e6)
     >>> erp.set_attr(eta_s=0.8)
     >>> f_dr.set_attr(p=5, T=-5)

--- a/tespy/components/nodes.py
+++ b/tespy/components/nodes.py
@@ -167,8 +167,7 @@ class node(component):
 
     @staticmethod
     def attr():
-        return {'num_in': dc_simple(),
-                'num_out': dc_simple()}
+        return {'num_in': dc_simple(), 'num_out': dc_simple()}
 
     def inlets(self):
         if self.num_in.is_set:
@@ -1313,8 +1312,7 @@ class merge(node):
 
     @staticmethod
     def attr():
-        return {'num_in': dc_simple(),
-                'zero_flag': dc_simple()}
+        return {'num_in': dc_simple()}
 
     def inlets(self):
         if self.num_in.is_set:

--- a/tespy/components/nodes.py
+++ b/tespy/components/nodes.py
@@ -949,11 +949,11 @@ class drum(component):
     >>> round(ev_amb.T.val - erp_ev.T.val ,1)
     5.0
     >>> round(f_dr.h.val, 1)
-    320.2
+    322.7
     >>> round(dr_erp.h.val, 1)
-    362.4
+    364.9
     >>> round(ev_dr.h.val, 1)
-    684.7
+    687.2
     >>> round(f_dr.m.val, 2)
     0.78
     >>> ev.set_attr(Q=-0.75e6)

--- a/tespy/components/piping.py
+++ b/tespy/components/piping.py
@@ -304,10 +304,11 @@ class valve(component):
 
     @staticmethod
     def attr():
-        return {'pr': dc_cp(min_val=1e-4, max_val=1),
-                'zeta': dc_cp(min_val=0),
-                'dp_char': dc_cc(param='m'),
-                'Sirr': dc_simple()}
+        return {
+            'pr': dc_cp(min_val=1e-4, max_val=1), 'zeta': dc_cp(min_val=0),
+            'dp_char': dc_cc(param='m'),
+            'Sirr': dc_simple()
+        }
 
     @staticmethod
     def inlets():

--- a/tespy/components/reactors.py
+++ b/tespy/components/reactors.py
@@ -232,14 +232,13 @@ class water_electrolyzer(component):
 
     @staticmethod
     def attr():
-        return {'P': dc_cp(min_val=0),
-                'Q': dc_cp(max_val=0),
-                'eta': dc_cp(min_val=0, max_val=1),
-                'e': dc_cp(),
-                'pr_c': dc_cp(max_val=1),
-                'zeta': dc_cp(min_val=0),
-                'eta_char': dc_cc(),
-                'S': dc_simple()}
+        return {
+            'P': dc_cp(min_val=0), 'Q': dc_cp(max_val=0),
+            'pr_c': dc_cp(max_val=1), 'zeta': dc_cp(min_val=0),
+            'eta': dc_cp(min_val=0, max_val=1), 'eta_char': dc_cc(),
+            'e': dc_cp(),
+            'S': dc_simple()
+        }
 
     @staticmethod
     def inlets():

--- a/tespy/components/turbomachinery.py
+++ b/tespy/components/turbomachinery.py
@@ -113,8 +113,7 @@ class turbomachine(component):
 
     @staticmethod
     def attr():
-        return {'P': dc_cp(), 'pr': dc_cp(),
-                'Sirr': dc_simple()}
+        return {'P': dc_cp(), 'pr': dc_cp(), 'Sirr': dc_simple()}
 
     @staticmethod
     def inlets():
@@ -444,13 +443,15 @@ class compressor(turbomachine):
 
     @staticmethod
     def attr():
-        return {'P': dc_cp(min_val=0),
-                'eta_s': dc_cp(min_val=0, max_val=1),
-                'pr': dc_cp(min_val=1),
-                'igva': dc_cp(min_val=-90, max_val=90, d=1e-3, val=0),
-                'char_map': dc_cm(),
-                'eta_s_char': dc_cc(param='m'),
-                'Sirr': dc_simple()}
+        return {
+            'P': dc_cp(min_val=0),
+            'eta_s': dc_cp(min_val=0, max_val=1),
+            'eta_s_char': dc_cc(param='m'),
+            'pr': dc_cp(min_val=1),
+            'igva': dc_cp(min_val=-90, max_val=90, d=1e-3, val=0),
+            'char_map': dc_cm(),
+            'Sirr': dc_simple()
+        }
 
     def comp_init(self, nw):
 
@@ -960,12 +961,13 @@ class pump(turbomachine):
 
     @staticmethod
     def attr():
-        return {'P': dc_cp(min_val=0),
-                'eta_s': dc_cp(min_val=0, max_val=1),
-                'pr': dc_cp(min_val=1),
-                'eta_s_char': dc_cc(),
-                'flow_char': dc_cc(),
-                'Sirr': dc_simple()}
+        return {
+            'P': dc_cp(min_val=0),
+            'eta_s': dc_cp(min_val=0, max_val=1), 'eta_s_char': dc_cc(),
+            'pr': dc_cp(min_val=1),
+            'flow_char': dc_cc(),
+            'Sirr': dc_simple()
+        }
 
     def comp_init(self, nw):
 
@@ -1390,12 +1392,14 @@ class turbine(turbomachine):
 
     @staticmethod
     def attr():
-        return {'P': dc_cp(max_val=0),
-                'eta_s': dc_cp(min_val=0, max_val=1),
-                'pr': dc_cp(min_val=0, max_val=1),
-                'eta_s_char': dc_cc(param='m'),
-                'cone': dc_simple(),
-                'Sirr': dc_simple()}
+        return {
+            'P': dc_cp(max_val=0),
+            'eta_s': dc_cp(min_val=0, max_val=1),
+            'eta_s_char': dc_cc(param='m'),
+            'pr': dc_cp(min_val=0, max_val=1),
+            'cone': dc_simple(),
+            'Sirr': dc_simple()
+        }
 
     def comp_init(self, nw):
 

--- a/tespy/connections.py
+++ b/tespy/connections.py
@@ -657,7 +657,7 @@ class bus:
     >>> chp.set_attr(pr1=0.99, lamb=1.0,
     ... design=['pr1'], offdesign=['zeta1'])
     >>> fgc.set_attr(pr1=0.999, pr2=0.98, design=['pr1', 'pr2'],
-    ... offdesign=['zeta1', 'zeta2', 'kA'])
+    ... offdesign=['zeta1', 'zeta2', 'kA_char'])
     >>> pu.set_attr(eta_s=0.8, design=['eta_s'], offdesign=['eta_s_char'])
     >>> amb_comb.set_attr(p=5, T=30, fluid={'Ar': 0.0129, 'N2': 0.7553,
     ... 'H2O': 0, 'CH4': 0, 'CO2': 0.0004, 'O2': 0.2314})

--- a/tests/test_components/test_heat_exchangers.py
+++ b/tests/test_components/test_heat_exchangers.py
@@ -322,7 +322,7 @@ class TestHeatExchangers:
         # design specification
         instance.set_attr(pr1=0.98, pr2=0.98, ttd_u=5,
                           design=['pr1', 'pr2', 'ttd_u'],
-                          offdesign=['zeta1', 'zeta2', 'kA'])
+                          offdesign=['zeta1', 'zeta2', 'kA_char'])
         self.c1.set_attr(T=120, p=3, fluid={'Ar': 0, 'H2O': 1, 'S800': 0})
         self.c2.set_attr(T=70)
         self.c3.set_attr(T=40, p=5, fluid={'Ar': 1, 'H2O': 0, 'S800': 0})
@@ -410,7 +410,7 @@ class TestHeatExchangers:
 
         # design specification
         instance.set_attr(pr1=0.98, pr2=0.98, ttd_u=5,
-                          offdesign=['zeta2', 'kA'])
+                          offdesign=['zeta2', 'kA_char'])
         self.c1.set_attr(T=100, p0=0.5, fluid={'Ar': 0, 'H2O': 1, 'S800': 0})
         self.c3.set_attr(T=30, p=5, fluid={'Ar': 0, 'H2O': 1, 'S800': 0})
         self.c4.set_attr(T=40)

--- a/tests/test_models/test_heat_pump_model.py
+++ b/tests/test_models/test_heat_pump_model.py
@@ -148,7 +148,7 @@ class TestHeatPump:
              0.9983, 0.9988, 0.9992, 0.9996, 0.9998, 1.0000, 1.0008, 1.0014])
         kA_char2 = dc_cc(func=char_line(x, y), param='m')
         ev.set_attr(
-            pr1=1, pr2=.999, ttd_l=5, design=['ttd_l'], offdesign=['kA'],
+            pr1=1, pr2=.999, ttd_l=5, design=['ttd_l'], offdesign=['kA_char'],
             kA_char1=kA_char1, kA_char2=kA_char2)
 
         # no kA modification for hot side!
@@ -163,7 +163,7 @@ class TestHeatPump:
             [0, 0.037, 0.112, 0.207, 0.5, 0.8, 0.85, 0.9, 0.95, 1, 1.04, 1.07])
         kA_char2 = dc_cc(func=char_line(x, y), param='m')
         su.set_attr(kA_char1=kA_char1, kA_char2=kA_char2,
-                    offdesign=['zeta1', 'zeta2', 'kA'])
+                    offdesign=['zeta1', 'zeta2', 'kA_char'])
 
         x = np.array(
             [0, 0.0625, 0.125, 0.1875, 0.25, 0.3125, 0.375, 0.4375, 0.5,
@@ -202,7 +202,7 @@ class TestHeatPump:
         kA_char2 = dc_cc(func=char_line(x, y), param='m')
 
         he.set_attr(kA_char1=kA_char1, kA_char2=kA_char2,
-                    offdesign=['zeta1', 'zeta2', 'kA'])
+                    offdesign=['zeta1', 'zeta2', 'kA_char'])
 
         # characteristic line for condenser kA
         x = np.linspace(0, 2.5, 26)
@@ -221,7 +221,7 @@ class TestHeatPump:
         kA_char2 = dc_cc(func=char_line(x, y), param='m')
 
         cd.set_attr(kA_char1=kA_char1, kA_char2=kA_char2, pr2=0.9998,
-                    design=['pr2'], offdesign=['zeta2', 'kA'])
+                    design=['pr2'], offdesign=['zeta2', 'kA_char'])
 
         # %% connection parametrization
         # condenser system


### PR DESCRIPTION
Using `kA` as offdesign parameter is counter-intuitive as it suggests a constant value for kA in offdesign. At the moment, this is not the case, instead, kA follows a characteristic line. Therefore, the parameter `kA` is renamed to `kA_char` and a new parameter `kA` is implemented. The new parameter `kA` will be constant in case it is an offdesign parameter. A warning will be printed to the user, that this behavior has changed.