### PR TITLE
minor typos, clarity changes in characteristics and components modules

### DIFF
--- a/docs/analyses/exergy.rst
+++ b/docs/analyses/exergy.rst
@@ -113,7 +113,7 @@ Two other full code examples are to be found at:
 - Refrigeration machine: https://github.com/fwitte/refrigeration_cycle_exergy
 
 SEGS consists of three main systems, the solar field, the steam cycle and the
-cooling water system. In the solar field Therminol VP1 is used as heat transfer
+cooling water system. In the solar field Therminol VP1 (TVP1) is used as heat transfer
 fluid. In the steam generator and reheater the TVP1 is cooled down to evaporate
 and overheat/reheat the water of the steam cycle. The turbine is divided in a
 high pressure turbine and a low pressure turbine, which are further subdivided
@@ -174,7 +174,7 @@ these values in the script provided.
 For the exact values of the component parameters please see in the referenced
 python script.
 
-Due to the complexity of the plant, the solver sometimes struggles given bad
+Due to the complexity of the plant, the solver sometimes struggles when given bad
 starting values. Therefore, the TESPy model is built in two steps. After
 solving the initial setup without both of the high pressure preheater
 subcoolers, the missing connections and components are added in a second step
@@ -317,7 +317,7 @@ deselect the tables, e.g. by passing :code:`groups=False` to the method call.
     ean.print_results(groups=False, connections=False)
 
 For the component related tables, i.e. busses, components, aggregation and
-groups, the data are sorted descending regarding the exergy destruction value
+groups, the data are sorted in descending order for the given exergy destruction value
 of the individual entry. The component data contain fuel exergy, product exergy
 and exergy destruction values related to the component itself ignoring losses
 that might occur on the busses, for example, mechanical or electrical

--- a/docs/tespy_modules/characteristics.rst
+++ b/docs/tespy_modules/characteristics.rst
@@ -94,7 +94,7 @@ Your custom definitions of characteristic lines go into the
 The :code:`char_lines.json` should have names for identification of the
 characteristic lines on the first level. On the second level the x and y data
 are assigned to the name of the characteristic line. The x and y data must be
-stated as list.
+stated as lists.
 
 .. code-block:: json
 

--- a/docs/tespy_modules/components.rst
+++ b/docs/tespy_modules/components.rst
@@ -1,9 +1,9 @@
 Components
 ==========
 
-In this section we will introduce you into the details of component
+In this section we will introduce you to the details of component
 parametrisation and component characteristics. At the end of the section we
-show you, how to create custom components.
+show you how to create custom components.
 
 List of components
 ------------------
@@ -70,9 +70,9 @@ Component parametrisation
 -------------------------
 
 All parameters of components are objects of a :code:`DataContainer` class. The
-data container for component parameters it is called
+data container for component parameters is called
 :code:`ComponentProperties`, :code:`ComponentCharacteristics` for component
-characteristics and :code:`ComponentCharacteristicMaps` for characteristic
+characteristics, and :code:`ComponentCharacteristicMaps` for characteristic
 maps. The main purpose of having a data container for the parameters (instead
 of pure numbers), is added flexibility for the user. There are different ways
 for you to specify and access component parameters.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -8,6 +8,7 @@ Discover noteable new features and improvements in each release
     :local:
     :backlinks: top
 
+.. include::  whats_new/v0-6-1.rst
 .. include::  whats_new/v0-6-0.rst
 .. include::  whats_new/v0-5-1.rst
 .. include::  whats_new/v0-5-0.rst

--- a/docs/whats_new/v0-6-1.rst
+++ b/docs/whats_new/v0-6-1.rst
@@ -1,0 +1,12 @@
+v0.6.1 - Upcoming features
+++++++++++++++++++++++++++
+
+Documentation
+#############
+- Fix some typos in the online documentation
+  (`PR #342 <https://github.com/oemof/tespy/pull/341>`_).
+
+Contributors
+############
+- Francesco Witte (`@fwitte <https://github.com/fwitte>`_)
+- `@NicholasFry <https://github.com/NicholasFry>`_

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read(*names, **kwargs):
 
 setup(
     name='TESPy',
-    version='0.6.0',
+    version='0.6.1.dev0',
     license='MIT',
     description='Thermal Engineering Systems in Python (TESPy)',
     long_description='%s' % (

--- a/src/tespy/__init__.py
+++ b/src/tespy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8
 
-__version__ = '0.6.0 - Colored Chemicals'
+__version__ = '0.6.1 - dev'
 
 # tespy data and connections import
 from . import connections  # noqa: F401


### PR DESCRIPTION
Minor changes to punctuation, grammar, and word order for clarity. Same for exergy, characteristics, and component documentation.