### PR TITLE
New Feature: Support for INCOMP binary mixtures

### DIFF
--- a/docs/tespy_modules/fluid_properties.rst
+++ b/docs/tespy_modules/fluid_properties.rst
@@ -45,8 +45,10 @@ cover liquid state only.
 
 Fluid mixtures
 --------------
-CoolProp provides fluid properties for two component mixtures. BUT: These are
-NOT integrated in TESPy! Nevertheless, you can use fluid mixtures for gases.
+CoolProp provides fluid properties for two component mixtures. Through the
+INCOMP backed, these `binary mixtures <http://www.coolprop.org/fluid_properties/Incompressibles.html#id180>`_
+are now also supported by TESPy along with fluid mixtures for gases as
+mentioned below.
 
 Ideal mixtures of gaseous fluids
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,9 +66,7 @@ for more information.
 
 Other mixtures
 ^^^^^^^^^^^^^^
-It is **not possible** to use mixtures of liquid and other liquid or gaseous
-fluids **at the moment**! If you try to use a mixture of two liquid or gaseous
-fluids and liquid fluids, e.g. water and methanol or liquid water and air, the
-equations will still be applied, but obviously return bad values. If you have
-ideas for the implementation of new kinds of mixtures we appreciate you
-contacting us.
+Support for arbitrary mixtures of liquid and other liquid or gaseous
+fluids is **not supported at the moment**! However, as mentioned previously, a set
+of mixtures defined in CoolProp is supported. If you have ideas for the
+implementation of new kinds of mixtures we appreciate you contacting us.

--- a/tutorial/binary_mixtures.py
+++ b/tutorial/binary_mixtures.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from tespy.components import HeatExchanger
+from tespy.components import Sink
+from tespy.components import Source
+from tespy.connections import Connection
+from tespy.networks import Network
+
+# %% network
+
+nw = Network(fluids=['INCOMP::MEG[0.2]', 'INCOMP::MPG[0.4]'], T_unit='C', p_unit='bar',
+             h_unit='kJ / kg', m_unit='kg / s')
+
+# %% components
+
+meg_in = Source('meg source')
+meg_out = Sink('meg sink')
+hx = HeatExchanger('exchanger')
+mpg_in = Source('mpg source')
+mpg_out = Sink('mpg sink')
+
+# %% connections
+
+# hot side
+meg_in_hx = Connection(meg_in, 'out1', hx, 'in2')
+hx_meg_out = Connection(hx, 'out2', meg_out, 'in1')
+nw.add_conns(meg_in_hx, hx_meg_out)
+
+# cold side
+mpg_in_hx = Connection(mpg_in, 'out1', hx, 'in1')
+hx_mpg_out = Connection(hx, 'out1', mpg_out, 'in1')
+nw.add_conns(mpg_in_hx, hx_mpg_out)
+
+
+# %% component parametrization
+
+hx.set_attr(Q=-1e3, pr1=1, pr2=1)
+
+# %% connection parametrization
+
+meg_in_hx.set_attr(fluid={'MEG[0.2]': 1, 'MPG[0.4]': 0}, m=0.4, T=10, p=1)
+mpg_in_hx.set_attr(fluid={'MEG[0.2]': 0, 'MPG[0.4]': 1}, m=0.2, T=20, p=1)
+
+path = 'binary_mixtures'
+nw.solve('design')
+nw.print_results()
+nw.save(path)


### PR DESCRIPTION
This pull request aims to implement minor changes to the backend processing of fluid properties so that mass-based binary mixtures included in CoolProp can be natively supported as network fluids. These fluids are crucial for simulation of low temperature applications such as ground-sourced energy.

The API is relatively straightforward. These mixtures should be included into the network just as any other, with a specified mass fraction and back end following the given syntax:

nw = Network(fluids=['INCOMP::MEG[0.2]', 'INCOMP::MPG[0.4]', 'water', ...], ...)

while these fluids can later be utilized as connection parameters like:

meg_in_hx.set_attr(fluid={'MEG[0.2]': 1, 'MPG[0.4]': 0, 'water': 0, ...}, ...).

No bugs appear to arise from this introduction and the regular operation appears not to be influenced in any way.

A simple demonstration of how these mixtures can be utilized is depicted in tutorials/binary_mixtures.py.
