### PR TITLE
Bugfix: Add logic for constant dT heat exchangers

### DIFF
--- a/docs/whats_new/v0-6-3.rst
+++ b/docs/whats_new/v0-6-3.rst
@@ -10,7 +10,16 @@ New Features
   applications that consume the TESPy library
   (`PR #390 <https://github.com/oemof/tespy/pull/390>`__).
 
+Bug Fixes
+#########
+- Heat exchangers will now provide a result for the logarithmic temperature
+  difference and the heat transfer coefficient in case the values of the upper
+  and lower temperature difference are equal. Some issues in such situations
+  remain when in offdesign mode
+  (`PR #396 <https://github.com/oemof/tespy/pull/396>`__).
+
 Contributors
 ############
 - Francesco Witte (`@fwitte <https://github.com/fwitte>`__)
 - `@jowr <https://github.com/jowr>`__
+- `@dk-teknologisk-enp <https://github.com/dk-teknologisk-enp`__

--- a/src/tespy/components/heat_exchangers/base.py
+++ b/src/tespy/components/heat_exchangers/base.py
@@ -835,6 +835,9 @@ class HeatExchanger(Component):
         if self.ttd_u.val < 0 or self.ttd_l.val < 0:
             self.td_log.val = np.nan
             self.kA.val = np.nan
+        elif self.ttd_l.val == self.ttd_u.val:
+            self.td_log.val = self.ttd_l.val
+            self.kA.val = -self.Q.val / self.td_log.val
         else:
             self.td_log.val = ((self.ttd_l.val - self.ttd_u.val) /
                                np.log(self.ttd_l.val / self.ttd_u.val))

--- a/src/tespy/components/heat_exchangers/base.py
+++ b/src/tespy/components/heat_exchangers/base.py
@@ -412,8 +412,12 @@ class HeatExchanger(Component):
         if T_o1 <= T_i2:
             T_i2 = T_o1 - 0.02
 
-        td_log = ((T_o1 - T_i2 - T_i1 + T_o2) /
-                  np.log((T_o1 - T_i2) / (T_i1 - T_o2)))
+        ttd_u = T_i1 - T_o2
+        ttd_l = T_o1 - T_i2
+        if ttd_u == ttd_l:
+            td_log = ttd_l
+        else:
+            td_log = (ttd_l - ttd_u) / np.log((ttd_l) / (ttd_u))
 
         return i1.m.val_SI * (
             o1.h.val_SI - i1.h.val_SI) + self.kA.val * td_log
@@ -510,8 +514,12 @@ class HeatExchanger(Component):
         if T_o1 <= T_i2:
             T_i2 = T_o1 - 0.02
 
-        td_log = ((T_o1 - T_i2 - T_i1 + T_o2) /
-                  np.log((T_o1 - T_i2) / (T_i1 - T_o2)))
+        ttd_u = T_i1 - T_o2
+        ttd_l = T_o1 - T_i2
+        if ttd_u == ttd_l:
+            td_log = ttd_l
+        else:
+            td_log = (ttd_l - ttd_u) / np.log((ttd_l) / (ttd_u))
 
         fkA1 = self.kA_char1.char_func.evaluate(f1)
         fkA2 = self.kA_char2.char_func.evaluate(f2)
@@ -834,14 +842,12 @@ class HeatExchanger(Component):
         # kA and logarithmic temperature difference
         if self.ttd_u.val < 0 or self.ttd_l.val < 0:
             self.td_log.val = np.nan
-            self.kA.val = np.nan
         elif self.ttd_l.val == self.ttd_u.val:
             self.td_log.val = self.ttd_l.val
-            self.kA.val = -self.Q.val / self.td_log.val
         else:
             self.td_log.val = ((self.ttd_l.val - self.ttd_u.val) /
                                np.log(self.ttd_l.val / self.ttd_u.val))
-            self.kA.val = -self.Q.val / self.td_log.val
+        self.kA.val = -self.Q.val / self.td_log.val
 
     def entropy_balance(self):
         r"""

--- a/src/tespy/components/heat_exchangers/condenser.py
+++ b/src/tespy/components/heat_exchangers/condenser.py
@@ -354,8 +354,12 @@ class Condenser(HeatExchanger):
         if T_o1 <= T_i2 and not i2.T.val_set:
             T_i2 = T_o1 - 1
 
-        td_log = ((T_o1 - T_i2 - T_i1 + T_o2) /
-                  np.log((T_o1 - T_i2) / (T_i1 - T_o2)))
+        ttd_u = T_i1 - T_o2
+        ttd_l = T_o1 - T_i2
+        if ttd_u == ttd_l:
+            td_log = ttd_l
+        else:
+            td_log = (ttd_l - ttd_u) / np.log((ttd_l) / (ttd_u))
 
         return i1.m.val_SI * (o1.h.val_SI - i1.h.val_SI) + self.kA.val * td_log
 
@@ -434,8 +438,12 @@ class Condenser(HeatExchanger):
         if T_o1 <= T_i2 and not i2.T.val_set:
             T_i2 = T_o1 - 1
 
-        td_log = ((T_o1 - T_i2 - T_i1 + T_o2) /
-                  np.log((T_o1 - T_i2) / (T_i1 - T_o2)))
+        ttd_u = T_i1 - T_o2
+        ttd_l = T_o1 - T_i2
+        if ttd_u == ttd_l:
+            td_log = ttd_l
+        else:
+            td_log = (ttd_l - ttd_u) / np.log((ttd_l) / (ttd_u))
 
         fkA1 = self.kA_char1.char_func.evaluate(f1)
         fkA2 = self.kA_char2.char_func.evaluate(f2)
@@ -537,8 +545,9 @@ class Condenser(HeatExchanger):
         # kA and logarithmic temperature difference
         if self.ttd_u.val < 0 or self.ttd_l.val < 0:
             self.td_log.val = np.nan
-            self.kA.val = np.nan
+        elif self.ttd_l.val == self.ttd_u.val:
+            self.td_log.val = self.ttd_l.val
         else:
             self.td_log.val = ((self.ttd_l.val - self.ttd_u.val) /
                                np.log(self.ttd_l.val / self.ttd_u.val))
-            self.kA.val = -self.Q.val / self.td_log.val
+        self.kA.val = -self.Q.val / self.td_log.val

--- a/src/tespy/components/heat_exchangers/simple.py
+++ b/src/tespy/components/heat_exchangers/simple.py
@@ -535,7 +535,8 @@ class HeatExchangerSimple(Component):
         elif ttd_1 < ttd_2:
             td_log = (ttd_2 - ttd_1) / np.log(ttd_2 / ttd_1)
         else:
-            td_log = 0
+            # both values are equal
+            td_log = ttd_2
 
         return i[0] * (o[2] - i[2]) + self.kA.val * td_log
 
@@ -646,7 +647,8 @@ class HeatExchangerSimple(Component):
         elif ttd_1 < ttd_2:
             td_log = (ttd_2 - ttd_1) / np.log(ttd_2 / ttd_1)
         else:
-            td_log = 0
+            # both values are equal
+            td_log = ttd_2
 
         fkA = 2 / (1 + 1 / self.kA_char.char_func.evaluate(expr))
 
@@ -865,12 +867,15 @@ class HeatExchangerSimple(Component):
             ttd_1 = self.inl[0].T.val_SI - self.Tamb.val_SI
             ttd_2 = self.outl[0].T.val_SI - self.Tamb.val_SI
 
+            if (ttd_1 / ttd_2) < 0:
+                td_log = np.nan
             if ttd_1 > ttd_2:
                 td_log = (ttd_1 - ttd_2) / np.log(ttd_1 / ttd_2)
             elif ttd_1 < ttd_2:
                 td_log = (ttd_2 - ttd_1) / np.log(ttd_2 / ttd_1)
             else:
-                td_log = np.nan
+                # both values are equal
+                td_log = ttd_1
 
             self.kA.val = abs(i[0] * (o[2] - i[2]) / td_log)
             self.kA.is_result = True


### PR DESCRIPTION
**General**

Describe your pull request as transparent as possible:

This PR fixes the treatment of heat exchangers with constant temperature difference.
For constant temperature differences the logarithmic mean temperature difference is invalid, as it would result in division by zero.
This simple bugfix just sets the logarithmic mean temperature difference to the constant temperature difference in the case that ttd_u == ttd_l.

**Documentation**
I have not changed any documentation

**Testing**
I have not updated any tests

