### PR TITLE
Report progress and results with the logger object

### DIFF
--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -1810,10 +1810,11 @@ class Network:
             enthalpy='enthalpy', 
             fluid='fluid', 
             custom=custom)
-        msg += '\n' + '-' * 7 + '+------------' * 7
         logger.progress(0, msg)
+        msg2 = '-' * 7 + '+------------' * 7
+        logger.progress(0, msg2)
         if print_results:
-            print('\n' + msg)
+            print('\n' + msg + '\n' + msg2)
         return
 
     def iterinfo_body(self, print_results=True):

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -1545,7 +1545,7 @@ class Network:
 
     def solve(self, mode, init_path=None, design_path=None,
               max_iter=50, min_iter=4, init_only=False, init_previous=True,
-              use_cuda=False, always_all_equations=True, print_result=True):
+              use_cuda=False, always_all_equations=True, return_result=False):
         r"""
         Solve the network.
 
@@ -1591,7 +1591,7 @@ class Network:
             will increase calculation speed, especially for mixtures, default:
             :code:`True`.
         
-        print_result : boolean
+        return_result : boolean
             Print the results to the terminal instead of returning a string 
             with the results, default: :code:`True`.
 
@@ -1663,7 +1663,7 @@ class Network:
         logger.info(msg)
 
         self.solve_determination()
-        iter_result = self.solve_loop(print_result)
+        iter_result = self.solve_loop(return_result)
 
         if self.lin_dep:
             msg = (
@@ -1697,7 +1697,7 @@ class Network:
         logger.info(msg)
         return iter_result
 
-    def solve_loop(self, print_result=True):
+    def solve_loop(self, return_result=False):
         r"""Loop of the newton algorithm."""
 
         result = ""
@@ -1711,7 +1711,7 @@ class Network:
         self.progress = True
 
         if self.iterinfo:
-            result += self.print_iterinfo_head(print_result) + '\n'
+            result += self.print_iterinfo_head(return_result) + '\n'
 
         for self.iter in range(self.max_iter):
 
@@ -1720,7 +1720,7 @@ class Network:
             self.res = np.append(self.res, norm(self.residual))
 
             if self.iterinfo:
-                result += self.print_iterinfo_body(print_result) + '\n'
+                result += self.print_iterinfo_body(return_result) + '\n'
 
             if ((self.iter >= self.min_iter and self.res[-1] < err ** 0.5) or
                     self.lin_dep):
@@ -1734,7 +1734,7 @@ class Network:
 
         self.end_time = time()
 
-        result += self.print_iterinfo_tail(print_result) + '\n'
+        result += self.print_iterinfo_tail(return_result) + '\n'
 
         if self.iter == self.max_iter - 1:
             msg = ('Reached maximum iteration count (' + str(self.max_iter) +
@@ -1800,7 +1800,7 @@ class Network:
             logger.error(msg)
             raise hlp.TESPyNetworkError(msg)
 
-    def print_iterinfo_head(self, print_result=True):
+    def print_iterinfo_head(self, return_result=False):
         """Print head of convergence progress."""
         if self.num_comp_vars == 0:
             # iterinfo printout without any custom variables
@@ -1814,14 +1814,14 @@ class Network:
                    'fluid    | custom\n')
             msg += '-' * 8 + '+----------' * 5 + '+' + '-' * 9
 
-        if print_result:
-            print(msg)
-            return ''
-        else:
+        if return_result:
             logging.log(31, msg)
             return msg
+        else:
+            print(msg)
+            return ''
 
-    def print_iterinfo_body(self, print_result=True):
+    def print_iterinfo_body(self, return_result=False):
         """Print convergence progress."""
         vec = self.increment[0:-(self.num_comp_vars + 1)]
         msg = (str(self.iter + 1))
@@ -1851,14 +1851,14 @@ class Network:
             if self.num_comp_vars > 0:
                 msg += ' |      nan'
         
-        if print_result:
-            print(msg)
-            return ''
-        else:
+        if return_result:
             logging.log(31, msg)
             return msg
+        else:
+            print(msg)
+            return ''
 
-    def print_iterinfo_tail(self, print_result=True):
+    def print_iterinfo_tail(self, return_result=False):
         """Print tail of convergence progress."""
         msg = (
             'Total iterations: ' + str(self.iter + 1) + ', Calculation '
@@ -1877,12 +1877,12 @@ class Network:
             else:
                 result_msg = '-' * 8 + '+----------' * 5 + '+' + '-' * 9 + '\n' + msg
 
-            if print_result:
-                print(result_msg)
-                return ''
-            else:
+            if return_result:
                 logging.log(31, result_msg)
                 return result_msg
+            else:
+                print(result_msg)
+                return ''
         return ''
 
     def matrix_inversion(self):
@@ -2654,7 +2654,7 @@ class Network:
 
 # %% printing and plotting
 
-    def print_results(self, colored=True, colors={}, print_result=True):
+    def print_results(self, colored=True, colors={}, return_result=False):
         r"""Print the calculations results to prompt."""
         # Define colors for highlighting values in result table
         result = ""
@@ -2734,11 +2734,11 @@ class Network:
                         floatfmt='.3e'
                     )
                 )
-        if print_result:
+        if return_result:
+            return result
+        else:
             print(result)
             return ''
-        else:
-            return result
 
     def print_components(self, c, *args):
         """

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -1659,7 +1659,7 @@ class Network:
         logger.info(msg)
 
         self.solve_determination()
-        self.solve_loop()
+        iter_result = self.solve_loop()
 
         if self.lin_dep:
             msg = (
@@ -1691,9 +1691,12 @@ class Network:
 
         msg = 'Calculation complete.'
         logger.info(msg)
+        return iter_result
 
     def solve_loop(self):
         r"""Loop of the newton algorithm."""
+
+        result = ""
         # parameter definitions
         self.res = np.array([])
         self.residual = np.zeros([self.num_vars])
@@ -1704,7 +1707,7 @@ class Network:
         self.progress = True
 
         if self.iterinfo:
-            self.print_iterinfo_head()
+            result += self.print_iterinfo_head() + '\n'
 
         for self.iter in range(self.max_iter):
 
@@ -1713,7 +1716,7 @@ class Network:
             self.res = np.append(self.res, norm(self.residual))
 
             if self.iterinfo:
-                self.print_iterinfo_body()
+                result += self.print_iterinfo_body() + '\n'
 
             if ((self.iter >= self.min_iter and self.res[-1] < err ** 0.5) or
                     self.lin_dep):
@@ -1727,13 +1730,14 @@ class Network:
 
         self.end_time = time()
 
-        self.print_iterinfo_tail()
+        result += self.print_iterinfo_tail() + '\n'
 
         if self.iter == self.max_iter - 1:
             msg = ('Reached maximum iteration count (' + str(self.max_iter) +
                    '), calculation stopped. Residual value is '
                    '{:.2e}'.format(norm(self.residual)))
             logger.warning(msg)
+        return result
 
     def solve_determination(self):
         r"""Check, if the number of supplied parameters is sufficient."""
@@ -1807,6 +1811,7 @@ class Network:
             msg += '-' * 8 + '+----------' * 5 + '+' + '-' * 9
 
         logging.log(31, msg)
+        return msg
 
     def print_iterinfo_body(self):
         """Print convergence progress."""
@@ -1839,6 +1844,7 @@ class Network:
                 msg += ' |      nan'
 
         logging.log(31, msg)
+        return msg
 
     def print_iterinfo_tail(self):
         """Print tail of convergence progress."""
@@ -1856,9 +1862,13 @@ class Network:
         if self.iterinfo:
             if self.num_comp_vars == 0:
                 logging.log(31, '-' * 8 + '+----------' * 4 + '+' + '-' * 9)
+                result_msg = '-' * 8 + '+----------' * 4 + '+' + '-' * 9 + '\n' + msg
             else:
                 logging.log(31, '-' * 8 + '+----------' * 5 + '+' + '-' * 9)
+                result_msg = '-' * 8 + '+----------' * 5 + '+' + '-' * 9 + '\n' + msg
             logging.log(31, msg)
+            return result_msg
+        return None
 
     def matrix_inversion(self):
         """Invert matrix of derivatives and caluclate increment."""

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -1806,7 +1806,7 @@ class Network:
                    'fluid    | custom\n')
             msg += '-' * 8 + '+----------' * 5 + '+' + '-' * 9
 
-        print(msg)
+        logging.log(31, msg)
 
     def print_iterinfo_body(self):
         """Print convergence progress."""
@@ -1838,7 +1838,7 @@ class Network:
             if self.num_comp_vars > 0:
                 msg += ' |      nan'
 
-        print(msg)
+        logging.log(31, msg)
 
     def print_iterinfo_tail(self):
         """Print tail of convergence progress."""
@@ -1855,10 +1855,10 @@ class Network:
 
         if self.iterinfo:
             if self.num_comp_vars == 0:
-                print('-' * 8 + '+----------' * 4 + '+' + '-' * 9)
+                logging.log(31, '-' * 8 + '+----------' * 4 + '+' + '-' * 9)
             else:
-                print('-' * 8 + '+----------' * 5 + '+' + '-' * 9)
-            print(msg)
+                logging.log(31, '-' * 8 + '+----------' * 5 + '+' + '-' * 9)
+            logging.log(31, msg)
 
     def matrix_inversion(self):
         """Invert matrix of derivatives and caluclate increment."""
@@ -2632,6 +2632,7 @@ class Network:
     def print_results(self, colored=True, colors={}):
         r"""Print the calculations results to prompt."""
         # Define colors for highlighting values in result table
+        result = ""
         coloring = {
             'end': '\033[0m',
             'set': '\033[94m',
@@ -2663,8 +2664,8 @@ class Network:
 
                     if len(df) > 0:
                         # printout with tabulate
-                        print('##### RESULTS (' + cp + ') #####')
-                        print(
+                        result += ('\n##### RESULTS (' + cp + ') #####\n')
+                        result += (
                             tabulate(
                                 df, headers='keys', tablefmt='psql',
                                 floatfmt='.2e'
@@ -2686,8 +2687,8 @@ class Network:
                             coloring['end'])
 
         if len(df) > 0:
-            print('##### RESULTS (Connection) #####')
-            print(
+            result += ('\n##### RESULTS (Connection) #####\n')
+            result += (
                 tabulate(df, headers='keys', tablefmt='psql', floatfmt='.3e')
             )
 
@@ -2701,13 +2702,14 @@ class Network:
                     df.loc['total', 'bus value'] = (
                         coloring['set'] + str(df.loc['total', 'bus value']) +
                         coloring['end'])
-                print('##### RESULTS (Bus: ' + b.label + ') #####')
-                print(
+                result += ('##### RESULTS (Bus: ' + b.label + ') #####')
+                result += (
                     tabulate(
                         df, headers='keys', tablefmt='psql',
                         floatfmt='.3e'
                     )
                 )
+        return result
 
     def print_components(self, c, *args):
         """

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -2698,7 +2698,7 @@ class Network:
                         )
 
         # connection properties
-        df = self.results['Connection'].loc[:, ['m', 'p', 'h', 'T']]
+        df = self.results['Connection']
         for c in df.index:
             if not self.get_conn(c).printout:
                 df.drop([c], axis=0, inplace=True)

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -2684,7 +2684,7 @@ class Network:
                         )
 
         # connection properties
-        df = self.results['Connection']
+        df = self.results['Connection'].loc[:, ['m', 'p', 'h', 'T']]
         for c in df.index:
             if not self.get_conn(c).printout:
                 df.drop([c], axis=0, inplace=True)

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -1693,10 +1693,8 @@ class Network:
         logger.info(msg)
         return
 
-    def solve_loop(self, print_results = True):
+    def solve_loop(self, print_results=True):
         r"""Loop of the newton algorithm."""
-
-        result = ""
         # parameter definitions
         self.res = np.array([])
         self.residual = np.zeros([self.num_vars])
@@ -1796,14 +1794,22 @@ class Network:
             logger.error(msg)
             raise hlp.TESPyNetworkError(msg)
 
-    def iterinfo_head(self, print_results = True):
+    def iterinfo_head(self, print_results=True):
         """Print head of convergence progress."""
         # Start with defining the format here
-        self.iterinfo_fmt = ' {iter:5s} | {residual:10s} | {progress:10s} | {massflow:10s} | {pressure:10s} | {enthalpy:10s} | {fluid:10s} | {custom:10s} '
+        self.iterinfo_fmt = ' {iter:5s} | {residual:10s} | {progress:10s} '
+        self.iterinfo_fmt += '| {massflow:10s} | {pressure:10s} | {enthalpy:10s} '
+        self.iterinfo_fmt += '| {fluid:10s} | {custom:10s} '
         # Use the format to create the first logging entry
         custom = '' if self.num_comp_vars == 0 else 'custom'
-        msg = self.iterinfo_fmt.format(iter='iter', residual='residual', progress='progress', massflow='massflow', pressure='pressure', enthalpy='enthalpy', fluid='fluid', custom=custom)
-        #msg += '-' * len(msg) + '\n'
+        msg = self.iterinfo_fmt.format(iter='iter', 
+            residual='residual', 
+            progress='progress', 
+            massflow='massflow', 
+            pressure='pressure', 
+            enthalpy='enthalpy', 
+            fluid='fluid', 
+            custom=custom)
         msg += '\n' + '-' * 7 + '+------------' * 7
         logger.progress(0, msg)
         if print_results:

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -1545,7 +1545,7 @@ class Network:
 
     def solve(self, mode, init_path=None, design_path=None,
               max_iter=50, min_iter=4, init_only=False, init_previous=True,
-              use_cuda=False, always_all_equations=True):
+              use_cuda=False, always_all_equations=True, print_results=True):
         r"""
         Solve the network.
 
@@ -1659,7 +1659,7 @@ class Network:
         logger.info(msg)
 
         self.solve_determination()
-        self.solve_loop()
+        self.solve_loop(print_results=print_results)
 
         if self.lin_dep:
             msg = (

--- a/src/tespy/tools/logger.py
+++ b/src/tespy/tools/logger.py
@@ -17,18 +17,23 @@ from logging import handlers
 import tespy
 
 TESPY_LOGGER_ID = "TESPyLogger"
-TESPY_PROGRESS_LOG_LEVEL = logging.DEBUG + 1  # 11
-TESPY_RESULT_LOG_LEVEL = logging.DEBUG + 2  # 12
+TESPY_PROGRESS_LOG_LEVEL = logging.INFO + 1  # 21
+TESPY_RESULT_LOG_LEVEL = logging.INFO + 2  # 22
+
+logging._levelToName[TESPY_PROGRESS_LOG_LEVEL] = 'PROGRESS'
+logging._nameToLevel['PROGRESS'] = TESPY_PROGRESS_LOG_LEVEL
+logging._levelToName[TESPY_RESULT_LOG_LEVEL] = 'RESULT'
+logging._nameToLevel['RESULT'] = TESPY_RESULT_LOG_LEVEL
 
 # Capture warnings globally instead of per file
 logging.captureWarnings(True)
-
+logger = logging.getLogger(TESPY_LOGGER_ID)
+logger.setLevel(logging.DEBUG)
 
 # Create a bunch of shorthand functions, this is mostly
 # copied straight from the logging module.
 def getLogger():
-    return logging.getLogger(TESPY_LOGGER_ID)
-
+    return logger
 
 def increment_stacklevel(kwargs):
     """"Method to force the logging framework to trace past this file"""
@@ -206,7 +211,7 @@ def add_console_logging(
 
     # Submit the first messages to the logger
     if log_the_version:
-        logging.info("Used TESPy version: {0}".format(get_version()))
+        info("Used TESPy version: {0}".format(get_version()))
 
     return None
 
@@ -279,10 +284,10 @@ def add_file_logging(
 
     # Submit the first messages to the logger
     if log_the_path:
-        logging.info("Path for logging: {0}".format(logfile_setting))
+        info("Path for logging: {0}".format(logfile_setting))
 
     if log_the_version:
-        logging.info("Used TESPy version: {0}".format(get_version()))
+        info("Used TESPy version: {0}".format(get_version()))
 
     return logfile_setting
 

--- a/src/tespy/tools/logger.py
+++ b/src/tespy/tools/logger.py
@@ -153,6 +153,20 @@ def progress(value, msg, *args, **kwargs):
     return log(TESPY_PROGRESS_LOG_LEVEL, msg, *args, **kwargs)
 
 
+# Custom reporting function that abuses log level TESPY_RESULT_LOG_LEVEL 
+# to report result information programmatically.
+def result(msg, *args, **kwargs):
+    """
+    Report result values by logging 'msg % args' with severity 'TESPY_RESULT_LOG_LEVEL'.    
+
+    result("The result is %f", 1.23456)
+    """
+    if "stacklevel" not in kwargs:
+        kwargs["stacklevel"] = 1
+    kwargs["stacklevel"] += 1
+    return log(TESPY_RESULT_LOG_LEVEL, msg, *args, **kwargs)
+
+
 def add_console_logging(
     logformat=None, logdatefmt="%H:%M:%S", loglevel=logging.INFO,
     log_version=True):

--- a/src/tespy/tools/logger.py
+++ b/src/tespy/tools/logger.py
@@ -30,10 +30,12 @@ logging.captureWarnings(True)
 logger = logging.getLogger(TESPY_LOGGER_ID)
 logger.setLevel(logging.DEBUG)
 
+
 # Create a bunch of shorthand functions, this is mostly
 # copied straight from the logging module.
-def getLogger():
+def get_logger():
     return logger
+
 
 def increment_stacklevel(kwargs):
     """"Method to force the logging framework to trace past this file"""
@@ -51,7 +53,7 @@ def log(level, msg, *args, **kwargs):
 
     log(level, "We have a %s", "mysterious problem", exc_info=1)
     """
-    logger = getLogger()
+    logger = get_logger()
     # We force the logging framework to trace past this file
     kwargs["stacklevel"] = increment_stacklevel(kwargs)
     # Last exit for Python < 3.8
@@ -154,7 +156,10 @@ def progress(value, msg, *args, **kwargs):
     progress(0.51, "Houston, we have completed %f percent of the mission.", 0.51*100, extra=dict(progress_min=0.0, progress_max=1.0))
     """
     if "extra" not in kwargs:
-        kwargs["extra"] = dict(progress_min=0, progress_max=100)
+        kwargs["extra"] = {}
+    if "progress_min" not in kwargs["extra"] and "progress_max" not in kwargs["extra"]:
+        kwargs["extra"]["progress_min"] = 0
+        kwargs["extra"]["progress_max"] = 100
     kwargs["extra"]["progress_val"] = value
     # We force the logging framework to trace past this file
     kwargs["stacklevel"] = increment_stacklevel(kwargs)
@@ -206,7 +211,7 @@ def add_console_logging(
     loghandler.setLevel(loglevel)
 
     # Get the logger object and register the handler
-    log = getLogger()
+    log = get_logger()
     log.addHandler(loghandler)
 
     # Submit the first messages to the logger
@@ -279,7 +284,7 @@ def add_file_logging(
     loghandler.setLevel(loglevel)
 
     # Get the logger object and register the handler
-    log = getLogger()
+    log = get_logger()
     log.addHandler(loghandler)
 
     # Submit the first messages to the logger

--- a/src/tespy/tools/logger.py
+++ b/src/tespy/tools/logger.py
@@ -30,6 +30,13 @@ def getLogger():
     return logging.getLogger(TESPY_LOGGER_ID)
 
 
+def increment_stacklevel(kwargs):
+    """"Method to force the logging framework to trace past this file"""
+    if "stacklevel" not in kwargs:
+        kwargs["stacklevel"] = 1
+    return kwargs["stacklevel"] + 1
+
+
 def log(level, msg, *args, **kwargs):
     """
     Log 'msg % args' with the integer severity 'level'.
@@ -149,13 +156,6 @@ def progress(value, msg, *args, **kwargs):
     return log(TESPY_PROGRESS_LOG_LEVEL, msg, *args, **kwargs)
 
 
-def increment_stacklevel(kwargs):
-    """"Method to force the logging framework to trace past this file"""
-    if "stacklevel" not in kwargs:
-        kwargs["stacklevel"] = 1
-    return kwargs["stacklevel"] + 1
-
-
 # Custom reporting function that abuses log level TESPY_RESULT_LOG_LEVEL 
 # to report result information programmatically.
 def result(msg, *args, **kwargs):
@@ -164,9 +164,7 @@ def result(msg, *args, **kwargs):
 
     result("The result is %f", 1.23456)
     """
-    if "stacklevel" not in kwargs:
-        kwargs["stacklevel"] = 1
-    kwargs["stacklevel"] += 1
+    kwargs["stacklevel"] = increment_stacklevel(kwargs)
     return log(TESPY_RESULT_LOG_LEVEL, msg, *args, **kwargs)
 
 

--- a/src/tespy/tools/logger.py
+++ b/src/tespy/tools/logger.py
@@ -156,11 +156,11 @@ def progress(value, msg, *args, **kwargs):
     return log(TESPY_PROGRESS_LOG_LEVEL, msg, *args, **kwargs)
 
 
-# Custom reporting function that abuses log level TESPY_RESULT_LOG_LEVEL 
+# Custom reporting function that abuses log level TESPY_RESULT_LOG_LEVEL
 # to report result information programmatically.
 def result(msg, *args, **kwargs):
     """
-    Report result values by logging 'msg % args' with severity 'TESPY_RESULT_LOG_LEVEL'.    
+    Report result values by logging 'msg % args' with severity 'TESPY_RESULT_LOG_LEVEL'.
 
     result("The result is %f", 1.23456)
     """


### PR DESCRIPTION
**General**

This PR is a follow-up on #390 - it should be merged after #390 has been integrated.

The main purpose of this PR is to silence stdout when running TESPy. For compatibility reasons, the default settings make the system run as before, but it is now possible to send iteration progress reports via the logging framework. The same is the case for the results. 

**Documentation**

Some internal functions have been renamed, but the external interface of TESPy is unchanged. The only noticeable change is that the iteration output now contains a progress indicator.

