### PR TITLE
Fix/exergy analysis fkt group labeling

### DIFF
--- a/docs/analyses/exergy.rst
+++ b/docs/analyses/exergy.rst
@@ -302,8 +302,8 @@ results are printed in five individual tables:
 - connections
 - components
 - busses
-- groups (component groups)
 - network
+- groups (component groups)
 
 By default, all of these tables are printed to the prompt. It is possible to
 deselect the tables, e.g. by passing :code:`groups=False` to the method call.
@@ -315,6 +315,14 @@ deselect the tables, e.g. by passing :code:`groups=False` to the method call.
 For the component related tables, i.e. busses, components and groups, the data
 are sorted descending regarding the exergy destruction value of the individual
 component.
+
+.. note::
+  Please note, that in contrast to the component and bus data, group data do
+  not contain fuel and product exergy as well as exergy efficiency. Instead all
+  exergy streams entering the system borders of the component group and all
+  exergy streams leaving the system borders are calculated. On this basis, a
+  graphical representation of the exergy flows in the network can be generated
+  in the form of a Grassmann diagram.
 
 Accessing the data
 ^^^^^^^^^^^^^^^^^^

--- a/docs/analyses/exergy.rst
+++ b/docs/analyses/exergy.rst
@@ -37,6 +37,7 @@ processes yet, chemical exergy is not considered. Changes in kinetic and
 potential exergy are neglected and therefore not considered as well.
 
 .. list-table:: Terminology
+
     :widths: 20 20 10 50
     :header-rows: 1
     :class: tight-table
@@ -103,33 +104,35 @@ potential exergy are neglected and therefore not considered as well.
 
 Tutorial
 --------
-In this short tutorial, an exergy analysis is carried out for the Solar Energy
-Generating System (SEGS). The full python script is available on GitHub in
-an individual repository: https://github.com/fwitte/SEGS_exergy.
+In this short tutorial, an exergy analysis is carried out for the so called
+"Solar Energy Generating System" (SEGS). The full python script is available on
+GitHub in an individual repository: https://github.com/fwitte/SEGS_exergy.
 
 Two other full code examples are to be found at:
 
 - Supercritical CO\ :sub:`2` power cycle: https://github.com/fwitte/sCO2_exergy
 - Refrigeration machine: https://github.com/fwitte/refrigeration_cycle_exergy
 
-The SEGS consists of three main systems, the solar field, the steam cycle and
-the cooling water system. In the solar field Therminol VP1 is used as heat
-transfer liquid. In the steam generator and reheater the TVP1 is cooled down to
-evaporate and overheat/reheat the water of the steam cycle. The turbine is
-divided in a high pressure turbine and a low pressure turbine, which are
-further subdivided in 2 stages (high pressure turbine) and 5 stages. In between
-the stages steam is exctracted for preheating. Finally, the main condenser of
-the steam cycle is connected to an air cooling tower. The figure below shows
-the topology of the model.
+SEGS consists of three main systems, the solar field, the steam cycle and the
+cooling water system. In the solar field Therminol VP1 is used as heat transfer
+fluid. In the steam generator and reheater the TVP1 is cooled down to evaporate
+and overheat/reheat the water of the steam cycle. The turbine is divided in a
+high pressure turbine and a low pressure turbine, which are further subdivided
+in 2 parts (high pressure turbine) and 5 parts. In between the stages steam is
+exctracted for preheating. Finally, the main condenser of the steam cycle is
+connected to an air cooling tower. The figure below shows the topology of the
+model.
 
 .. figure:: api/_images/SEGS_flowsheet.svg
+
     :align: center
     :alt: Topology of the Solar Energy Generating System (SEGS)
 
 The input data are based on literature :cite:`Kearney1988`, which provides
 measured data. Some parameters are however taken from a follow-up publication,
 as the original data show some inconsistencies, e.g. higher enthalpy at the low
-pressure turbine's last stage outlet than at its inlet :cite:`Lippke1995`.
+pressure turbine's last stage outlet than at its inlet :cite:`Lippke1995`. As
+mentioned, you can find all data in the respective GitHub repository.
 
 TESPy model
 ^^^^^^^^^^^
@@ -142,9 +145,11 @@ is implemented, calculating the surface area required for the provision of the
 heat input at optimal conditions.
 
 All components are flagged with the :code:`fkt_group` parameter, which will
-automatically create component groups for the exergy analysis sankey diagram.
-The specification of this parameter is not required for the exergy analysis
-itself, but helps to simplify the automatically generated sankey diagram.
+automatically create functional groups (component groups) for the exergy
+analysis Grassmann diagram. The specification of this parameter is not required
+for the exergy analysis itself, but helps to simplify the automatically
+generated diagram. Components not assigned to any functional group will form
+their respective group.
 
 Regarding parameter specification, the following parameters are specified:
 
@@ -303,7 +308,7 @@ results are printed in five individual tables:
 - components
 - busses
 - network
-- groups (component groups)
+- groups (functional groups)
 
 By default, all of these tables are printed to the prompt. It is possible to
 deselect the tables, e.g. by passing :code:`groups=False` to the method call.
@@ -314,9 +319,11 @@ deselect the tables, e.g. by passing :code:`groups=False` to the method call.
 
 For the component related tables, i.e. busses, components and groups, the data
 are sorted descending regarding the exergy destruction value of the individual
-component.
+entry. To merge the bus and component data into one table, use:
+...
 
 .. note::
+
   Please note, that in contrast to the component and bus data, group data do
   not contain fuel and product exergy as well as exergy efficiency. Instead all
   exergy streams entering the system borders of the component group and all
@@ -364,6 +371,7 @@ diagram is then easily done:
     fig.show()
 
 .. figure:: api/_images/SEGS_sankey.png
+
     :align: center
     :alt: Sankey diagram of the Soler Energy Generating System (SEGS)
 
@@ -391,11 +399,12 @@ colors can be assigned to these types of streams.
 
 .. note::
 
-    - The :code:`node_order` must contain all exergy streams, thus including
+    - The :code:`node_order` must contain all exergy streams, thus
 
-      - ALL component group labels
-      - lables of the busses used in the definitions of the analysis
-      - :code:`'E_F'`, :code:`'E_P'`, :code:`'E_D'`, :code:`'E_L'`
+      - ALL component group labels (you can find the labels in the group data
+        results printout),
+      - lables of the busses used in the definitions of the analysis and
+      - :code:`'E_F'`, :code:`'E_P'`, :code:`'E_D'` as well as :code:`'E_L'`
 
     - The colors dictionary works with the following keys:
 

--- a/docs/analyses/exergy.rst
+++ b/docs/analyses/exergy.rst
@@ -302,11 +302,12 @@ rounding errors).
 
 Printing the results is possible with the
 :py:meth:`tespy.tools.analyses.ExergyAnalysis.print_results` method. The
-results are printed in five individual tables:
+results are printed in six individual tables:
 
 - connections
 - components
 - busses
+- aggregation (aggregation of components and the respective busses)
 - network
 - groups (functional groups)
 
@@ -317,10 +318,19 @@ deselect the tables, e.g. by passing :code:`groups=False` to the method call.
 
     ean.print_results(groups=False, connections=False)
 
-For the component related tables, i.e. busses, components and groups, the data
-are sorted descending regarding the exergy destruction value of the individual
-entry. To merge the bus and component data into one table, use:
-...
+For the component related tables, i.e. busses, components, aggregation and
+groups, the data are sorted descending regarding the exergy destruction value
+of the individual entry. The component data contain fuel exergy, product exergy
+and exergy destruction values related to the component itself ignoring losses
+that might occur on the busses, for example, mechanical or electrical
+conversion losses in motors and generators. The bus data contain the respective
+information related to the conversion losses on the busses only. The
+aggregation data contain both, the component and the bus data. For instance,
+a turbine driving a generator will have the electrical energy delivered by the
+generator as product exergy value. The same component's exergy product without
+considering the mechanical or electrical conversion losses is the shaft power
+delivered by the turbine. From the generator's perspective, this is the fuel
+exergy, while the product is the electrical energy.
 
 .. note::
 
@@ -343,6 +353,7 @@ the following code snippet.
     connection_data = ean.connection_data
     bus_data = ean.bus_data
     component_data = ean.component_data
+    aggregation_data = ean.aggregation_data
     network_data = ean.network_data
     group_data = ean.group_data
 

--- a/docs/whats_new/v0-5-1.rst
+++ b/docs/whats_new/v0-5-1.rst
@@ -3,6 +3,10 @@ v0.5.1 - Someversion (Somemonth, Someday, Someyear)
 
 Documentation
 #############
+- Improvements on the description of the exergy analysis results data.
+  Additional dataframe added, that contains the aggregated component exergy
+  analysis results (component and respective bus exergy data)
+  (`PR #293 <https://github.com/oemof/tespy/pull/293>`_).
 
 Bug Fixes
 #########

--- a/src/tespy/tools/analyses.py
+++ b/src/tespy/tools/analyses.py
@@ -366,14 +366,16 @@ class ExergyAnalysis:
         # calculate exergy destruction ratios for components/busses
         E_F = self.network_data.loc['E_F']
         E_D = self.network_data.loc['E_D']
-        self.component_data['y_Dk'] = self.component_data['E_D'] / E_F
-        self.component_data['y*_Dk'] = self.component_data['E_D'] / E_D
-        self.bus_data['y_Dk'] = self.bus_data['E_D'] / E_F
-        self.bus_data['y*_Dk'] = self.bus_data['E_D'] / E_D
+
+        for d in [self.component_data, self.bus_data, self.aggregation_data]:
+            d['y_Dk'] = d['E_D'] / E_F
+            d['y*_Dk'] = d['E_D'] / E_D
+            d['epsilon'] = d['E_P'] / d['E_F']
 
         residual = abs(
             self.network_data.loc['E_F'] - self.network_data.loc['E_P'] -
-            self.network_data.loc['E_D'] - self.network_data.loc['E_L'])
+            self.network_data.loc['E_D'] - self.network_data.loc['E_L']
+        )
 
         if residual >= err ** 0.5:
             msg = (
@@ -449,19 +451,40 @@ class ExergyAnalysis:
                     else:
                         self.sankey_data[cp.fkt_group].loc[b.label] = [E_P, cat]
 
+                self.bus_data.loc[cp.label, 'base'] = b.comps.loc[cp, 'base']
                 self.bus_data.loc[cp.label, 'group'] = cp.fkt_group
 
                 cp_on_num_busses += 1
 
         self.bus_data['E_D'] = self.bus_data['E_F'] - self.bus_data['E_P']
-        self.bus_data['epsilon'] = self.bus_data['E_P'] / self.bus_data['E_F']
+
+        # create a table that includes exergy destruction attributed to the
+        # components
+        self.aggregation_data = self.component_data.copy()
+        bus_based = self.bus_data[self.bus_data['base'] == 'bus'].index
+        component_based = self.bus_data[self.bus_data['base'] == 'component'].index
+
+        self.aggregation_data.loc[bus_based, 'E_F'] = (
+            self.bus_data.loc[bus_based, 'E_F']
+        )
+        self.aggregation_data.loc[component_based, 'E_P'] = (
+            self.bus_data.loc[component_based, 'E_P']
+        )
+
+        E_P_notna = self.aggregation_data[
+            ~np.isnan(self.aggregation_data['E_P'])
+        ].index
+        self.aggregation_data.loc[E_P_notna, 'E_D'] = (
+            self.aggregation_data.loc[E_P_notna, 'E_F'] -
+            self.aggregation_data.loc[E_P_notna, 'E_P']
+        )
 
     def create_group_data(self):
         """Collect the component group exergy data."""
         for group in self.sankey_data.keys():
-            E_D = 0
-            for df in [self.component_data, self.bus_data]:
-                E_D += df[df['group'] == group]['E_D'].sum()
+            E_D = self.aggregation_data[
+                self.aggregation_data['group'] == group
+            ]['E_D'].sum()
             self.sankey_data[group].loc['E_D'] = [E_D, 'E_D']
 
         # establish connections for fuel exergy via bus balance
@@ -681,7 +704,7 @@ class ExergyAnalysis:
     def print_results(
             self, sort_desc=True,
             busses=True, components=True, connections=True, groups=True,
-            network=True):
+            network=True, aggregation=True):
         r"""Print the results of the exergy analysis to prompt.
 
         - The results are sorted beginning with the component having the
@@ -705,6 +728,9 @@ class ExergyAnalysis:
 
         network : boolean
             Print network results, default value :code:`True`.
+
+        aggregation : boolean
+            Print aggregated component results, default value :code:`True`.
         """
         if connections:
             print('##### RESULTS: Connection specific physical exergy and ' +
@@ -730,6 +756,16 @@ class ExergyAnalysis:
                 df.sort_values(by=['E_D'], ascending=False, inplace=True)
 
             print('##### RESULTS: Bus exergy analysis #####')
+            print(tabulate(
+                df, headers='keys', tablefmt='psql', floatfmt='.3e'))
+
+        if aggregation:
+            df = self.aggregation_data.copy()
+            df = df.loc[:, df.columns != 'group']
+            if sort_desc:
+                df.sort_values(by=['E_D'], ascending=False, inplace=True)
+
+            print('##### RESULTS: Aggregation of components and busses #####')
             print(tabulate(
                 df, headers='keys', tablefmt='psql', floatfmt='.3e'))
 

--- a/src/tespy/tools/analyses.py
+++ b/src/tespy/tools/analyses.py
@@ -505,18 +505,16 @@ class ExergyAnalysis:
 
         # create overview of component groups
         self.group_data = pd.DataFrame(
-            columns=['E_F', 'E_P', 'E_D'], dtype='float64')
+            columns=['E_in', 'E_out', 'E_D'], dtype='float64')
         for fkt_group in self.component_data['group'].unique():
-            self.group_data.loc[fkt_group, 'E_F'] = (
+            self.group_data.loc[fkt_group, 'E_in'] = (
                 self.calculate_group_input_value(fkt_group))
             self.group_data.loc[fkt_group, 'E_D'] = (
                 self.sankey_data[fkt_group].loc['E_D', 'value'])
 
         # calculate missing values
-        self.group_data['E_P'] = (
-            self.group_data['E_F'] - self.group_data['E_D'])
-        self.group_data['epsilon'] = (
-            self.group_data['E_P'] / self.group_data['E_F'])
+        self.group_data['E_out'] = (
+            self.group_data['E_in'] - self.group_data['E_D'])
         self.group_data['y_Dk'] = (
             self.group_data['E_D'] / self.network_data.loc['E_F'])
         self.group_data['y*_Dk'] = (
@@ -735,18 +733,18 @@ class ExergyAnalysis:
             print(tabulate(
                 df, headers='keys', tablefmt='psql', floatfmt='.3e'))
 
-        if groups:
-            df = self.group_data.copy()
-            if sort_desc:
-                df.sort_values(by=['E_D'], ascending=False, inplace=True)
-
-            print('##### RESULTS: Component group exergy analysis #####')
-            print(tabulate(
-                df, headers='keys', tablefmt='psql', floatfmt='.3e'))
-
         if network:
             print('##### RESULTS: Network exergy analysis #####')
             print(tabulate(
                 self.network_data.to_frame().transpose(),
                 headers='keys', tablefmt='psql', floatfmt='.3e',
                 showindex=False))
+
+        if groups:
+            df = self.group_data.copy()
+            if sort_desc:
+                df.sort_values(by=['E_D'], ascending=False, inplace=True)
+
+            print('##### RESULTS: Component group exergy inflows and outflows #####')
+            print(tabulate(
+                df, headers='keys', tablefmt='psql', floatfmt='.3e'))

--- a/src/tespy/tools/analyses.py
+++ b/src/tespy/tools/analyses.py
@@ -745,6 +745,6 @@ class ExergyAnalysis:
             if sort_desc:
                 df.sort_values(by=['E_D'], ascending=False, inplace=True)
 
-            print('##### RESULTS: Component group exergy inflows and outflows #####')
+            print('##### RESULTS: Functional groups exergy flows #####')
             print(tabulate(
                 df, headers='keys', tablefmt='psql', floatfmt='.3e'))


### PR DESCRIPTION
Correct the exergy analysis result printout. The component group's result data are used for Grassmann diagrams only. `E_F` and `E_P` are not following a respective definition, but are the summed exergy streams entering and leaving the component group. Therefore, these data are relabelled to `E_in` and `E_out` and the exergy efficiency `epsilon` is removed.