### PR TITLE
Change units for fluid properties in log file

### DIFF
--- a/docs/whats_new/v0-6-3.rst
+++ b/docs/whats_new/v0-6-3.rst
@@ -31,6 +31,8 @@ Bug Fixes
   and lower temperature difference are equal. Some issues in such situations
   remain when in offdesign mode
   (`PR #396 <https://github.com/oemof/tespy/pull/396>`__).
+- Fix unit display for fluid property ranges in log files
+  (`PR #420 <https://github.com/oemof/tespy/pull/420>`__).
 
 Other Changes
 #############
@@ -43,6 +45,7 @@ Contributors
 - `@jowr <https://github.com/jowr>`__
 - `@dk-teknologisk-enp <https://github.com/dk-teknologisk-enp>`__
 - `@aburabazam <https://github.com/aburabazam>`__
+- `@tboussaid <https://github.com/tboussaid>`__
 
 Special thanks to `@KarimHShawky <https://github.com/KarimHShawky>`__ and
 `@tub-hofmann <https://github.com/tub-hofmann>`__ for the compilation and

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -340,9 +340,9 @@ class Network:
                 msg = (
                     'Setting ' + fpd[prop]['text'] +
                     ' limits\nmin: ' + str(limits[0]) + ' ' +
-                    self.get_attr(prop + '_unit') + '\n'
+                    fpd[prop]['SI_unit'] + '\n'
                     'max: ' + str(limits[1]) + ' ' +
-                    self.get_attr(prop + '_unit'))
+                    fpd[prop]['SI_unit'])
                 logger.debug(msg)
 
         # update non SI value ranges


### PR DESCRIPTION
**General**

This PR fixes a small printing error in the log file. When the user choose a unit for a fluid property, the log file will show the range values in SI unit rather than the user specified one.
More details can be found in the related issue: [https://github.com/oemof/tespy/issues/417](#417) 

**Documentation**

No documentation file is affected.

**Testing**

No tests are affected by this change.