### PR TITLE
Bump up CoolProp dependency and remove incompressible fluid handling quick fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "CoolProp>=6.4,<7",
+    "CoolProp>=6.6,<7",
     "jinja2",
     "matplotlib>=3.2.1,<4",
     "numpy>=1.13.3,<2",

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -191,15 +191,6 @@ class CoolPropWrapper(FluidPropertyWrapper):
         return self.AS.hmass()
 
     def h_pT(self, p, T):
-        if self.back_end == "INCOMP":
-            if T == (self._T_max + self._T_min) / 2:
-                T += ERR
-                self.AS.update(CP.PT_INPUTS, p, T)
-                h = self.AS.hmass() * 0.5
-                T -= 2 * ERR
-                self.AS.update(CP.PT_INPUTS, p, T)
-                h += self.AS.hmass() * 0.5
-                return h
         self.AS.update(CP.PT_INPUTS, p, T)
         return self.AS.hmass()
 


### PR DESCRIPTION
CoolProp recently published version 6.6. The bug concerning incompressible fluid reference temperatures has been resolved on their side, therefore this PR introduces minimum CoolProp version of 6.6 and removes the quickfix in the fluid property wrapper module.