### PR TITLE
Fix: Add missing component results in the results DataFrames

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -7,7 +7,8 @@ Discover noteable new features and improvements in each release
     :depth: 1
     :local:
     :backlinks: top
-
+    
+.. include::  whats_new/v0-4-4.rst
 .. include::  whats_new/v0-4-3-003.rst
 .. include::  whats_new/v0-4-3-001.rst
 .. include::  whats_new/v0-4-3.rst

--- a/docs/whats_new/v0-4-4.rst
+++ b/docs/whats_new/v0-4-4.rst
@@ -1,0 +1,20 @@
+v0.4.4 - Someversion (July, 12, 2021)
++++++++++++++++++++++++++++++++++++++
+
+Documentation
+#############
+- Fix some typos here and there.
+
+Bug Fixes
+#########
+- Fix pandas version 1.3.0 dependencies
+  (`PR #277 <https://github.com/oemof/tespy/pull/277>`_).
+- Add missing results for some components in the results DataFrame of the
+  network (`PR #277 <https://github.com/oemof/tespy/pull/277>`_).
+
+Other Changes
+#############
+
+Contributors
+############
+- Francesco Witte (`@fwitte <https://github.com/fwitte>`_)

--- a/src/tespy/components/basics/cycle_closer.py
+++ b/src/tespy/components/basics/cycle_closer.py
@@ -99,8 +99,8 @@ class CycleCloser(Component):
     @staticmethod
     def get_variables():
         return {
-            'mass_deviation': dc_cp(val=0, max_val=1e-3),
-            'fluid_deviation': dc_cp(val=0, max_val=1e-5)
+            'mass_deviation': dc_cp(val=0, max_val=1e-3, is_result=True),
+            'fluid_deviation': dc_cp(val=0, max_val=1e-5, is_result=True)
         }
 
     def get_mandatory_constraints(self):

--- a/src/tespy/components/heat_exchangers/heat_exchanger_simple.py
+++ b/src/tespy/components/heat_exchangers/heat_exchanger_simple.py
@@ -868,6 +868,9 @@ class HeatExchangerSimple(Component):
                 td_log = np.nan
 
             self.kA.val = abs(i[0] * (o[2] - i[2]) / td_log)
+            self.kA.is_result = True
+        else:
+            self.kA.is_result = False
 
     def entropy_balance(self):
         r"""

--- a/src/tespy/components/heat_exchangers/parabolic_trough.py
+++ b/src/tespy/components/heat_exchangers/parabolic_trough.py
@@ -366,3 +366,6 @@ class ParabolicTrough(HeatExchangerSimple):
             ))
         if self.energy_group.is_set:
             self.Q_loss.val = - self.E.val * self.A.val + self.Q.val
+            self.Q_loss.is_result = True
+        else:
+            self.Q_loss.is_result = False

--- a/src/tespy/components/heat_exchangers/solar_collector.py
+++ b/src/tespy/components/heat_exchangers/solar_collector.py
@@ -315,3 +315,6 @@ class SolarCollector(HeatExchangerSimple):
             ))
         if self.energy_group.is_set:
             self.Q_loss.val = -(self.E.val * self.A.val - self.Q.val)
+            self.Q_loss.is_result = True
+        else:
+            self.Q_loss.is_result = False

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -2537,6 +2537,8 @@ class Network:
                 if (p.func is not None or (p.func is None and p.is_set) or
                         p.is_result):
                     self.results[key].loc[cp.label, param] = p.val
+                else:
+                    self.results[key].loc[cp.label, param] = np.nan
 
     def process_busses(self):
         """Process the bus results."""

--- a/src/tespy/tools/data_containers.py
+++ b/src/tespy/tools/data_containers.py
@@ -278,7 +278,7 @@ class ComponentProperties(DataContainer):
         return {
             'val': 1, 'val_SI': 0, 'is_set': False, 'd': 1e-4,
             'min_val': -1e12, 'max_val': 1e12, 'is_var': False,
-            'val_ref': 1, 'design': np.nan,
+            'val_ref': 1, 'design': np.nan, 'is_result': False,
             'num_eq': 0, 'func_params': {}, 'func': None, 'deriv': None,
             'latex': None}
 

--- a/tests/test_components/test_heat_exchangers.py
+++ b/tests/test_components/test_heat_exchangers.py
@@ -61,7 +61,7 @@ class TestHeatExchangers:
 
         self.nw.add_conns(self.c1, self.c2, self.c3, self.c4)
 
-    def test_HeatExhangerSimple(self):
+    def test_HeatExchangerSimple(self):
         """Test component properties of simple heat exchanger."""
         instance = HeatExchangerSimple('heat exchanger')
         self.setup_HeatExchangerSimple_network(instance)
@@ -138,6 +138,27 @@ class TestHeatExchangers:
         msg = ('Value of heat transfer must be ' + str(Q) +
                ', is ' + str(instance.Q.val) + '.')
         assert Q == round(instance.Q.val, 0), msg
+
+        # test kA as network results parameter
+        instance.set_attr(Q=-5e4, Tamb=None)
+        b.set_attr(P=None)
+        self.nw.solve('design')
+        convergence_check(self.nw.lin_dep)
+        kA_network = self.nw.results['HeatExchangerSimple'].loc[
+            instance.label, 'kA']
+        print(kA_network)
+        msg = 'kA value must not be included in network results.'
+        expr = not instance.kA.is_result and np.isnan(kA_network)
+        assert expr, msg
+
+        # test kA as network results parameter
+        instance.set_attr(Tamb=20)
+        self.nw.solve('design')
+        kA_network = self.nw.results['HeatExchangerSimple'].loc[
+            instance.label, 'kA']
+        kA_comp = instance.kA.val
+        msg = 'kA value needs to be identical on network and component level.'
+        assert kA_network == kA_comp, msg
 
     def test_ParabolicTrough(self):
         """Test component properties of parabolic trough."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -309,7 +309,7 @@ class TestCombustionChamberStoichErrors:
         self.setup_CombustionChamberStoich_error_tests()
         self.instance.set_attr(air_alias='some alias')
         msg = 'The air_alias has been set, is_set should be True.'
-        assert self.instance.air_alias.is_set is True, msg
+        assert self.instance.air_alias.is_set, msg
 
         self.instance.set_attr(air_alias=None)
         msg = 'The air_alias has been unset, is_set should be False.'

--- a/tests/test_networks/test_network.py
+++ b/tests/test_networks/test_network.py
@@ -57,7 +57,7 @@ class TestNetworks:
         self.nw.solve('design')
         msg = ('This test must result in a linear dependency of the jacobian '
                'matrix.')
-        assert self.nw.lin_dep is True, msg
+        assert self.nw.lin_dep, msg
 
     def test_Network_no_progress(self):
         """Test no convergence progress."""
@@ -92,7 +92,7 @@ class TestNetworks:
         self.nw.add_conns(a)
         self.nw.check_network()
         msg = ('After the network check, the .checked-property must be True.')
-        assert self.nw.checked is True, msg
+        assert self.nw.checked, msg
 
         self.nw.del_conns(a)
         msg = ('A connection has been deleted, the network consistency check '
@@ -108,7 +108,7 @@ class TestNetworks:
         self.nw.solve('design', init_only=True)
         self.nw.save('tmp')
         msg = ('After the network check, the .checked-property must be True.')
-        assert self.nw.checked is True, msg
+        assert self.nw.checked, msg
 
         self.nw.del_conns(a)
         a = Connection(self.source, 'out1', IF, 'in1')
@@ -116,7 +116,7 @@ class TestNetworks:
         self.nw.add_conns(a, b)
         self.nw.solve('design', init_path='tmp', init_only=True)
         msg = ('After the network check, the .checked-property must be True.')
-        assert self.nw.checked is True, msg
+        assert self.nw.checked, msg
 
         shutil.rmtree('./tmp', ignore_errors=True)
 
@@ -152,7 +152,7 @@ class TestNetworks:
         imported_nwk.solve('design', init_only=True)
         msg = ('If the network import was successful the network check '
                'should have been successful, too, but it is not.')
-        assert imported_nwk.checked is True, msg
+        assert imported_nwk.checked, msg
         shutil.rmtree('./tmp', ignore_errors=True)
 
     def test_Network_reader_deleted_chars(self):
@@ -174,7 +174,7 @@ class TestNetworks:
         imported_nwk.solve('design', init_only=True)
         msg = ('If the network import was successful the network check '
                'should have been successful, too, but it is not.')
-        assert imported_nwk.checked is True, msg
+        assert imported_nwk.checked, msg
         shutil.rmtree('./tmp', ignore_errors=True)
 
     def test_Network_missing_data_in_design_case_files(self):
@@ -397,11 +397,11 @@ class TestNetworkIndividualOffdesign:
         assert self.sc1_v1.T.design > self.sc1_v1.T.val, msg
 
         msg = ('Parameter eta_s_char must be set for pump one.')
-        assert self.pump1.eta_s_char.is_set is True, msg
+        assert self.pump1.eta_s_char.is_set, msg
 
         msg = ('Parameter v must be set for connection from solar collector1 '
                'to pump1.')
-        assert self.sc1_v1.v.val_set is True, msg
+        assert self.sc1_v1.v.val_set, msg
 
         shutil.rmtree('./design1', ignore_errors=True)
         shutil.rmtree('./design2', ignore_errors=True)

--- a/tests/test_tools/test_characteristics.py
+++ b/tests/test_tools/test_characteristics.py
@@ -62,13 +62,13 @@ def test_custom_CharLine_import():
            str(char_custom.x) + ' must be identical to the x values from '
            'the default characteristic line ' + str(char_original.x) + ' '
            'as these have been duplicated before load.')
-    assert x_cond is True, msg
+    assert x_cond, msg
 
     msg = ('The y values from the custom characteristic line ' +
            str(char_custom.y) + ' must be identical to the y values from '
            'the default characteristic line ' + str(char_original.y) + ' '
            'as these have been duplicated before load.')
-    assert y_cond is True, msg
+    assert y_cond, msg
 
 
 def test_custom_CharMap_import():
@@ -111,19 +111,19 @@ def test_custom_CharMap_import():
            str(char_custom.x) + ' must be identical to the x values from '
            'the default characteristic line ' + str(char_original.x) + ' '
            'as these have been duplicated before load.')
-    assert x_cond is True, msg
+    assert x_cond, msg
 
     msg = ('The y values from the custom characteristic line ' +
            str(char_custom.y) + ' must be identical to the y values from '
            'the default characteristic line ' + str(char_original.y) + ' '
            'as these have been duplicated before load.')
-    assert y_cond is True, msg
+    assert y_cond, msg
 
     msg = ('The z values from the custom characteristic line ' +
            str(char_custom.z) + ' must be identical to the z values from '
            'the default characteristic line ' + str(char_original.z) + ' '
            'as these have been duplicated before load.')
-    assert z_cond is True, msg
+    assert z_cond, msg
 
 
 def test_CharLine_evaluation():


### PR DESCRIPTION
Resolve #276 

The components
- HeatExchangerSimple
- ParabolicTrough
- Pipe
- SolarCollector
are missing results in the results DataFrame, e.g. in case kA is a result of change in temperature in a pipe at specified ambient temperature. The result is available on component level (i.e. comp.kA.val) but not in the network's results DataFrame (i.e. network.results['Pipe']). A new 'is_result' attribute is added to ComponentProperties DataContainers to handle this.

Tests to be added!