### PR TITLE
checking fluid vector for fluids not within the network's fluid list

### DIFF
--- a/docs/whats_new/v0-3-5.rst
+++ b/docs/whats_new/v0-3-5.rst
@@ -35,7 +35,12 @@ Other Changes
 
       mynetwork.print_results(colored=False)
 
+ - An error message is raised in case the user specifies a fluid vector
+   containing fluids, that are not part of the network's fluid list
+   (`PR #233 <https://github.com/oemof/tespy/pull/233>`_).
+
 Contributors
 ############
 - Francesco Witte (`@fwitte <https://github.com/fwitte>`_)
 - `@jbueck <https://github.com/jbueck>`_
+- Markus Brandt (`@MarBrandt <https://github.com/MarBrandt>`_)

--- a/src/tespy/networks/networks.py
+++ b/src/tespy/networks/networks.py
@@ -791,6 +791,12 @@ class network:
 
             # fluid vector specification
             tmp = c.fluid.val
+            for fluid in tmp.keys():
+                if fluid not in self.fluids:
+                    msg = ('Your connection ' + c.label + ' holds a fluid, '
+                           'that is not part of the networks\'s fluids (' +
+                           fluid + ').')
+                    raise hlp.TESPyNetworkError(msg)
             tmp0 = c.fluid.val0
             tmp_set = c.fluid.val_set
             c.fluid.val = OrderedDict()

--- a/tests/test_components/test_turbomachinery.py
+++ b/tests/test_components/test_turbomachinery.py
@@ -349,8 +349,7 @@ class TestTurbomachinery:
                instance.component() + '.')
         assert 'turbomachine' == instance.component(), msg
         self.setup_network(instance)
-        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'DowQ': 0,
-              'H2O': 0, 'NH3': 0, 'CO2': 0, 'CH4': 0}
+        fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129, 'DowQ': 0, 'NH3': 0}
         self.c1.set_attr(fluid=fl, m=10, p=1, h=1e5)
         self.c2.set_attr(p=3, h=2e5)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -503,11 +503,11 @@ class TestNetworkErrors:
     def test_no_connections_error(self):
         with raises(TESPyNetworkError):
             self.nw.solve('design')
-            
+    
     def test_bad_fluids_in_fluid_vector(self):
         source1 = basics.source('source1')
         sink1 = basics.sink('sink1')
-        a = connection(source1, 'out1', sink1, 'in1', fluid={'air': 1,})
+        a = connection(source1, 'out1', sink1, 'in1', fluid={'air': 1})
         self.nw.add_conns(a)
         with raises(TESPyNetworkError):
             self.nw.solve('design')

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -503,6 +503,14 @@ class TestNetworkErrors:
     def test_no_connections_error(self):
         with raises(TESPyNetworkError):
             self.nw.solve('design')
+            
+    def test_bad_fluids_in_fluid_vector(self):
+        source1 = basics.source('source1')
+        sink1 = basics.sink('sink1')
+        a = connection(source1, 'out1', sink1, 'in1', fluid={'air': 1,})
+        self.nw.add_conns(a)
+        with raises(TESPyNetworkError):
+            self.nw.solve('design')
 
     def test_duplicate_connection_labels(self):
         source1 = basics.source('source1')

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -503,7 +503,7 @@ class TestNetworkErrors:
     def test_no_connections_error(self):
         with raises(TESPyNetworkError):
             self.nw.solve('design')
-    
+
     def test_bad_fluids_in_fluid_vector(self):
         source1 = basics.source('source1')
         sink1 = basics.sink('sink1')


### PR DESCRIPTION
- checking fluid vector for fluids not within the network's fluid list
- added 'def test_bad_fluids_in_fluid_vector' in 'test_errors.py'
- resolve #232 