### PR TITLE
#Line 253 combustion chamber stoich - issue of dict size change during for loop

### DIFF
--- a/docs/whats_new/v0-4-1.rst
+++ b/docs/whats_new/v0-4-1.rst
@@ -9,9 +9,12 @@ Documentation
 
 Bug Fixes
 #########
+- Fix RuntimeError in CombustionChamberStoich class
+  (`PR #244 <https://github.com/oemof/tespy/pull/244>`_).
 
 Other Changes
 #############
 
 Contributors
 ############
+- `@govind-menon110 <https://github.com/govind-menon110>`_

--- a/src/tespy/components/combustion/combustion_chamber_stoich.py
+++ b/src/tespy/components/combustion/combustion_chamber_stoich.py
@@ -250,7 +250,7 @@ class CombustionChamberStoich(CombustionChamber):
 
         # adjust the names for required fluids according to naming in the
         # network air
-        for f in self.air.val.keys():
+        for f in list(self.air.val.keys()):
             alias = [x for x in self.nw_fluids if x in [
                 a.replace(' ', '') for a in CP.get_aliases(f)]]
             if len(alias) > 0:


### PR DESCRIPTION
**General**

Describe your pull request as transparent as possible:

* What functionality does it implement? Bug Fix

* Where is it located? 
Location: [Combustion Chamber Stoich](https://github.com/oemof/tespy/blob/dev/src/tespy/components/combustion/combustion_chamber.py)

* Which bugs are fixed
Received an error: "RuntimeError: dictionary keys changed during iteration" for CombustionChamberStoich on the line "for f in self.air.val.keys():" which can be mitigated by adding a **list casting** similar to one on line 260 for the fuel

* Are there related issues? No
