### PR TITLE
Improve stability: Add minimum value restriction for temperature in fluid property functions

### DIFF
--- a/doc/tespy_modules/networks.rst
+++ b/doc/tespy_modules/networks.rst
@@ -416,8 +416,8 @@ three iteration steps of the algorithm only. In other cases this convergence
 check is skipped.
 
  * Fox mixtures: check, if the fluid properties (pressure, enthalpy and
-   temperature)
-   are within the user specified boundaries (:code:`p_range, h_range, T_range`)
+   mass flow)
+   are within the user specified boundaries (:code:`p_range, h_range, m_range`)
    and if not, cut off higher/lower values.
  * Check the fluid properties of the connections based on the components they
    are connecting. E. g. check if the pressure at the outlet of a turbine is

--- a/doc/tutorials_examples/tutorial_combustion_chamber.rst
+++ b/doc/tutorials_examples/tutorial_combustion_chamber.rst
@@ -32,11 +32,6 @@ First of all you need to define the network containing all fluid components
 used for the combustion chamber. **These are at least the fuel, oxygen,
 carbon-dioxide and water**. For this example we added Argon, and of course - as
 we are using Air for the combustion - Nitrogen.
-On top, it is highly recommended to specify reasonable ranges for the fluid
-properties. If you have fluid mixtures within your network, the fluid property
-ranges will keep your fluid properties within the specified ranges for the
-first three steps of the newton's algorithm in order to stabilize the
-calculation.
 
 .. code-block:: python
 
@@ -45,9 +40,8 @@ calculation.
     # define full fluid list for the network's variable space
     fluid_list = ['Ar', 'N2', 'O2', 'CO2', 'CH4', 'H2O']
 
-    # define unit systems and fluid property ranges
-    nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
-                 p_range=[0.5, 10], T_range=[10, 1200])
+    # define unit systems
+    nw = network(fluids=fluid_list, p_unit='bar', T_unit='C')
 
 As components there are two sources required, one for the fresh air, one for
 the fuel, a sink for the flue gas and the combustion chamber. Connect the
@@ -111,10 +105,10 @@ Of course, you can change the parametrisation in any desired way. For example
 instead of stating the thermal input, you could choose any of the mass flows,
 or instead of the air to stoichometric air ratio you could specify the flue
 gas temperature. It is also possible to make modifications on the fluid
-composition, for example stating the oxygen content in the flue gas. It is also
-possible to change the fuel composition. Make sure, all desired fuels of your
-fuel mixture are also within the fluid_list of the network. For the example
-below we added some hydrogen to the fuel mixture.
+composition, for example stating the oxygen content in the flue gas or to
+change the fuel composition. Make sure, all desired fuels of your fuel mixture
+are also within the fluid_list of the network. For the example below we added
+hydrogen to the fuel mixture.
 
 .. code-block:: python
 
@@ -125,8 +119,7 @@ below we added some hydrogen to the fuel mixture.
     # %% network
 
     fluid_list = ['Ar', 'N2', 'O2', 'CO2', 'CH4', 'H2O', 'H2']
-    nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
-                 p_range=[0.5, 10], T_range=[10, 1200])
+    nw = network(fluids=fluid_list, p_unit='bar', T_unit='C')
 
     # %% components
 
@@ -176,8 +169,8 @@ Again, the network must have the information, which fluids will be part of the
 fluid vector. In contrast to the normal combustion chamber, you will need the
 following fluids: **Air, Fuel and Flue Gas**. For this tutorial we will call
 them: **"myAir", "myFuel" and "myFuel_fg"**. Do not forget to specify the
-ranges for pressure and temperature. This is a very important step for this
-specific component, we will explain later, why it is.
+value range for pressure. This is a very important step for this specific
+component, we will explain later, why it is.
 
 .. code-block:: python
 
@@ -187,8 +180,7 @@ specific component, we will explain later, why it is.
     fluid_list = ['myAir', 'myFuel', 'myFuel_fg']
 
     # define unit systems and fluid property ranges
-    nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
-                 p_range=[1, 10], T_range=[10, 2000])
+    nw = network(fluids=fluid_list, p_unit='bar', T_unit='C', p_range=[1, 10])
 
 The components required are then the same as in the first tutorial, the
 stoichiometric combustion chamber's class is called
@@ -229,7 +221,7 @@ stoichiometric flue gas composition. The fluids will then be accessible with
 the following aliases: **"youraliasforair", "youraliasforfuel"
 and "youraliasforfuel_fg"**. The creation of the lookup tables will use
 your network's settings: **The fluid properties will be calculated within the
-network's specified ranges for pressure and temperature.**
+network's specified value range for pressure.**
 
 A folder called "LUT" will be created in your working directory containing all
 fluid property lookup tables. As the creation of the lookup tables does take
@@ -241,12 +233,9 @@ properties from path:
 
 - **Do not specify the path in case**
 
-    - you change the pressure range or the temperature range or
+    - you change the pressure range
     - you change the air or the fuel composition.
 
-- **For convergence stability choose large maximum temperatures**, much higher
-  than the highest temperature you are expecting at the combustion chambers
-  outlet.
 - **If you use more than one combustion chamber** do not use identical aliases,
   if the fluid compositions are not identical.
 

--- a/doc/whats_new/v0-3-0.rst
+++ b/doc/whats_new/v0-3-0.rst
@@ -124,12 +124,22 @@ Bug fixes
 - Fix the default characteristic line for compressor isentropic efficiency: The
   line did not have an intersection with the point 1/1
   (`PR #196 <https://github.com/oemof/tespy/pull/196>`_).
+- If a temperature value of a mixture was not found within the maximum number
+  of newton iterations in the :py:mod:`tespy.tools.fluid_properties` module,
+  the wrong value was still displayed in the output without a warning. In this
+  case, the value will be :code:`nan` in the future and a warning message is
+  displayed (`PR #200 <https://github.com/oemof/tespy/pull/200>`_).
 
 Other changes
 #############
 - Improve naming in networks, components and connections modules
   (`PR #172 <https://github.com/oemof/tespy/pull/172>`_,
   `PR #175 <https://github.com/oemof/tespy/pull/175>`_).
+- The Parameter :code:`T_range` of networks is deprecated. The fluid property
+  calls for mixtures have been modified to prevent errors when the temperature
+  of the mixture is below the minimum or above the maximum temperature limit of
+  a component of the mixture
+  (`PR #200 <https://github.com/oemof/tespy/pull/200>`_).
 
 Changes in the API
 ##################

--- a/doc/whats_new/v0-3-0.rst
+++ b/doc/whats_new/v0-3-0.rst
@@ -184,7 +184,7 @@ which has been used until version 0.2.x in TESPy.
         "T_unit": "C",
         "h_unit": "kJ / kg",
         "m_unit": "kg / s",
-        "T_range": [150, 200]
+        "h_range": [150, 3000]
     }
 
 Due to the addition of the CoolProp back end selection the

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -118,9 +118,8 @@ class combustion_chamber(component):
     -------
     The combustion chamber calculates energy input due to combustion as well as
     the flue gas composition based on the type of fuel and the amount of
-    oxygen supplied. Using the parameters p_range and T_range is recommended
-    when using combustion, as these stabilize the calculation. In this example
-    a mixture of methane, hydrogen and carbondioxide is used as fuel.
+    oxygen supplied. In this example a mixture of methane, hydrogen and
+    carbondioxide is used as fuel.
 
     >>> from tespy.components import sink, source, combustion_chamber
     >>> from tespy.connections import connection
@@ -129,7 +128,7 @@ class combustion_chamber(component):
     >>> import shutil
     >>> fluid_list = ['Ar', 'N2', 'H2', 'O2', 'CO2', 'CH4', 'H2O']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
-    ... p_range=[0.5, 10], T_range=[10, 1200], iterinfo=False)
+    ... iterinfo=False)
     >>> amb = source('ambient air')
     >>> sf = source('fuel')
     >>> fg = sink('flue gas outlet')
@@ -2098,10 +2097,9 @@ class combustion_engine(combustion_chamber):
     -------
     The combustion chamber calculates energy input due to combustion as well as
     the flue gas composition based on the type of fuel and the amount of
-    oxygen supplied. Using the parameters p_range and T_range is recommended
-    when using combustion, as these stabilize the calculation. In this example
-    a mixture of methane, hydrogen and carbondioxide is used as fuel. There are
-    two cooling ports, the cooling water will flow through them in parallel.
+    oxygen supplied. In this example a mixture of methane, hydrogen and
+    carbondioxide is used as fuel. There are two cooling ports, the cooling
+    water will flow through them in parallel.
 
     >>> from tespy.components import (sink, source, combustion_engine, merge,
     ... splitter)
@@ -2111,7 +2109,7 @@ class combustion_engine(combustion_chamber):
     >>> import shutil
     >>> fluid_list = ['Ar', 'N2', 'O2', 'CO2', 'CH4', 'H2O']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
-    ... p_range=[0.5, 10], T_range=[10, 1200], iterinfo=False)
+    ... iterinfo=False)
     >>> amb = source('ambient')
     >>> sf = source('fuel')
     >>> fg = sink('flue gas outlet')

--- a/tespy/components/combustion.py
+++ b/tespy/components/combustion.py
@@ -1261,7 +1261,7 @@ class combustion_chamber_stoich(combustion_chamber):
     >>> import shutil
     >>> fluid_list = ['myAir', 'myFuel', 'myFuel_fg']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
-    ... p_range=[0.001, 10], T_range=[10, 2000], iterinfo=False)
+    ... p_range=[1, 10], iterinfo=False)
     >>> amb = source('ambient air')
     >>> sf = source('fuel')
     >>> fg = sink('flue gas outlet')
@@ -1289,12 +1289,12 @@ class combustion_chamber_stoich(combustion_chamber):
     >>> comb_fg.set_attr(T=1200)
     >>> nw.solve('design')
     >>> round(comb.lamb.val, 3)
-    2.016
+    2.015
     >>> comb.set_attr(lamb=2)
     >>> comb_fg.set_attr(T=np.nan)
     >>> nw.solve('design')
     >>> round(comb_fg.T.val, 1)
-    1207.9
+    1207.1
     >>> shutil.rmtree('./LUT', ignore_errors=True)
     """
 
@@ -1602,21 +1602,22 @@ class combustion_chamber_stoich(combustion_chamber):
 
         if not self.path.is_set:
             self.path.val = None
-        tespy_fluid(self.fuel_alias.val, self.fuel.val,
-                    [1000, nw.p_range_SI[1]], nw.T_range_SI,
-                    path=self.path.val)
-        tespy_fluid(self.fuel_alias.val + '_fg', self.fg,
-                    [1000, nw.p_range_SI[1]], nw.T_range_SI,
-                    path=self.path.val)
-        msg = ('Generated lookup table for ' + self.fuel_alias.val +
-               ' and for stoichiometric flue gas at stoichiometric '
-               'combustion chamber ' + self.label + '.')
+
+        tespy_fluid(
+            self.fuel_alias.val, self.fuel.val, [1000, nw.p_range_SI[1]],
+            path=self.path.val)
+        tespy_fluid(
+            self.fuel_alias.val + '_fg', self.fg, [1000, nw.p_range_SI[1]],
+            path=self.path.val)
+        msg = (
+            'Generated lookup table for ' + self.fuel_alias.val + ' and for '
+            'stoichiometric flue gas at component ' + self.label + '.')
         logging.debug(msg)
 
         if self.air_alias.val not in ['Air', 'air']:
-            tespy_fluid(self.air_alias.val, self.air.val,
-                        [1000, nw.p_range_SI[1]], nw.T_range_SI,
-                        path=self.path.val)
+            tespy_fluid(
+                self.air_alias.val, self.air.val, [1000, nw.p_range_SI[1]],
+                path=self.path.val)
             msg = ('Generated lookup table for ' + self.air_alias.val +
                    ' at stoichiometric combustion chamber ' + self.label + '.')
         else:

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -2325,61 +2325,6 @@ class heat_exchanger(component):
         deriv[0, 2, 2] = self.numeric_deriv(f, 'h', 2, bus=bus)
         return deriv
 
-    def convergence_check(self, nw):
-        r"""
-        Perform a convergence check.
-
-        Parameters
-        ----------
-        nw : tespy.networks.network
-            The network object using this component.
-
-        Note
-        ----
-        Manipulate enthalpies/pressure at inlet and outlet if not specified by
-        user to match physically feasible constraints, keep fluid composition
-        within feasible range and then propagates it towards the outlet.
-        """
-        i, o = self.inl, self.outl
-
-        if self.ttd_l.is_set or self.ttd_u.is_set:
-            fl_i1 = single_fluid(i[0].fluid.val)
-            fl_i2 = single_fluid(i[1].fluid.val)
-            fl_o1 = single_fluid(o[0].fluid.val)
-            fl_o2 = single_fluid(o[1].fluid.val)
-
-        if self.ttd_l.is_set:
-            if isinstance(fl_o1, str):
-                T_min_o1 = memorise.value_range[fl_o1][2] * 1.1
-            else:
-                T_min_o1 = nw.T_range_SI[0] * 1.1
-            if isinstance(fl_i2, str):
-                T_min_i2 = memorise.value_range[fl_i2][2] * 1.1
-            else:
-                T_min_i2 = nw.T_range_SI[0] * 1.1
-            h_min_o1 = h_mix_pT(o[0].to_flow(), T_min_o1)
-            h_min_i2 = h_mix_pT(i[1].to_flow(), T_min_i2)
-            if not o[0].h.val_set and o[0].h.val_SI < h_min_o1 * 2:
-                o[0].h.val_SI = h_min_o1 * 2
-            if not i[1].h.val_set and i[1].h.val_SI < h_min_i2:
-                i[1].h.val_SI = h_min_i2 * 1.1
-
-        if self.ttd_u.is_set:
-            if isinstance(fl_i1, str):
-                T_min_i1 = memorise.value_range[fl_i1][2] * 1.1
-            else:
-                T_min_i1 = nw.T_range_SI[0] * 1.1
-            if isinstance(fl_o2, str):
-                T_min_o2 = memorise.value_range[fl_o2][2] * 1.1
-            else:
-                T_min_o2 = nw.T_range_SI[0] * 1.1
-            h_min_i1 = h_mix_pT(i[0].to_flow(), T_min_i1)
-            h_min_o2 = h_mix_pT(o[1].to_flow(), T_min_o2)
-            if not i[0].h.val_set and i[0].h.val_SI < h_min_i1 * 2:
-                i[0].h.val_SI = h_min_i1 * 2
-            if not o[1].h.val_set and o[1].h.val_SI < h_min_o2:
-                o[1].h.val_SI = h_min_o2 * 1.1
-
     def initialise_source(self, c, key):
         r"""
         Return a starting value for pressure and enthalpy at outlet.

--- a/tespy/components/heat_exchangers.py
+++ b/tespy/components/heat_exchangers.py
@@ -24,11 +24,11 @@ import numpy as np
 from tespy.components.components import component
 from tespy.tools.data_containers import dc_cc, dc_cp, dc_simple, dc_gcp
 from tespy.tools.fluid_properties import (
-        h_mix_pT, s_mix_ph, v_mix_ph, visc_mix_ph, T_mix_ph,
-        dh_mix_dpQ, h_mix_pQ, T_bp_p, memorise
-        )
+    h_mix_pT, s_mix_ph, v_mix_ph, visc_mix_ph, T_mix_ph,
+    dh_mix_dpQ, h_mix_pQ, T_bp_p, memorise
+)
 from tespy.tools.global_vars import err
-from tespy.tools.helpers import lamb, single_fluid
+from tespy.tools.helpers import lamb
 import warnings
 
 # %%

--- a/tespy/networks/network_reader.py
+++ b/tespy/networks/network_reader.py
@@ -138,7 +138,7 @@ def load_network(path):
     >>> import shutil
     >>> fluid_list = ['CH4', 'O2', 'N2', 'CO2', 'H2O', 'Ar']
     >>> nw = network(fluids=fluid_list, p_unit='bar', T_unit='C',
-    ... h_unit='kJ / kg', T_range=[250, 1300], iterinfo=False)
+    ... h_unit='kJ / kg', iterinfo=False)
     >>> air = source('air')
     >>> f = source('fuel')
     >>> c = compressor('compressor')

--- a/tespy/networks/network_reader.py
+++ b/tespy/networks/network_reader.py
@@ -126,11 +126,13 @@ def load_network(path):
     with the network_reader module. All network information stored will be
     passed to a new network object. Components, connections and busses will
     be accessible by label. The following example setup is simple gas turbine
-    setup with compressor, combustion chamber and turbine.
+    setup with compressor, combustion chamber and turbine. The fuel is fed
+    from a pipeline and throttled to the required pressure while keeping the
+    temperature at a constant value.
 
     >>> import numpy as np
     >>> from tespy.components import (sink, source, combustion_chamber,
-    ... compressor, turbine)
+    ... compressor, turbine, heat_exchanger_simple)
     >>> from tespy.connections import connection, ref, bus
     >>> from tespy.networks import load_network, network
     >>> import shutil
@@ -142,13 +144,15 @@ def load_network(path):
     >>> c = compressor('compressor')
     >>> comb = combustion_chamber('combustion')
     >>> t = turbine('turbine')
+    >>> p = heat_exchanger_simple('fuel preheater')
     >>> si = sink('sink')
     >>> inc = connection(air, 'out1', c, 'in1', label='ambient air')
     >>> cc = connection(c, 'out1', comb, 'in1')
-    >>> fc = connection(f, 'out1', comb, 'in2')
+    >>> fp = connection(f, 'out1', p, 'in1')
+    >>> pc = connection(p, 'out1', comb, 'in2')
     >>> ct = connection(comb, 'out1', t, 'in1')
     >>> outg = connection(t, 'out1', si, 'in1')
-    >>> nw.add_conns(inc, cc, fc, ct, outg)
+    >>> nw.add_conns(inc, cc, fp, pc, ct, outg)
 
     Specify component and connection properties. The intlet pressure at the
     compressor and the outlet pressure after the turbine are identical. For the
@@ -162,8 +166,9 @@ def load_network(path):
     ... offdesign=['eta_s_char', 'cone'])
     >>> inc.set_attr(fluid={'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'CH4': 0,
     ... 'H2O': 0}, fluid_balance=True, T=25, p=1)
-    >>> fc.set_attr(fluid={'N2': 0, 'O2': 0, 'Ar': 0, 'CH4': 0.96, 'H2O': 0,
-    ... 'CO2': 0.04}, T=25)
+    >>> fp.set_attr(fluid={'N2': 0, 'O2': 0, 'Ar': 0, 'CH4': 0.96, 'H2O': 0,
+    ... 'CO2': 0.04}, T=25, p=40)
+    >>> pc.set_attr(T=25)
     >>> ct.set_attr(T=1100)
     >>> outg.set_attr(p=ref(inc, 1, 0))
     >>> power = bus('total power output')

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -371,18 +371,18 @@ class network:
                         '_min, ' + prop + '_max]')
                     logging.error(msg)
                     raise TypeError(msg)
-            else:
-                self.__dict__.update(
-                    {prop + '_range_SI':
-                     np.array(kwargs[prop + '_range']) *
-                     self.__dict__[prop][self.__dict__[prop + '_unit']]})
+                else:
+                    self.__dict__.update(
+                        {prop + '_range_SI':
+                         np.array(kwargs[prop + '_range']) *
+                         self.__dict__[prop][self.__dict__[prop + '_unit']]})
 
-            msg = ('Setting ' + self.props[prop] + ' limits, min: ' +
-                   str(self.__dict__[prop + '_range_SI'][0]) + ' ' +
-                   self.SI_units[prop] + ', max: ' +
-                   str(self.__dict__[prop + '_range_SI'][1]) + ' ' +
-                   self.SI_units[prop] + '.')
-            logging.debug(msg)
+                msg = ('Setting ' + self.props[prop] + ' limits, min: ' +
+                       str(self.__dict__[prop + '_range_SI'][0]) + ' ' +
+                       self.SI_units[prop] + ', max: ' +
+                       str(self.__dict__[prop + '_range_SI'][1]) + ' ' +
+                       self.SI_units[prop] + '.')
+                logging.debug(msg)
 
         # update non SI value ranges
         self.m_range = self.m_range_SI / self.m[self.m_unit]

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -370,48 +370,25 @@ class network:
                            kwargs[unit] + '.')
                     logging.debug(msg)
 
-        # value ranges
-        if 'm_range' in kwargs.keys():
-            if not isinstance(kwargs['m_range'], list):
-                msg = ('Specify the value range as list: [m_min, m_max]')
-                logging.error(msg)
-                raise TypeError(msg)
+        for prop in ['m', 'p', 'h']:
+            if prop + '_range' in kwargs.keys():
+                if not isinstance(kwargs[prop + '_range'], list):
+                    msg = (
+                        'Specify the value range as list: [' + prop +
+                        '_min, ' + prop + '_max]')
+                    logging.error(msg)
+                    raise TypeError(msg)
             else:
-                self.m_range_SI = (np.array(kwargs['m_range']) *
-                                   self.m[self.m_unit])
+                self.__dict__.update(
+                    {prop + '_range_SI':
+                     np.array(kwargs[prop + '_range']) *
+                     self.__dict__[prop][self.__dict__[prop + '_unit']]})
 
-            msg = ('Setting mass flow limits, min: ' +
-                   str(self.m_range_SI[0]) + ' ' + self.SI_units['m'] +
-                   ', max: ' + str(self.m_range_SI[1]) + ' ' +
-                   self.SI_units['m'] + '.')
-            logging.debug(msg)
-
-        if 'p_range' in kwargs.keys():
-            if not isinstance(kwargs['p_range'], list):
-                msg = ('Specify the value range as list: [p_min, p_max]')
-                logging.error(msg)
-                raise TypeError(msg)
-            else:
-                self.p_range_SI = (np.array(kwargs['p_range']) *
-                                   self.p[self.p_unit])
-            msg = ('Setting pressure limits, min: ' +
-                   str(self.p_range_SI[0]) + ' ' + self.SI_units['p'] +
-                   ', max: ' + str(self.p_range_SI[1]) + ' ' +
-                   self.SI_units['p'] + '.')
-            logging.debug(msg)
-
-        if 'h_range' in kwargs.keys():
-            if not isinstance(kwargs['h_range'], list):
-                msg = ('Specify the value range as list: [h_min, h_max]')
-                logging.error(msg)
-                raise TypeError(msg)
-            else:
-                self.h_range_SI = (np.array(kwargs['h_range']) *
-                                   self.h[self.h_unit])
-            msg = ('Setting enthalpy limits, min: ' +
-                   str(self.h_range_SI[0]) + ' ' + self.SI_units['h'] +
-                   ', max: ' + str(self.h_range_SI[1]) + ' ' +
-                   self.SI_units['h'] + '.')
+            msg = ('Setting ' + self.props[prop] + ' limits, min: ' +
+                   str(self.__dict__[prop + '_range_SI'][0]) + ' ' +
+                   self.SI_units[prop] + ', max: ' +
+                   str(self.__dict__[prop + '_range_SI'][1]) + ' ' +
+                   self.SI_units[prop] + '.')
             logging.debug(msg)
 
         # update non SI value ranges

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -297,20 +297,13 @@ class network:
         self.p_range_SI = np.array([2e2, 300e5])
         self.h_range_SI = np.array([1e3, 7e6])
 
-        msg = ('Default mass flow limits, '
-               'min: ' + str(self.m_range_SI[0]) + ' ' + self.m_unit +
-               ', max: ' + str(self.m_range_SI[1]) + ' ' + self.m_unit + ', ')
-        logging.debug(msg)
-
-        msg = ('Default pressure limits, '
-               'min: ' + str(self.p_range_SI[0]) + ' ' + self.p_unit +
-               ', max: ' + str(self.p_range_SI[1]) + ' ' + self.p_unit + ', ')
-        logging.debug(msg)
-
-        msg = ('Default enthalpy limits, '
-               'min: ' + str(self.h_range_SI[0]) + ' ' + self.h_unit +
-               ', max: ' + str(self.h_range_SI[1]) + ' ' + self.h_unit + ', ')
-        logging.debug(msg)
+        for prop in ['m', 'p', 'h']:
+            msg = ('Default ' + self.props[prop] + ' limits, min: ' +
+                   str(self.__dict__[prop + '_range_SI'][0]) + ' ' +
+                   self.SI_units[prop] + ', max: ' +
+                   str(self.__dict__[prop + '_range_SI'][1]) + ' ' +
+                   self.SI_units[prop] + '.')
+            logging.debug(msg)
 
         self.set_attr(**kwargs)
 

--- a/tespy/networks/networks.py
+++ b/tespy/networks/networks.py
@@ -2531,7 +2531,9 @@ class network:
             c.T.val_SI = fp.T_mix_ph(flow, T0=c.T.val_SI)
             fluid = hlp.single_fluid(c.fluid.val)
             if (fluid is None and
-                    abs(fp.h_mix_pT(flow, c.T.val_SI) - c.h.val_SI) > err):
+                    abs(
+                        fp.h_mix_pT(flow, c.T.val_SI) - c.h.val_SI
+                    ) > err ** .5):
                 c.T.val_SI = np.nan
                 c.vol.val_SI = np.nan
                 c.v.val_SI = np.nan

--- a/tespy/tools/fluid_properties.py
+++ b/tespy/tools/fluid_properties.py
@@ -58,9 +58,6 @@ class tespy_fluid:
     p_range : list/ndarray
         Pressure range for the new fluid lookup table.
 
-    T_range : list/ndarray
-        Temperature range for the new fluid lookup table.
-
     path : str
         Path to importing tespy fluid from.
 
@@ -91,9 +88,8 @@ class tespy_fluid:
     >>> import shutil
     >>> fluidvec = {'N2': 0.7552, 'O2': 0.2314, 'CO2': 0.0005, 'Ar': 0.0129}
     >>> p_arr = np.array([0.1, 10]) * 1e5
-    >>> T_arr = np.array([250, 1280])
     >>> myfluid = tespy_fluid('dry air', fluid=fluidvec, p_range=p_arr,
-    ... T_range=T_arr)
+    ... T_range=[300, 1200])
 
     Check if the fluid creation was successful and compare some fluid
     properties to the CoolProp air implementation. We have to add the CoolProp
@@ -137,13 +133,13 @@ class tespy_fluid:
     The fluid had been saved automatically, load it now.
 
     >>> loadfluid = tespy_fluid('dry air', fluid=fluidvec, p_range=p_arr,
-    ... T_range=T_arr, path='./LUT')
+    ... path='./LUT')
     >>> type(loadfluid)
     <class 'tespy.tools.fluid_properties.tespy_fluid'>
     >>> shutil.rmtree('./LUT', ignore_errors=True)
     """
 
-    def __init__(self, alias, fluid, p_range, T_range, path=None):
+    def __init__(self, alias, fluid, p_range, T_range=None, path=None):
 
         if not isinstance(alias, str):
             msg = 'Alias must be of type String.'
@@ -159,14 +155,6 @@ class tespy_fluid:
             self.alias = alias
 
         self.fluid = fluid
-
-        # adjust value ranges according to specified unit system
-        self.p_range = np.asarray(p_range)
-        self.T_range = np.asarray(T_range)
-
-        # set up grid
-        self.p = np.geomspace(self.p_range[0], self.p_range[1], 100)
-        self.T = np.linspace(self.T_range[0], self.T_range[1], 100)
 
         # path for loading
         self.path = path
@@ -186,13 +174,21 @@ class tespy_fluid:
                 fluid = f
             if f != self.alias:
                 self.fluids_back_ends[f] = back_end
-            else:
-                self.fluids_back_ends[f] = 'TESPy'
 
         memorise.add_fluids(self.fluids_back_ends)
 
-        params = {}
+        # set up grid
+        self.p = np.geomspace(p_range[0], p_range[1], 100)
 
+        if T_range is None:
+            T_range = [max([memorise.value_range[f][2] for f
+                            in self.fluids_back_ends.keys()]) + 1, 2000]
+
+        self.T = np.geomspace(T_range[0], T_range[1], 100)
+
+        memorise.add_fluids({self.alias: 'TESPy'})
+
+        params = {}
         params['h_pT'] = h_mix_pT
         params['s_pT'] = s_mix_pT
         params['d_pT'] = d_mix_pT
@@ -437,12 +433,12 @@ class memorise:
                 logging.debug(msg)
 
             elif back_end == 'TESPy':
-                pmin = tespy_fluid.fluids[f].p_range[0]
-                pmax = tespy_fluid.fluids[f].p_range[1]
-                Tmin = tespy_fluid.fluids[f].T_range[0]
-                Tmax = tespy_fluid.fluids[f].T_range[1]
-                msg = ('Loading fluid property ranges for TESPy-fluid ' +
-                       f + '.')
+                pmin = tespy_fluid.fluids[f].p[0]
+                pmax = tespy_fluid.fluids[f].p[-1]
+                Tmin = tespy_fluid.fluids[f].T[0]
+                Tmax = tespy_fluid.fluids[f].T[-1]
+                msg = (
+                    'Loading fluid property ranges for TESPy-fluid ' + f + '.')
                 logging.debug(msg)
                 # value range for fluid properties
                 memorise.value_range[f] = [pmin, pmax, Tmin, Tmax]

--- a/tespy/tools/fluid_properties.py
+++ b/tespy/tools/fluid_properties.py
@@ -559,10 +559,16 @@ def T_mix_ph(flow, T0=300):
     fluid = single_fluid(flow[3])
     if fluid is None:
         # calculate the fluid properties for fluid mixtures
-        if T0 < 70:
-            T0 = 300
+        if memorisation is True:
+            valmin = max(
+                [memorise.value_range[f][2] for f in fl if flow[3][f] > err]
+            ) + 0.1
+            if T0 < valmin:
+                T0 = valmin * 1.1
+        else:
+            valmin = 70
         val = newton(h_mix_pT, dh_mix_pdT, flow, flow[2], val0=T0,
-                     valmin=70, valmax=3000, imax=10)
+                     valmin=valmin, valmax=3000, imax=10)
     else:
         # calculate fluid property for pure fluids
         val = T_ph(flow[1], flow[2], fluid)
@@ -753,10 +759,17 @@ def T_mix_ps(flow, s, T0=300):
     fluid = single_fluid(flow[3])
     if fluid is None:
         # calculate the fluid properties for fluid mixtures
-        if T0 < 70:
-            T0 = 300
+        if memorisation is True:
+            valmin = max(
+                [memorise.value_range[f][2] for f in fl if flow[3][f] > err]
+            ) + 0.1
+            if T0 < valmin:
+                T0 = valmin * 1.1
+        else:
+            valmin = 70
+
         val = newton(s_mix_pT, ds_mix_pdT, flow, s, val0=T0,
-                     valmin=70, valmax=3000, imax=10)
+                     valmin=valmin, valmax=3000, imax=10)
         if memorisation is True:
             new = np.asarray(
                 [[flow[1], flow[2]] + list(flow[3].values()) + [s, val]])
@@ -911,7 +924,7 @@ def dh_mix_pdT(flow, T):
             \frac{\partial h_{mix}}{\partial T} =
             \frac{h_{mix}(p,T+d)-h_{mix}(p,T-d)}{2 \cdot d}
     """
-    d = 2
+    d = 0.1
     return (h_mix_pT(flow, T + d) - h_mix_pT(flow, T - d)) / (2 * d)
 
 # %%
@@ -1749,5 +1762,5 @@ def ds_mix_pdT(flow, T):
             \frac{\partial s_{mix}}{\partial T} =
             \frac{s_{mix}(p,T+d)-s_{mix}(p,T-d)}{2 \cdot d}
     """
-    d = 2
+    d = 0.1
     return (s_mix_pT(flow, T + d) - s_mix_pT(flow, T - d)) / (2 * d)

--- a/tespy/tools/fluid_properties.py
+++ b/tespy/tools/fluid_properties.py
@@ -563,7 +563,7 @@ def T_mix_ph(flow, T0=300):
             valmin = max(
                 [memorise.value_range[f][2] for f in fl if flow[3][f] > err]
             ) + 0.1
-            if T0 < valmin:
+            if T0 < valmin or np.isnan(T0):
                 T0 = valmin * 1.1
         else:
             valmin = 70
@@ -763,7 +763,7 @@ def T_mix_ps(flow, s, T0=300):
             valmin = max(
                 [memorise.value_range[f][2] for f in fl if flow[3][f] > err]
             ) + 0.1
-            if T0 < valmin:
+            if T0 < valmin or np.isnan(T0):
                 T0 = valmin * 1.1
         else:
             valmin = 70

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -102,7 +102,6 @@ def test_set_attr_errors():
     set_attr_TypeError(nw, m_range=5)
     set_attr_TypeError(nw, p_range=5)
     set_attr_TypeError(nw, h_range=5)
-    set_attr_TypeError(nw, T_range=5)
     set_attr_TypeError(nw, iterinfo=5)
     set_attr_TypeError(mybus, P='some value')
     set_attr_TypeError(mybus, printout=5)
@@ -246,8 +245,7 @@ class TestCombustionChamberStoichErrors:
 
     def setup_combustion_chamber_stoich_error_tests(self):
         self.nw = network(
-            ['fuel', 'fuel_fg', 'Air'],
-            p_range=[1e4, 1e6], T_range=[300, 1500])
+            ['fuel', 'fuel_fg', 'Air'], p_range=[1e4, 1e6])
         label = 'combustion chamber'
         self.instance = combustion.combustion_chamber_stoich(label)
         c1 = connection(basics.source('air'), 'out1', self.instance, 'in1')

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -12,15 +12,20 @@ SPDX-License-Identifier: MIT
 from pytest import raises
 
 from tespy.connections import connection, bus, ref
-from tespy.components import (basics, combustion, components, heat_exchangers,
-                              nodes, piping, reactors, subsystems,
-                              turbomachinery)
+from tespy.components import (
+    basics, combustion, components, heat_exchangers, nodes, piping, reactors,
+    subsystems, turbomachinery
+)
 from tespy.networks.network_reader import load_network
 from tespy.networks.networks import network
-from tespy.tools.helpers import (TESPyComponentError, TESPyConnectionError,
-                                 TESPyNetworkError, extend_basic_path)
+from tespy.tools.helpers import (
+    TESPyComponentError, TESPyConnectionError, TESPyNetworkError,
+    extend_basic_path
+)
 from tespy.tools.data_containers import data_container, dc_cc, dc_cp, dc_flu
-from tespy.tools.fluid_properties import tespy_fluid, memorise, h_mix_pQ
+from tespy.tools.fluid_properties import (
+    tespy_fluid, memorise, h_mix_pQ, T_mix_ps
+)
 from tespy.tools.characteristics import char_map, char_line, load_custom_char
 
 import os
@@ -244,8 +249,7 @@ def test_combustion_chamber_missing_fuel():
 class TestCombustionChamberStoichErrors:
 
     def setup_combustion_chamber_stoich_error_tests(self):
-        self.nw = network(
-            ['fuel', 'fuel_fg', 'Air'], p_range=[1e4, 1e6])
+        self.nw = network(['fuel', 'fuel_fg', 'Air'], p_range=[1e4, 1e6])
         label = 'combustion chamber'
         self.instance = combustion.combustion_chamber_stoich(label)
         c1 = connection(basics.source('air'), 'out1', self.instance, 'in1')
@@ -710,3 +714,7 @@ def test_IF97_back_end():
 def test_h_mix_pQ_on_mixtures():
     with raises(ValueError):
         h_mix_pQ([0, 0, 0, {'O2': 0.24, 'N2': 0.76}], 0.75)
+
+def test_T_mix_ps_on_pure_fluids():
+    with raises(ValueError):
+        T_mix_ps([0, 0, 0, {'O2': 1}], 1e3)


### PR DESCRIPTION
The minimum value for temperature will be selected as maximum of the given minimum temperature levels of the fluid property database within the specified fluid mixture. This ensures, that T_mix_ph and T_mix_ps calls on mixtures do not fail due to temperature limit restrictions. At the same time, there must be a check, if the newton algorithm actually found a valid value for T. Additionally, the parameter T_range will be deprecated by this feature.