### PR TITLE
Remove conditions for computing equations

### DIFF
--- a/docs/whats_new/v0-3-5.rst
+++ b/docs/whats_new/v0-3-5.rst
@@ -35,6 +35,17 @@ Other Changes
 
       mynetwork.print_results(colored=False)
 
+- Add a flag to activate calculation of all component equations in every
+  iteration. This improves stability in some cases but reduces calculation
+  speed (`PR #228 <https://github.com/oemof/tespy/pull/228>`_). To activate
+  simply import the variable from the global variables at the start of your
+  script and change the value accordingly. The default value is :code:`False`.
+
+  .. code-block:: python
+
+      from tespy.tools.global_vars import always_all_equations
+      always_all_equations = True
+
 Contributors
 ############
 - Francesco Witte (`@fwitte <https://github.com/fwitte>`_)

--- a/src/tespy/components/combustion.py
+++ b/src/tespy/components/combustion.py
@@ -324,8 +324,7 @@ class combustion_chamber(component):
 
         ######################################################################
         # equation for energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = self.energy_balance()
+        self.residual[k] = self.energy_balance()
         k += 1
 
         ######################################################################
@@ -2276,36 +2275,30 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for fluids in combustion chamber
         for fluid in self.inl[0].fluid.val.keys():
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.reaction_balance(fluid)
+            self.residual[k] = self.reaction_balance(fluid)
             k += 1
 
         ######################################################################
         # equation for combustion engine energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = self.energy_balance()
+        self.residual[k] = self.energy_balance()
         k += 1
 
         ######################################################################
         # equation for power to thermal input ratio from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = self.tiP_char_func()
+        self.residual[k] = self.tiP_char_func()
         k += 1
 
         ######################################################################
         # equations for heat outputs from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = self.Q1_char_func()
+        self.residual[k] = self.Q1_char_func()
         k += 1
 
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = self.Q2_char_func()
+        self.residual[k] = self.Q2_char_func()
         k += 1
 
         ######################################################################
         # equation for heat loss from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = self.Qloss_char_func()
+        self.residual[k] = self.Qloss_char_func()
         k += 1
 
         ######################################################################
@@ -2345,15 +2338,11 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for specified zeta values at cooling loops
         if self.zeta1.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.zeta_func(
-                    zeta='zeta1', inconn=0, outconn=0)
+            self.residual[k] = self.zeta_func(zeta='zeta1', inconn=0, outconn=0)
             k += 1
 
         if self.zeta2.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.zeta_func(
-                    zeta='zeta2', inconn=1, outconn=1)
+            self.residual[k] = self.zeta_func(zeta='zeta2', inconn=1, outconn=1)
             k += 1
 
     def derivatives(self, increment_filter):

--- a/src/tespy/components/combustion.py
+++ b/src/tespy/components/combustion.py
@@ -32,9 +32,9 @@ from tespy.tools.fluid_properties import s_mix_ph
 from tespy.tools.fluid_properties import s_mix_pT
 from tespy.tools.fluid_properties import tespy_fluid
 from tespy.tools.fluid_properties import v_mix_ph
+from tespy.tools.global_vars import always_all_equations
 from tespy.tools.global_vars import err
 from tespy.tools.global_vars import molar_masses
-from tespy.tools.global_vars import always_all_equations
 from tespy.tools.helpers import TESPyComponentError
 from tespy.tools.helpers import fluid_structure
 from tespy.tools.helpers import molar_mass_flow
@@ -319,14 +319,15 @@ class combustion_chamber(component):
         ######################################################################
         # equations for fluids in reaction balance
         for fluid in self.inl[0].fluid.val.keys():
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 3 == 0:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 3 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.reaction_balance(fluid)
             k += 1
 
         ######################################################################
         # equation for energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = self.energy_balance()
         k += 1
 
@@ -2278,41 +2279,41 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for fluids in combustion chamber
         for fluid in self.inl[0].fluid.val.keys():
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.reaction_balance(fluid)
             k += 1
 
         ######################################################################
         # equation for combustion engine energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = self.energy_balance()
         k += 1
 
         ######################################################################
         # equation for power to thermal input ratio from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = self.tiP_char_func()
         k += 1
 
         ######################################################################
         # equations for heat outputs from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = self.Q1_char_func()
         k += 1
 
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = self.Q2_char_func()
         k += 1
 
         ######################################################################
         # equation for heat loss from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = self.Qloss_char_func()
         k += 1
 
@@ -2353,15 +2354,15 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for specified zeta values at cooling loops
         if self.zeta1.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.zeta_func(
                     zeta='zeta1', inconn=0, outconn=0)
             k += 1
 
         if self.zeta2.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.zeta_func(
                     zeta='zeta2', inconn=1, outconn=1)
             k += 1

--- a/src/tespy/components/combustion.py
+++ b/src/tespy/components/combustion.py
@@ -2338,11 +2338,13 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for specified zeta values at cooling loops
         if self.zeta1.is_set:
-            self.residual[k] = self.zeta_func(zeta='zeta1', inconn=0, outconn=0)
+            self.residual[k] = self.zeta_func(zeta='zeta1', inconn=0,
+                                              outconn=0)
             k += 1
 
         if self.zeta2.is_set:
-            self.residual[k] = self.zeta_func(zeta='zeta2', inconn=1, outconn=1)
+            self.residual[k] = self.zeta_func(zeta='zeta2', inconn=1,
+                                              outconn=1)
             k += 1
 
     def derivatives(self, increment_filter):

--- a/src/tespy/components/combustion.py
+++ b/src/tespy/components/combustion.py
@@ -34,6 +34,7 @@ from tespy.tools.fluid_properties import tespy_fluid
 from tespy.tools.fluid_properties import v_mix_ph
 from tespy.tools.global_vars import err
 from tespy.tools.global_vars import molar_masses
+from tespy.tools.global_vars import always_all_equations
 from tespy.tools.helpers import TESPyComponentError
 from tespy.tools.helpers import fluid_structure
 from tespy.tools.helpers import molar_mass_flow
@@ -324,7 +325,8 @@ class combustion_chamber(component):
 
         ######################################################################
         # equation for energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = self.energy_balance()
         k += 1
 
@@ -2276,35 +2278,41 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for fluids in combustion chamber
         for fluid in self.inl[0].fluid.val.keys():
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.reaction_balance(fluid)
             k += 1
 
         ######################################################################
         # equation for combustion engine energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = self.energy_balance()
         k += 1
 
         ######################################################################
         # equation for power to thermal input ratio from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = self.tiP_char_func()
         k += 1
 
         ######################################################################
         # equations for heat outputs from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = self.Q1_char_func()
         k += 1
 
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = self.Q2_char_func()
         k += 1
 
         ######################################################################
         # equation for heat loss from characteristic line
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = self.Qloss_char_func()
         k += 1
 
@@ -2345,13 +2353,15 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for specified zeta values at cooling loops
         if self.zeta1.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.zeta_func(
                     zeta='zeta1', inconn=0, outconn=0)
             k += 1
 
         if self.zeta2.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.zeta_func(
                     zeta='zeta2', inconn=1, outconn=1)
             k += 1

--- a/src/tespy/components/combustion.py
+++ b/src/tespy/components/combustion.py
@@ -324,7 +324,8 @@ class combustion_chamber(component):
 
         ######################################################################
         # equation for energy balance
-        self.residual[k] = self.energy_balance()
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = self.energy_balance()
         k += 1
 
         ######################################################################
@@ -2275,30 +2276,36 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for fluids in combustion chamber
         for fluid in self.inl[0].fluid.val.keys():
-            self.residual[k] = self.reaction_balance(fluid)
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.reaction_balance(fluid)
             k += 1
 
         ######################################################################
         # equation for combustion engine energy balance
-        self.residual[k] = self.energy_balance()
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = self.energy_balance()
         k += 1
 
         ######################################################################
         # equation for power to thermal input ratio from characteristic line
-        self.residual[k] = self.tiP_char_func()
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = self.tiP_char_func()
         k += 1
 
         ######################################################################
         # equations for heat outputs from characteristic line
-        self.residual[k] = self.Q1_char_func()
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = self.Q1_char_func()
         k += 1
 
-        self.residual[k] = self.Q2_char_func()
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = self.Q2_char_func()
         k += 1
 
         ######################################################################
         # equation for heat loss from characteristic line
-        self.residual[k] = self.Qloss_char_func()
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = self.Qloss_char_func()
         k += 1
 
         ######################################################################
@@ -2338,13 +2345,15 @@ class combustion_engine(combustion_chamber):
         ######################################################################
         # equations for specified zeta values at cooling loops
         if self.zeta1.is_set:
-            self.residual[k] = self.zeta_func(zeta='zeta1', inconn=0,
-                                              outconn=0)
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.zeta_func(
+                    zeta='zeta1', inconn=0, outconn=0)
             k += 1
 
         if self.zeta2.is_set:
-            self.residual[k] = self.zeta_func(zeta='zeta2', inconn=1,
-                                              outconn=1)
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.zeta_func(
+                    zeta='zeta2', inconn=1, outconn=1)
             k += 1
 
     def derivatives(self, increment_filter):

--- a/src/tespy/components/heat_exchangers.py
+++ b/src/tespy/components/heat_exchangers.py
@@ -37,8 +37,8 @@ from tespy.tools.fluid_properties import h_mix_pT
 from tespy.tools.fluid_properties import s_mix_ph
 from tespy.tools.fluid_properties import v_mix_ph
 from tespy.tools.fluid_properties import visc_mix_ph
-from tespy.tools.global_vars import err
 from tespy.tools.global_vars import always_all_equations
+from tespy.tools.global_vars import err
 from tespy.tools.helpers import lamb
 
 # %%
@@ -363,16 +363,16 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equations for specified zeta
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified hydro-group paremeters
         if self.hydro_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 # hazen williams equation
                 if self.hydro_group.method == 'HW':
                     func = self.hw_func
@@ -400,16 +400,16 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equation for specified kA_group paremeters
         if self.kA_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equation for specified kA_char_group paremeters
         if self.kA_char_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.kA_char_func()
             k += 1
 
@@ -1183,8 +1183,8 @@ class parabolic_trough(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
@@ -1538,8 +1538,8 @@ class solar_collector(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
@@ -1877,16 +1877,16 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified heat transfer coefficient
         if self.kA.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equations for specified heat transfer coefficient characteristic
         if self.kA_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.kA_char_func()
             k += 1
 
@@ -1919,8 +1919,8 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified zeta at hot side
         if self.zeta1.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.zeta_func(
                     zeta='zeta1', inconn=0, outconn=0)
             k += 1
@@ -1928,8 +1928,8 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified zeta at cold side
         if self.zeta2.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-                always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.zeta_func(
                     zeta='zeta2', inconn=1, outconn=1)
             k += 1

--- a/src/tespy/components/heat_exchangers.py
+++ b/src/tespy/components/heat_exchangers.py
@@ -362,19 +362,21 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equations for specified zeta
         if self.zeta.is_set:
-            self.residual[k] = self.zeta_func(zeta='zeta')
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified hydro-group paremeters
         if self.hydro_group.is_set:
-            # hazen williams equation
-            if self.hydro_group.method == 'HW':
-                func = self.hw_func
-            # darcy friction factor
-            else:
-                func = self.darcy_func
-            self.residual[k] = func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                # hazen williams equation
+                if self.hydro_group.method == 'HW':
+                    func = self.hw_func
+                # darcy friction factor
+                else:
+                    func = self.darcy_func
+                self.residual[k] = func()
             k += 1
 
         ######################################################################
@@ -395,13 +397,15 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equation for specified kA_group paremeters
         if self.kA_group.is_set:
-            self.residual[k] = self.kA_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equation for specified kA_char_group paremeters
         if self.kA_char_group.is_set:
-            self.residual[k] = self.kA_char_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.kA_char_func()
             k += 1
 
     def derivatives(self, increment_filter):
@@ -1174,7 +1178,8 @@ class parabolic_trough(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            self.residual[k] = self.energy_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
         r"""Calculate partial derivatives for given additional equations."""
@@ -1527,7 +1532,8 @@ class solar_collector(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            self.residual[k] = self.energy_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
         r"""Calculate partial derivatives for given additional equations."""
@@ -1864,13 +1870,15 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified heat transfer coefficient
         if self.kA.is_set:
-            self.residual[k] = self.kA_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equations for specified heat transfer coefficient characteristic
         if self.kA_char.is_set:
-            self.residual[k] = self.kA_char_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.kA_char_func()
             k += 1
 
         ######################################################################
@@ -1902,15 +1910,17 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified zeta at hot side
         if self.zeta1.is_set:
-            self.residual[k] = self.zeta_func(
-                zeta='zeta1', inconn=0, outconn=0)
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.zeta_func(
+                    zeta='zeta1', inconn=0, outconn=0)
             k += 1
 
         ######################################################################
         # equations for specified zeta at cold side
         if self.zeta2.is_set:
-            self.residual[k] = self.zeta_func(
-                zeta='zeta2', inconn=1, outconn=1)
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.zeta_func(
+                    zeta='zeta2', inconn=1, outconn=1)
             k += 1
 
         ######################################################################

--- a/src/tespy/components/heat_exchangers.py
+++ b/src/tespy/components/heat_exchangers.py
@@ -362,21 +362,19 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equations for specified zeta
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.zeta_func(zeta='zeta')
+            self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified hydro-group paremeters
         if self.hydro_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                # hazen williams equation
-                if self.hydro_group.method == 'HW':
-                    func = self.hw_func
-                # darcy friction factor
-                else:
-                    func = self.darcy_func
-                self.residual[k] = func()
+            # hazen williams equation
+            if self.hydro_group.method == 'HW':
+                func = self.hw_func
+            # darcy friction factor
+            else:
+                func = self.darcy_func
+            self.residual[k] = func()
             k += 1
 
         ######################################################################
@@ -397,15 +395,13 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equation for specified kA_group paremeters
         if self.kA_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.kA_func()
+            self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equation for specified kA_char_group paremeters
         if self.kA_char_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.kA_char_func()
+            self.residual[k] = self.kA_char_func()
             k += 1
 
     def derivatives(self, increment_filter):
@@ -1178,8 +1174,7 @@ class parabolic_trough(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.energy_func()
+            self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
         r"""Calculate partial derivatives for given additional equations."""
@@ -1532,8 +1527,7 @@ class solar_collector(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.energy_func()
+            self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
         r"""Calculate partial derivatives for given additional equations."""
@@ -1870,15 +1864,13 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified heat transfer coefficient
         if self.kA.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.kA_func()
+            self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equations for specified heat transfer coefficient characteristic
         if self.kA_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.kA_char_func()
+            self.residual[k] = self.kA_char_func()
             k += 1
 
         ######################################################################
@@ -1910,17 +1902,15 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified zeta at hot side
         if self.zeta1.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.zeta_func(
-                    zeta='zeta1', inconn=0, outconn=0)
+            self.residual[k] = self.zeta_func(
+                zeta='zeta1', inconn=0, outconn=0)
             k += 1
 
         ######################################################################
         # equations for specified zeta at cold side
         if self.zeta2.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.zeta_func(
-                    zeta='zeta2', inconn=1, outconn=1)
+            self.residual[k] = self.zeta_func(
+                zeta='zeta2', inconn=1, outconn=1)
             k += 1
 
         ######################################################################

--- a/src/tespy/components/heat_exchangers.py
+++ b/src/tespy/components/heat_exchangers.py
@@ -38,6 +38,7 @@ from tespy.tools.fluid_properties import s_mix_ph
 from tespy.tools.fluid_properties import v_mix_ph
 from tespy.tools.fluid_properties import visc_mix_ph
 from tespy.tools.global_vars import err
+from tespy.tools.global_vars import always_all_equations
 from tespy.tools.helpers import lamb
 
 # %%
@@ -362,14 +363,16 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equations for specified zeta
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified hydro-group paremeters
         if self.hydro_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 # hazen williams equation
                 if self.hydro_group.method == 'HW':
                     func = self.hw_func
@@ -397,14 +400,16 @@ class heat_exchanger_simple(component):
         ######################################################################
         # equation for specified kA_group paremeters
         if self.kA_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equation for specified kA_char_group paremeters
         if self.kA_char_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.kA_char_func()
             k += 1
 
@@ -1178,7 +1183,8 @@ class parabolic_trough(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
@@ -1532,7 +1538,8 @@ class solar_collector(heat_exchanger_simple):
         ######################################################################
         # equation for specified energy-group paremeters
         if self.energy_group.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.energy_func()
 
     def additional_derivatives(self, increment_filter, k):
@@ -1870,14 +1877,16 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified heat transfer coefficient
         if self.kA.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.kA_func()
             k += 1
 
         ######################################################################
         # equations for specified heat transfer coefficient characteristic
         if self.kA_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.kA_char_func()
             k += 1
 
@@ -1910,7 +1919,8 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified zeta at hot side
         if self.zeta1.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.zeta_func(
                     zeta='zeta1', inconn=0, outconn=0)
             k += 1
@@ -1918,7 +1928,8 @@ class heat_exchanger(component):
         ######################################################################
         # equations for specified zeta at cold side
         if self.zeta2.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+                always_all_equations:
                 self.residual[k] = self.zeta_func(
                     zeta='zeta2', inconn=1, outconn=1)
             k += 1

--- a/src/tespy/components/piping.py
+++ b/src/tespy/components/piping.py
@@ -24,8 +24,8 @@ from tespy.tools.data_containers import dc_cp
 from tespy.tools.data_containers import dc_simple
 from tespy.tools.fluid_properties import s_mix_ph
 from tespy.tools.fluid_properties import v_mix_ph
-from tespy.tools.global_vars import err
 from tespy.tools.global_vars import always_all_equations
+from tespy.tools.global_vars import err
 
 # %%
 
@@ -374,16 +374,16 @@ class valve(component):
         ######################################################################
         # eqation specified zeta
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified difference pressure char
         if self.dp_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.dp_char_func()
             k += 1
 

--- a/src/tespy/components/piping.py
+++ b/src/tespy/components/piping.py
@@ -25,6 +25,7 @@ from tespy.tools.data_containers import dc_simple
 from tespy.tools.fluid_properties import s_mix_ph
 from tespy.tools.fluid_properties import v_mix_ph
 from tespy.tools.global_vars import err
+from tespy.tools.global_vars import always_all_equations
 
 # %%
 
@@ -373,14 +374,16 @@ class valve(component):
         ######################################################################
         # eqation specified zeta
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified difference pressure char
         if self.dp_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.dp_char_func()
             k += 1
 

--- a/src/tespy/components/piping.py
+++ b/src/tespy/components/piping.py
@@ -373,13 +373,15 @@ class valve(component):
         ######################################################################
         # eqation specified zeta
         if self.zeta.is_set:
-            self.residual[k] = self.zeta_func(zeta='zeta')
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified difference pressure char
         if self.dp_char.is_set:
-            self.residual[k] = self.dp_char_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.dp_char_func()
             k += 1
 
     def derivatives(self, increment_filter):

--- a/src/tespy/components/piping.py
+++ b/src/tespy/components/piping.py
@@ -373,15 +373,13 @@ class valve(component):
         ######################################################################
         # eqation specified zeta
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.zeta_func(zeta='zeta')
+            self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         ######################################################################
         # equation for specified difference pressure char
         if self.dp_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.dp_char_func()
+            self.residual[k] = self.dp_char_func()
             k += 1
 
     def derivatives(self, increment_filter):

--- a/src/tespy/components/reactors.py
+++ b/src/tespy/components/reactors.py
@@ -415,7 +415,7 @@ class water_electrolyzer(component):
         ######################################################################
         # temperature electrolyzer outlet
         self.residual[k] = (T_mix_ph(self.outl[1].to_flow()) -
-            T_mix_ph(self.outl[2].to_flow()))
+                            T_mix_ph(self.outl[2].to_flow()))
         k += 1
 
         ######################################################################

--- a/src/tespy/components/reactors.py
+++ b/src/tespy/components/reactors.py
@@ -29,6 +29,7 @@ from tespy.tools.fluid_properties import dT_mix_pdh
 from tespy.tools.fluid_properties import h_mix_pT
 from tespy.tools.fluid_properties import v_mix_ph
 from tespy.tools.global_vars import err
+from tespy.tools.global_vars import always_all_equations
 from tespy.tools.global_vars import molar_masses
 from tespy.tools.helpers import TESPyComponentError
 
@@ -409,13 +410,15 @@ class water_electrolyzer(component):
 
         ######################################################################
         # equation for energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = self.P.val + self.energy_balance()
         k += 1
 
         ######################################################################
         # temperature electrolyzer outlet
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+          always_all_equations:
             self.residual[k] = (
                 T_mix_ph(self.outl[1].to_flow()) -
                 T_mix_ph(self.outl[2].to_flow()))
@@ -437,7 +440,8 @@ class water_electrolyzer(component):
         ######################################################################
         # specified zeta value
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 

--- a/src/tespy/components/reactors.py
+++ b/src/tespy/components/reactors.py
@@ -409,16 +409,13 @@ class water_electrolyzer(component):
 
         ######################################################################
         # equation for energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = self.P.val + self.energy_balance()
+        self.residual[k] = self.P.val + self.energy_balance()
         k += 1
 
         ######################################################################
         # temperature electrolyzer outlet
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-            self.residual[k] = (
-                T_mix_ph(self.outl[1].to_flow()) -
-                T_mix_ph(self.outl[2].to_flow()))
+        self.residual[k] = (T_mix_ph(self.outl[1].to_flow()) -
+            T_mix_ph(self.outl[2].to_flow()))
         k += 1
 
         ######################################################################
@@ -437,8 +434,7 @@ class water_electrolyzer(component):
         ######################################################################
         # specified zeta value
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.zeta_func(zeta='zeta')
+            self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         # equation for heat transfer

--- a/src/tespy/components/reactors.py
+++ b/src/tespy/components/reactors.py
@@ -28,8 +28,8 @@ from tespy.tools.fluid_properties import dT_mix_dph
 from tespy.tools.fluid_properties import dT_mix_pdh
 from tespy.tools.fluid_properties import h_mix_pT
 from tespy.tools.fluid_properties import v_mix_ph
-from tespy.tools.global_vars import err
 from tespy.tools.global_vars import always_all_equations
+from tespy.tools.global_vars import err
 from tespy.tools.global_vars import molar_masses
 from tespy.tools.helpers import TESPyComponentError
 
@@ -410,15 +410,15 @@ class water_electrolyzer(component):
 
         ######################################################################
         # equation for energy balance
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = self.P.val + self.energy_balance()
         k += 1
 
         ######################################################################
         # temperature electrolyzer outlet
-        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-          always_all_equations:
+        if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                always_all_equations):
             self.residual[k] = (
                 T_mix_ph(self.outl[1].to_flow()) -
                 T_mix_ph(self.outl[2].to_flow()))
@@ -440,8 +440,8 @@ class water_electrolyzer(component):
         ######################################################################
         # specified zeta value
         if self.zeta.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 

--- a/src/tespy/components/reactors.py
+++ b/src/tespy/components/reactors.py
@@ -409,13 +409,16 @@ class water_electrolyzer(component):
 
         ######################################################################
         # equation for energy balance
-        self.residual[k] = self.P.val + self.energy_balance()
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = self.P.val + self.energy_balance()
         k += 1
 
         ######################################################################
         # temperature electrolyzer outlet
-        self.residual[k] = (T_mix_ph(self.outl[1].to_flow()) -
-                            T_mix_ph(self.outl[2].to_flow()))
+        if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            self.residual[k] = (
+                T_mix_ph(self.outl[1].to_flow()) -
+                T_mix_ph(self.outl[2].to_flow()))
         k += 1
 
         ######################################################################
@@ -434,7 +437,8 @@ class water_electrolyzer(component):
         ######################################################################
         # specified zeta value
         if self.zeta.is_set:
-            self.residual[k] = self.zeta_func(zeta='zeta')
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.zeta_func(zeta='zeta')
             k += 1
 
         # equation for heat transfer

--- a/src/tespy/components/turbomachinery.py
+++ b/src/tespy/components/turbomachinery.py
@@ -37,6 +37,7 @@ from tespy.tools.fluid_properties import s_ph
 from tespy.tools.fluid_properties import single_fluid
 from tespy.tools.fluid_properties import v_mix_ph
 from tespy.tools.global_vars import err
+from tespy.tools.global_vars import always_all_equations
 
 # %%
 
@@ -161,7 +162,7 @@ class turbomachine(component):
         ######################################################################
         # eqations for fluids
         if (any(np.absolute(self.residual[k:self.num_nw_fluids])) > err ** 2 or
-                self.it % 4 == 0):
+                self.it % 4 == 0) or always_all_equations:
             self.residual[k:self.num_nw_fluids] = self.fluid_func()
         k += self.num_nw_fluids
 
@@ -515,14 +516,16 @@ class compressor(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equation for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.eta_s_char_func()
             k += 1
 
@@ -530,7 +533,7 @@ class compressor(turbomachine):
         # equations for specified characteristic map
         if self.char_map.is_set:
             if (any(np.absolute(self.residual[k:k + 2])) > err ** 2 or
-                    self.it % 4 == 0):
+                    self.it % 4 == 0) or always_all_equations:
                 self.residual[k:k + 2] = self.char_map_func()
             k += 2
 
@@ -1017,21 +1020,24 @@ class pump(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equations for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equations for specified pressure rise vs. flowrate characteristics
         if self.flow_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.flow_char_func()
             k += 1
 
@@ -1451,21 +1457,24 @@ class turbine(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # derivatives for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equation for specified cone law
         if self.cone.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
+              always_all_equations:
                 self.residual[k] = self.cone_func()
             k += 1
 

--- a/src/tespy/components/turbomachinery.py
+++ b/src/tespy/components/turbomachinery.py
@@ -36,8 +36,8 @@ from tespy.tools.fluid_properties import s_mix_pT
 from tespy.tools.fluid_properties import s_ph
 from tespy.tools.fluid_properties import single_fluid
 from tespy.tools.fluid_properties import v_mix_ph
-from tespy.tools.global_vars import err
 from tespy.tools.global_vars import always_all_equations
+from tespy.tools.global_vars import err
 
 # %%
 
@@ -162,7 +162,7 @@ class turbomachine(component):
         ######################################################################
         # eqations for fluids
         if (any(np.absolute(self.residual[k:self.num_nw_fluids])) > err ** 2 or
-                self.it % 4 == 0) or always_all_equations:
+                self.it % 4 == 0 or always_all_equations):
             self.residual[k:self.num_nw_fluids] = self.fluid_func()
         k += self.num_nw_fluids
 
@@ -516,16 +516,16 @@ class compressor(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equation for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.eta_s_char_func()
             k += 1
 
@@ -533,7 +533,7 @@ class compressor(turbomachine):
         # equations for specified characteristic map
         if self.char_map.is_set:
             if (any(np.absolute(self.residual[k:k + 2])) > err ** 2 or
-                    self.it % 4 == 0) or always_all_equations:
+                    self.it % 4 == 0 or always_all_equations):
                 self.residual[k:k + 2] = self.char_map_func()
             k += 2
 
@@ -1020,24 +1020,24 @@ class pump(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equations for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equations for specified pressure rise vs. flowrate characteristics
         if self.flow_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.flow_char_func()
             k += 1
 
@@ -1457,24 +1457,24 @@ class turbine(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # derivatives for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equation for specified cone law
         if self.cone.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or\
-              always_all_equations:
+            if (np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0 or
+                    always_all_equations):
                 self.residual[k] = self.cone_func()
             k += 1
 

--- a/src/tespy/components/turbomachinery.py
+++ b/src/tespy/components/turbomachinery.py
@@ -160,7 +160,9 @@ class turbomachine(component):
         k = 0
         ######################################################################
         # eqations for fluids
-        self.residual[k:self.num_nw_fluids] = self.fluid_func()
+        if (any(np.absolute(self.residual[k:self.num_nw_fluids])) > err ** 2 or
+                self.it % 4 == 0):
+            self.residual[k:self.num_nw_fluids] = self.fluid_func()
         k += self.num_nw_fluids
 
         ######################################################################
@@ -513,19 +515,23 @@ class compressor(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            self.residual[k] = self.eta_s_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equation for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            self.residual[k] = self.eta_s_char_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equations for specified characteristic map
         if self.char_map.is_set:
-            self.residual[k:k + 2] = self.char_map_func()
+            if (any(np.absolute(self.residual[k:k + 2])) > err ** 2 or
+                    self.it % 4 == 0):
+                self.residual[k:k + 2] = self.char_map_func()
             k += 2
 
     def additional_derivatives(self, increment_filter, k):
@@ -1011,19 +1017,22 @@ class pump(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            self.residual[k] = self.eta_s_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equations for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            self.residual[k] = self.eta_s_char_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equations for specified pressure rise vs. flowrate characteristics
         if self.flow_char.is_set:
-            self.residual[k] = self.flow_char_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.flow_char_func()
             k += 1
 
     def additional_derivatives(self, increment_filter, k):
@@ -1442,19 +1451,22 @@ class turbine(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            self.residual[k] = self.eta_s_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # derivatives for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            self.residual[k] = self.eta_s_char_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equation for specified cone law
         if self.cone.is_set:
-            self.residual[k] = self.cone_func()
+            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
+                self.residual[k] = self.cone_func()
             k += 1
 
     def additional_derivatives(self, increment_filter, k):

--- a/src/tespy/components/turbomachinery.py
+++ b/src/tespy/components/turbomachinery.py
@@ -160,9 +160,7 @@ class turbomachine(component):
         k = 0
         ######################################################################
         # eqations for fluids
-        if (any(np.absolute(self.residual[k:self.num_nw_fluids])) > err ** 2 or
-                self.it % 4 == 0):
-            self.residual[k:self.num_nw_fluids] = self.fluid_func()
+        self.residual[k:self.num_nw_fluids] = self.fluid_func()
         k += self.num_nw_fluids
 
         ######################################################################
@@ -515,23 +513,19 @@ class compressor(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.eta_s_func()
+            self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equation for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.eta_s_char_func()
+            self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equations for specified characteristic map
         if self.char_map.is_set:
-            if (any(np.absolute(self.residual[k:k + 2])) > err ** 2 or
-                    self.it % 4 == 0):
-                self.residual[k:k + 2] = self.char_map_func()
+            self.residual[k:k + 2] = self.char_map_func()
             k += 2
 
     def additional_derivatives(self, increment_filter, k):
@@ -1017,22 +1011,19 @@ class pump(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.eta_s_func()
+            self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # equations for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.eta_s_char_func()
+            self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equations for specified pressure rise vs. flowrate characteristics
         if self.flow_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.flow_char_func()
+            self.residual[k] = self.flow_char_func()
             k += 1
 
     def additional_derivatives(self, increment_filter, k):
@@ -1451,22 +1442,19 @@ class turbine(turbomachine):
         ######################################################################
         # eqations for specified isentropic efficiency
         if self.eta_s.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.eta_s_func()
+            self.residual[k] = self.eta_s_func()
             k += 1
 
         ######################################################################
         # derivatives for specified isentropic efficiency characteristics
         if self.eta_s_char.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.eta_s_char_func()
+            self.residual[k] = self.eta_s_char_func()
             k += 1
 
         ######################################################################
         # equation for specified cone law
         if self.cone.is_set:
-            if np.absolute(self.residual[k]) > err ** 2 or self.it % 4 == 0:
-                self.residual[k] = self.cone_func()
+            self.residual[k] = self.cone_func()
             k += 1
 
     def additional_derivatives(self, increment_filter, k):

--- a/src/tespy/tools/global_vars.py
+++ b/src/tespy/tools/global_vars.py
@@ -21,4 +21,4 @@ coloring = {
     'var': '\033[32m'
 }
 
-always_all_equations = True
+always_all_equations = False

--- a/src/tespy/tools/global_vars.py
+++ b/src/tespy/tools/global_vars.py
@@ -20,3 +20,5 @@ coloring = {
     'err': '\033[31m',
     'var': '\033[32m'
 }
+
+always_all_equations = True


### PR DESCRIPTION
Remove the conditions that trigger whether an component equation is to be computed. In my simulations this often caused fluid states to be pushed out of bounds and attribute values to be out of their limited range when being calculated in calc_parameters after a successfully run simulation. Removing the calculation conditions solved those problems for me.