### PR TITLE
Add timestamp to automatic model documentation generation

### DIFF
--- a/docs/whats_new/v0-4-3.rst
+++ b/docs/whats_new/v0-4-3.rst
@@ -7,5 +7,11 @@ New Features
 Bug Fixes
 #########
 
+Other Changes
+#############
+- Add a timestamp for the automatic model documentation feature
+  (`PR #247 <https://github.com/oemof/tespy/pull/247>`_)
+
 Contributors
 ############
+- `@jfreissmann <https://github.com/jfreissmann>`_

--- a/docs/whats_new/v0-4-3.rst
+++ b/docs/whats_new/v0-4-3.rst
@@ -10,7 +10,7 @@ Bug Fixes
 Other Changes
 #############
 - Add a timestamp for the automatic model documentation feature
-  (`PR #247 <https://github.com/oemof/tespy/pull/247>`_)
+  (`PR #248 <https://github.com/oemof/tespy/pull/248>`_)
 
 Contributors
 ############

--- a/src/tespy/tools/document_models.py
+++ b/src/tespy/tools/document_models.py
@@ -10,6 +10,7 @@ SPDX-License-Identifier: MIT
 """
 import os
 import sys
+from datetime import date
 
 import CoolProp as CP
 import numpy as np
@@ -124,6 +125,8 @@ def document_software_info(draft):
     latex += 'Commit:&' + git + r'\\' + '\n'
     latex += 'CoolProp version:&' + CP.__version__ + r'\\' + '\n'
     latex += 'Python version:&' + sys.version + r'\\' + '\n'
+    timestamp = date.today().strftime('%B %d, %Y')
+    latex += 'Documentation generated:&' + timestamp + r'\\' + '\n'
     latex += r'\end{tabular}' + '\n'
     latex += r'\end{table}' + '\n'
 


### PR DESCRIPTION
Adds a information on when the model documentation was generated to the main info table.