### PR TITLE
Add new feature: nDodecane as fuel for combustion

### DIFF
--- a/docs/whats_new/v0-4-4.rst
+++ b/docs/whats_new/v0-4-4.rst
@@ -1,0 +1,25 @@
+v0.4.4 - Someversion (July, 12, 2021)
++++++++++++++++++++++++++++++++++++++
+
+Documentation
+#############
+- Fix some typos here and there.
+
+Bug Fixes
+#########
+- Fix pandas version 1.3.0 dependencies
+  (`PR #277 <https://github.com/oemof/tespy/pull/277>`_).
+- Add missing results for some components in the results DataFrame of the
+  network (`PR #277 <https://github.com/oemof/tespy/pull/277>`_).
+
+Other Changes
+#############
+- Add warning logs for missing fluid composition data in the initialisation
+  process of the network
+  (`PR #278 <https://github.com/oemof/tespy/pull/278>`_).
+- Add Dodecane to the available fuels for combustion
+  (`PR #273 <https://github.com/oemof/tespy/pull/273>`_).
+
+Contributors
+############
+- Francesco Witte (`@fwitte <https://github.com/fwitte>`_)

--- a/src/tespy/components/combustion/combustion_chamber.py
+++ b/src/tespy/components/combustion/combustion_chamber.py
@@ -279,7 +279,7 @@ class CombustionChamber(Component):
         hf['ethane'] = -84.68
         hf['propane'] = -103.8
         hf['butane'] = -124.51
-        hf['nDodecane'] = -352.1
+        hf['nDodecane'] = -288.1
         hf[self.o2] = 0
         hf[self.co2] = -393.5
         # water (gaseous)

--- a/src/tespy/components/combustion/combustion_chamber.py
+++ b/src/tespy/components/combustion/combustion_chamber.py
@@ -201,7 +201,8 @@ class CombustionChamber(Component):
     def setup_reaction_parameters(self):
         r"""Setup parameters for reaction (gas name aliases and LHV)."""
         self.fuel_list = []
-        fuels = ['methane', 'ethane', 'propane', 'butane', 'hydrogen']
+        fuels = [
+            'methane', 'ethane', 'propane', 'butane', 'hydrogen', 'nDodecane']
         for f in fuels:
             self.fuel_list += [x for x in self.nw_fluids if x in [
                 a.replace(' ', '') for a in CP.get_aliases(f)]]
@@ -209,14 +210,15 @@ class CombustionChamber(Component):
         if len(self.fuel_list) == 0:
             msg = ('Your network\'s fluids do not contain any fuels, that are '
                    'available for the component ' + self.label + ' of type ' +
-                   self.component() + '. Available fuels are: ' + str(fuels) +
-                   '.')
+                   self.component() + '. Available fuels are: ' +
+                   ', '.join(fuels) + '.')
             logging.error(msg)
             raise TESPyComponentError(msg)
 
         else:
             msg = ('The fuels for component ' + self.label + ' of type ' +
-                   self.component() + ' are: ' + str(self.fuel_list) + '.')
+                   self.component() + ' are: ' + ', '.join(self.fuel_list) +
+                   '.')
             logging.debug(msg)
 
         for fluid in ['o2', 'co2', 'h2o', 'n2']:
@@ -277,6 +279,7 @@ class CombustionChamber(Component):
         hf['ethane'] = -84.68
         hf['propane'] = -103.8
         hf['butane'] = -124.51
+        hf['nDodecane'] = -352.1
         hf[self.o2] = 0
         hf[self.co2] = -393.5
         # water (gaseous)


### PR DESCRIPTION
Resolve #272 

This PR adds new fuels to the class CombustionChamber. To check:

- Is the energy balance calculated correctly even for liquid fuels?
- Default starting values for nDodecane are really bad.