### PR TITLE
Fix: Checking dictionaries for specific keys

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -8,6 +8,7 @@ Discover noteable new features and improvements in each release
     :local:
     :backlinks: top
 
+.. include::  whats_new/v0-4-4.rst
 .. include::  whats_new/v0-4-3.rst
 .. include::  whats_new/v0-4-2.rst
 .. include::  whats_new/v0-4-1.rst

--- a/docs/whats_new/v0-4-4.rst
+++ b/docs/whats_new/v0-4-4.rst
@@ -1,0 +1,21 @@
+v0.4.4 - Someversion (Somemonth, Someday, Someyear)
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+New Features
+############
+
+Documentation
+#############
+
+Bug Fixes
+#########
+
+Other Changes
+#############
+- Check for :code:`key in dictionary` instead of
+  :code:`key in dictionary.keys()` in boolean operations
+  (`PR #264 <https://github.com/oemof/tespy/pull/264>`_).
+
+Contributors
+############
+- Francesco Witte (`@fwitte <https://github.com/fwitte>`_)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name='TESPy',
-    version='0.4.3',
+    version='0.4.4.dev0',
     license='MIT',
     description='Thermal Engineering Systems in Python (TESPy)',
     long_description='%s' % (

--- a/src/tespy/__init__.py
+++ b/src/tespy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8
 
-__version__ = '0.4.3 - Grassmann\'s Graph'
+__version__ = '0.4.4 - dev'
 
 # tespy data and connections import
 from . import connections  # noqa: F401

--- a/src/tespy/components/combustion/combustion_chamber.py
+++ b/src/tespy/components/combustion/combustion_chamber.py
@@ -242,7 +242,7 @@ class CombustionChamber(Component):
             self.fuels[f] = {}
             structure = fluid_structure(f)
             for el in ['C', 'H', 'O']:
-                if el in structure.keys():
+                if el in structure:
                     self.fuels[f][el] = structure[el]
                 else:
                     self.fuels[f][el] = 0
@@ -1134,7 +1134,7 @@ class CombustionChamber(Component):
 
         for o in self.outl:
             for fluid, x in o.fluid.val.items():
-                if not o.fluid.val_set[fluid] and fluid in fg.keys():
+                if not o.fluid.val_set[fluid] and fluid in fg:
                     o.fluid.val[fluid] = fg[fluid]
             o.target.propagate_fluid_to_target(o, o.target)
 

--- a/src/tespy/components/combustion/combustion_chamber_stoich.py
+++ b/src/tespy/components/combustion/combustion_chamber_stoich.py
@@ -345,7 +345,7 @@ class CombustionChamberStoich(CombustionChamber):
 
                 n = {}
                 for el in ['C', 'H', 'O']:
-                    if el in structure.keys():
+                    if el in structure:
                         n[el] = structure[el]
                     else:
                         n[el] = 0
@@ -435,7 +435,7 @@ class CombustionChamberStoich(CombustionChamber):
                     set([a.replace(' ', '') for a in CP.get_aliases(f)]))
 
             if len(fl) == 0:
-                if f in self.fg.keys():
+                if f in self.fg:
                     self.fg[f] += x * m_fuel
                 else:
                     self.fg[f] = x * m_fuel
@@ -445,7 +445,7 @@ class CombustionChamberStoich(CombustionChamber):
                 structure = fluid_structure(f)
                 n = {}
                 for el in ['C', 'H', 'O']:
-                    if el in structure.keys():
+                    if el in structure:
                         n[el] = structure[el]
                     else:
                         n[el] = 0
@@ -464,7 +464,7 @@ class CombustionChamberStoich(CombustionChamber):
 
         for f, x in self.air.val.items():
             if f != self.o2:
-                if f in self.fg.keys():
+                if f in self.fg:
                     self.fg[f] += m_air * x
                 else:
                     self.fg[f] = m_air * x

--- a/src/tespy/components/combustion/combustion_engine.py
+++ b/src/tespy/components/combustion/combustion_engine.py
@@ -1404,7 +1404,7 @@ class CombustionEngine(CombustionChamber):
 
         o = self.outl[2]
         for fluid, x in o.fluid.val.items():
-            if not o.fluid.val_set[fluid] and fluid in fg.keys():
+            if not o.fluid.val_set[fluid] and fluid in fg:
                 o.fluid.val[fluid] = fg[fluid]
         o.target.propagate_fluid_to_target(o, o.target)
 

--- a/src/tespy/components/component.py
+++ b/src/tespy/components/component.py
@@ -151,7 +151,7 @@ class Component:
         """
         # set specified values
         for key in kwargs:
-            if key in self.variables.keys():
+            if key in self.variables:
                 data = self.get_attr(key)
                 if kwargs[key] is None:
                     data.set_attr(is_set=False)

--- a/src/tespy/connections/bus.py
+++ b/src/tespy/connections/bus.py
@@ -326,7 +326,7 @@ class Bus:
         """
         for c in args:
             if isinstance(c, dict):
-                if 'comp' in c.keys():
+                if 'comp' in c:
                     comp = c['comp']
                     # default values
                     if isinstance(comp, Component):

--- a/src/tespy/connections/connection.py
+++ b/src/tespy/connections/connection.py
@@ -375,7 +375,7 @@ class Connection:
                 msg = 'Label can only be specified on instance creation.'
                 logging.error(msg)
                 raise TESPyConnectionError(msg)
-            elif key in self.variables.keys() or key in self.variables0:
+            elif key in self.variables or key in self.variables0:
                 # fluid specification
                 try:
                     float(kwargs[key])

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -282,8 +282,8 @@ class Network:
         # unit sets
         for prop in fpd.keys():
             unit = prop + '_unit'
-            if unit in kwargs.keys():
-                if kwargs[unit] in fpd[prop]['units'].keys():
+            if unit in kwargs:
+                if kwargs[unit] in fpd[prop]['units']:
                     self.__dict__.update({unit: kwargs[unit]})
                     msg = (
                         'Setting ' + fpd[prop]['text'] +
@@ -298,7 +298,7 @@ class Network:
                     raise ValueError(msg)
 
         for prop in ['m', 'p', 'h']:
-            if prop + '_range' in kwargs.keys():
+            if prop + '_range' in kwargs:
                 if isinstance(kwargs[prop + '_range'], list):
                     self.__dict__.update(
                         {prop + '_range_SI': hlp.convert_to_SI(
@@ -516,7 +516,7 @@ class Network:
                 logging.error(msg)
                 raise TypeError(msg)
 
-            elif c.label in self.user_defined_eq.keys():
+            elif c.label in self.user_defined_eq:
                 msg = (
                     'There is already a UserDefinedEquation with the label ' +
                     c.label + '. The UserDefinedEquation labels must be '
@@ -591,7 +591,7 @@ class Network:
                            str(b) + ') already.')
                     logging.error(msg)
                     raise hlp.TESPyNetworkError(msg)
-                elif b.label in self.busses.keys():
+                elif b.label in self.busses:
                     msg = ('Network already has a bus with the name ' +
                            b.label + '.')
                     logging.error(msg)
@@ -806,7 +806,7 @@ class Network:
             if len(self.fluids) == 1:
                 c.fluid.val[self.fluids[0]] = 1
                 c.fluid.val0[self.fluids[0]] = 1
-                if self.fluids[0] in tmp_set.keys():
+                if self.fluids[0] in tmp_set:
                     c.fluid.val_set[self.fluids[0]] = tmp_set[self.fluids[0]]
                 else:
                     c.fluid.val_set[self.fluids[0]] = False
@@ -816,13 +816,13 @@ class Network:
 
             for fluid in self.fluids:
                 # take over values from temporary dicts
-                if fluid in tmp.keys() and fluid in tmp_set.keys():
+                if fluid in tmp and fluid in tmp_set:
                     c.fluid.val[fluid] = tmp[fluid]
                     c.fluid.val0[fluid] = tmp[fluid]
                     c.fluid.val_set[fluid] = tmp_set[fluid]
                 # take over starting values
-                elif fluid in tmp0.keys():
-                    if fluid not in tmp_set.keys():
+                elif fluid in tmp0:
+                    if fluid not in tmp_set:
                         c.fluid.val[fluid] = tmp0[fluid]
                         c.fluid.val0[fluid] = tmp0[fluid]
                         c.fluid.val_set[fluid] = False
@@ -2423,7 +2423,7 @@ class Network:
 
             key = cp.__class__.__name__
 
-            if key not in self.results.keys():
+            if key not in self.results:
                 cols = [col for col, data in cp.variables.items()
                         if isinstance(data, dc_cp)]
                 self.results[key] = pd.DataFrame(columns=cols, dtype='float64')

--- a/src/tespy/tools/analyses.py
+++ b/src/tespy/tools/analyses.py
@@ -347,7 +347,7 @@ class ExergyAnalysis:
                     'or component groups in the exergy analysis. Found '
                     'component/group with name ' + cp.fkt_group + '.')
                 raise ValueError(msg)
-            elif cp.fkt_group not in self.sankey_data.keys():
+            elif cp.fkt_group not in self.sankey_data:
                 self.sankey_data[cp.fkt_group] = pd.DataFrame(
                     columns=['value', 'cat'])
 

--- a/src/tespy/tools/data_containers.py
+++ b/src/tespy/tools/data_containers.py
@@ -116,7 +116,7 @@ class DataContainer:
         var = self.attr()
         # specify values
         for key in kwargs:
-            if key in var.keys():
+            if key in var:
                 self.__dict__.update({key: kwargs[key]})
 
             else:

--- a/src/tespy/tools/document_models.py
+++ b/src/tespy/tools/document_models.py
@@ -156,7 +156,7 @@ def document_connections(nw):
         fluid_dict = data_dict.copy()
 
         data_dict.update(
-            {param: c.get_attr(param).val for param in fpd.keys()
+            {param: c.get_attr(param).val for param in fpd
              if c.get_attr(param).val_set})
 
         conn_data += [data_dict]
@@ -433,7 +433,7 @@ def get_component_mandatory_constraints(cp, component_list, path):
     mandatory_eq = ''
     figures = []
     for label, data in component_list['object'][0].constraints.items():
-        if 'char' in data.keys():
+        if 'char' in data:
             for component in component_list['object']:
                 local_path = (
                     'figures/' + cp + '_CharLine_' + label + '_' +
@@ -508,7 +508,7 @@ def get_component_specifications(cp, component_list, path):
                             {element.replace('_', r'\_'):
                              get_parameter_specification(element_data)})
 
-                    if param in data_dict_gcp.keys():
+                    if param in data_dict_gcp:
                         data_dict_gcp[param] += [gcp_data]
                     else:
                         data_dict_gcp[param] = [gcp_data]
@@ -596,7 +596,7 @@ def document_busses(nw, path):
             else:
 
                 key = (char, cp_data['base'])
-                if key in chars_plotted.keys():
+                if key in chars_plotted:
                     eta = (
                         r'$f\left(X\right)$ (\ref{fig:' +
                         chars_plotted[key]['label'] + '})')

--- a/src/tespy/tools/fluid_properties.py
+++ b/src/tespy/tools/fluid_properties.py
@@ -362,7 +362,7 @@ class Memorise:
             logging.debug(msg)
 
         for f, back_end in fluids.items():
-            if f not in Memorise.state.keys() and back_end != 'TESPy':
+            if f not in Memorise.state and back_end != 'TESPy':
                 # create CoolProp.AbstractState object
                 try:
                     Memorise.state[f] = CP.AbstractState(back_end, f)
@@ -525,7 +525,7 @@ def T_mix_ph(flow, T0=300):
     """
     # check if fluid properties have been calculated before
     fl = tuple(flow[3].keys())
-    memorisation = fl in Memorise.T_ph.keys()
+    memorisation = fl in Memorise.T_ph
     if memorisation:
         a = Memorise.T_ph[fl][:, :-2]
         b = np.array([flow[1], flow[2]] + list(flow[3].values()))
@@ -581,7 +581,7 @@ def T_ph(p, h, fluid):
     T : float
         Temperature T / K.
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         db = TESPyFluid.fluids[fluid].funcs['h_pT']
         return newton(reverse_2d, reverse_2d_deriv, [db, p, h], 0)
     elif Memorise.back_end[fluid] == 'IF97':
@@ -726,7 +726,7 @@ def T_mix_ps(flow, s, T0=300):
     """
     # check if fluid properties have been calculated before
     fl = tuple(flow[3].keys())
-    memorisation = fl in Memorise.T_ps.keys()
+    memorisation = fl in Memorise.T_ps
     if memorisation:
         a = Memorise.T_ps[fl][:, :-2]
         b = np.asarray([flow[1], flow[2]] + list(flow[3].values()) + [s])
@@ -782,7 +782,7 @@ def T_ps(p, s, fluid):
     T : float
        Temperature T / K.
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         db = TESPyFluid.fluids[fluid].funcs['s_pT']
         return newton(reverse_2d, reverse_2d_deriv, [db, p, s], 0)
     else:
@@ -851,7 +851,7 @@ def h_pT(p, T, fluid, force_gas=False):
     h : float
         Specific enthalpy h / (J/kg).
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         return TESPyFluid.fluids[fluid].funcs['h_pT'].ev(p, T)
     else:
         if force_gas:
@@ -944,7 +944,7 @@ def h_ps(p, s, fluid):
     h : float
         Specific enthalpy h / (J/kg).
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         db = TESPyFluid.fluids[fluid].funcs['s_pT']
         T = newton(reverse_2d, reverse_2d_deriv, [db, p, s], 0)
         return TESPyFluid.fluids[fluid].funcs['h_pT'].ev(p, T)
@@ -1178,7 +1178,7 @@ def v_mix_ph(flow, T0=300):
     """
     # check if fluid properties have been calculated before
     fl = tuple(flow[3].keys())
-    memorisation = fl in Memorise.v_ph.keys()
+    memorisation = fl in Memorise.v_ph
     if memorisation:
         a = Memorise.v_ph[fl][:, :-2]
         b = np.asarray([flow[1], flow[2]] + list(flow[3].values()))
@@ -1226,7 +1226,7 @@ def d_ph(p, h, fluid):
     d : float
         Density d / (kg/:math:`\mathrm{m}^3`).
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         db = TESPyFluid.fluids[fluid].funcs['h_pT']
         T = newton(reverse_2d, reverse_2d_deriv, [db, p, h], 0)
         return TESPyFluid.fluids[fluid].funcs['d_pT'].ev(p, T)
@@ -1416,7 +1416,7 @@ def d_pT(p, T, fluid):
     d : float
         Density d / (kg/:math:`\mathrm{m}^3`).
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         return TESPyFluid.fluids[fluid].funcs['d_pT'].ev(p, T)
     else:
         Memorise.state[fluid].update(CP.PT_INPUTS, p, T)
@@ -1454,7 +1454,7 @@ def visc_mix_ph(flow, T0=300):
     """
     # check if fluid properties have been calculated before
     fl = tuple(flow[3].keys())
-    memorisation = fl in Memorise.visc_ph.keys()
+    memorisation = fl in Memorise.visc_ph
     if memorisation:
         a = Memorise.visc_ph[fl][:, :-2]
         b = np.asarray([flow[1], flow[2]] + list(flow[3].values()))
@@ -1501,7 +1501,7 @@ def visc_ph(p, h, fluid):
     visc : float
         Viscosity visc / Pa s.
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         db = TESPyFluid.fluids[fluid].funcs['h_pT']
         T = newton(reverse_2d, reverse_2d_deriv, [db, p, h], 0)
         return TESPyFluid.fluids[fluid].funcs['visc_pT'].ev(p, T)
@@ -1580,7 +1580,7 @@ def visc_pT(p, T, fluid):
     visc : float
         Viscosity visc / Pa s.
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         return TESPyFluid.fluids[fluid].funcs['visc_pT'].ev(p, T)
     else:
         Memorise.state[fluid].update(CP.PT_INPUTS, p, T)
@@ -1618,7 +1618,7 @@ def s_mix_ph(flow, T0=300):
     """
     # check if fluid properties have been calculated before
     fl = tuple(flow[3].keys())
-    memorisation = fl in Memorise.s_ph.keys()
+    memorisation = fl in Memorise.s_ph
     if memorisation:
         a = Memorise.s_ph[fl][:, :-2]
         b = np.asarray([flow[1], flow[2]] + list(flow[3].values()))
@@ -1666,7 +1666,7 @@ def s_ph(p, h, fluid):
     s : float
         Specific entropy s / (J/(kgK)).
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         db = TESPyFluid.fluids[fluid].funcs['h_pT']
         T = newton(reverse_2d, reverse_2d_deriv, [db, p, h], 0)
         return TESPyFluid.fluids[fluid].funcs['s_pT'].ev(p, T)
@@ -1714,17 +1714,17 @@ def s_mix_pT(flow, T, force_gas=False):
     fluid_comps = {}
 
     tespy_fluids = [
-        s for s in flow[3].keys() if s in TESPyFluid.fluids.keys()]
+        s for s in flow[3].keys() if s in TESPyFluid.fluids]
     for f in tespy_fluids:
         for it, x in TESPyFluid.fluids[f].fluid.items():
-            if it in fluid_comps.keys():
+            if it in fluid_comps:
                 fluid_comps[it] += x * flow[3][f]
             else:
                 fluid_comps[it] = x * flow[3][f]
 
-    fluids = [s for s in flow[3].keys() if s not in TESPyFluid.fluids.keys()]
+    fluids = [s for s in flow[3].keys() if s not in TESPyFluid.fluids]
     for f in fluids:
-        if f in fluid_comps.keys():
+        if f in fluid_comps:
             fluid_comps[f] += flow[3][f]
         else:
             fluid_comps[f] = flow[3][f]
@@ -1762,7 +1762,7 @@ def s_pT(p, T, fluid, force_gas):
     s : float
         Specific entropy s / (J/(kgK)).
     """
-    if fluid in TESPyFluid.fluids.keys():
+    if fluid in TESPyFluid.fluids:
         return TESPyFluid.fluids[fluid].funcs['s_pT'].ev(p, T)
     else:
         if force_gas:


### PR DESCRIPTION
Checking for keys ins dictionaries should not be done with `in dict.keys()` but with `in dict` instead.