### PR TITLE
Remove old newton function and use newton_with_kwargs instead

### DIFF
--- a/docs/modules/ude.rst
+++ b/docs/modules/ude.rst
@@ -65,15 +65,15 @@ equation in a function which returns the residual value of the equation.
 
 .. code-block:: python
 
-    >>> def my_ude(self):
-    ...     return self.conns[0].m.val_SI - self.conns[1].m.val_SI ** 2
+    >>> def my_ude(ude):
+    ...     return ude.conns[0].m.val_SI - ude.conns[1].m.val_SI ** 2
 
 
 .. note::
 
     The function must only take one parameter, i.e. the UserDefinedEquation
     class instance. The **name of the parameter is arbitrary**. We will use
-    :code:`self` in this example. It serves to access some important parameters
+    :code:`ude` in this example. It serves to access some important parameters
     of the equation:
 
     - connections required in the equation
@@ -94,7 +94,7 @@ composition of every connection. The derivatives have to be passed to the
 Jacobian. In order to do this, we create a function that updates the values
 inside the Jacobian of the :code:`UserDefinedEquation` and returns it:
 
-- :code:`self.jacobian` is a dictionary containing numpy arrays for every
+- :code:`ude.jacobian` is a dictionary containing numpy arrays for every
   connection required by the :code:`UserDefinedEquation`.
 - derivatives to **mass flow** are placed in the first element of the numpy
   array (**index 0**)
@@ -114,13 +114,13 @@ derivatives to mass flow are not zero.
 
 .. code-block:: python
 
-    >>> def my_ude_deriv(self):
-    ...     c0 = self.conns[0]
-    ...     c1 = self.conns[1]
+    >>> def my_ude_deriv(ude):
+    ...     c0 = ude.conns[0]
+    ...     c1 = ude.conns[1]
     ...     if c0.m.is_var:
-    ...         self.jacobian[c0.m.J_col] = 1
+    ...         ude.jacobian[c0.m.J_col] = 1
     ...     if c1.m.is_var:
-    ...         self.jacobian[c1.m.J_col] = -2 * self.conns[1].m.val_SI
+    ...         ude.jacobian[c1.m.J_col] = -2 * ude.conns[1].m.val_SI
 
 Now we can create our instance of the :code:`UserDefinedEquation` and add it to
 the network. The class requires four mandatory arguments to be passed:
@@ -185,21 +185,21 @@ respectively to calculate the partial derivatives.
     >>> from tespy.tools.fluid_properties import dT_mix_dph
     >>> from tespy.tools.fluid_properties import dT_mix_pdh
 
-    >>> def my_ude_deriv(self):
-    ...     c0 = self.conns[0]
-    ...     c1 = self.conns[1]
+    >>> def my_ude_deriv(ude):
+    ...     c0 = ude.conns[0]
+    ...     c1 = ude.conns[1]
     ...     if c0.m.is_var:
-    ...         self.jacobian[c0.m.J_col] = 1 / self.conns[0].m.val_SI
+    ...         ude.jacobian[c0.m.J_col] = 1 / ude.conns[0].m.val_SI
     ...     if c0.p.is_var:
-    ...         self.jacobian[c0.p.J_col] = - 2 / self.conns[0].p.val_SI
+    ...         ude.jacobian[c0.p.J_col] = - 2 / ude.conns[0].p.val_SI
     ...     T = c1.calc_T()
     ...     if c1.p.is_var:
-    ...         self.jacobian[c1.p.J_col] = (
+    ...         ude.jacobian[c1.p.J_col] = (
     ...             dT_mix_dph(c1.p.val_SI, c1.h.val_SI, c1.fluid_data, c1.mixing_rule)
     ...             * 0.5 / (T ** 0.5)
     ...         )
     ...     if c1.h.is_var:
-    ...         self.jacobian[c1.h.J_col] = (
+    ...         ude.jacobian[c1.h.J_col] = (
     ...             dT_mix_pdh(c1.p.val_SI, c1.h.val_SI, c1.fluid_data, c1.mixing_rule)
     ...             * 0.5 / (T ** 0.5)
     ...         )
@@ -265,27 +265,27 @@ instance must therefore be changed as below.
     >>> from tespy.tools.fluid_properties import h_mix_pQ
     >>> from tespy.tools.fluid_properties import dh_mix_dpQ
 
-    >>> def my_ude(self):
-    ...     a = self.params['a']
-    ...     b = self.params['b']
-    ...     c0 = self.conns[0]
-    ...     c1 = self.conns[1]
+    >>> def my_ude(ude):
+    ...     a = ude.params['a']
+    ...     b = ude.params['b']
+    ...     c0 = ude.conns[0]
+    ...     c1 = ude.conns[1]
     ...     return (
     ...         a * (c1.h.val_SI - c0.h.val_SI) -
     ...         (c1.h.val_SI - h_mix_pQ(c0.p.val_SI, b, c0.fluid_data))
     ...     )
 
-    >>> def my_ude_deriv(self):
-    ...     a = self.params['a']
-    ...     b = self.params['b']
-    ...     c0 = self.conns[0]
-    ...     c1 = self.conns[1]
+    >>> def my_ude_deriv(ude):
+    ...     a = ude.params['a']
+    ...     b = ude.params['b']
+    ...     c0 = ude.conns[0]
+    ...     c1 = ude.conns[1]
     ...     if c0.p.is_var:
-    ...         self.jacobian[c0.p.J_col] = dh_mix_dpQ(c0.p.val_SI, b, c0.fluid_data)
+    ...         ude.jacobian[c0.p.J_col] = dh_mix_dpQ(c0.p.val_SI, b, c0.fluid_data)
     ...     if c0.h.is_var:
-    ...         self.jacobian[c0.h.J_col] = -a
+    ...         ude.jacobian[c0.h.J_col] = -a
     ...     if c1.p.is_var:
-    ...         self.jacobian[c1.p.J_col] = a - 1
+    ...         ude.jacobian[c1.p.J_col] = a - 1
 
     >>> ude = UserDefinedEquation(
     ...     'my ude', my_ude, my_ude_deriv, [c1, c2], params={'a': 0.5, 'b': 1}

--- a/src/tespy/components/component.py
+++ b/src/tespy/components/component.py
@@ -30,7 +30,7 @@ from tespy.tools.global_vars import ERR
 from tespy.tools.helpers import _numeric_deriv
 from tespy.tools.helpers import bus_char_derivative
 from tespy.tools.helpers import bus_char_evaluation
-from tespy.tools.helpers import newton
+from tespy.tools.helpers import newton_with_kwargs
 
 
 class Component:
@@ -642,11 +642,21 @@ class Component:
             if b['base'] == 'component':
                 return abs(comp_val / b['P_ref'])
             else:
-                bus_value = newton(
-                    bus_char_evaluation,
-                    bus_char_derivative,
-                    [comp_val, b['P_ref'], b['char']], 0,
-                    val0=b['P_ref'], valmin=-1e15, valmax=1e15)
+                kwargs = {
+                    "function": bus_char_evaluation,
+                    "parameter": "bus_value",
+                    "component_value": comp_val,
+                    "reference_value": b["P_ref"],
+                    "char_func": b["char"]
+                }
+                bus_value = newton_with_kwargs(
+                    derivative=bus_char_derivative,
+                    target_value=0,
+                    val0=b['P_ref'],
+                    valmin=-1e15,
+                    valmax=1e15,
+                    **kwargs
+                )
                 return bus_value / b['P_ref']
 
     def calc_bus_efficiency(self, bus):

--- a/tests/test_tools/test_helpers.py
+++ b/tests/test_tools/test_helpers.py
@@ -9,15 +9,16 @@ tests/test_tools/test_helpers.py
 
 SPDX-License-Identifier: MIT
 """
+from pytest import approx
 
-from tespy.tools.helpers import newton
+from tespy.tools.helpers import newton_with_kwargs
 
 
-def func(params, x):
+def func(x, **kwargs):
     return x ** 2 + x - 20
 
 
-def deriv(params, x):
+def deriv(x, **kwargs):
     return 2 * x + 1
 
 
@@ -36,24 +37,25 @@ def test_newton_bounds():
 
     The function is x^2 + x - 20, there crossings are -5 and 4.
     """
-    result = newton(func, deriv, [], 0, valmin=-10, valmax=10, val0=0)
+    kwargs = {"function": func, "parameter": "x"}
+    result = newton_with_kwargs(deriv, 0, valmin=-10, valmax=10, val0=0, **kwargs)
     msg = ('The newton algorithm should find the zero crossing at 4.0. ' +
            str(round(result, 1)) + ' was found instead.')
-    assert 4.0 == result, msg
+    assert 4.0 == approx(result), msg
 
-    result = newton(func, deriv, [], 0, valmin=-10, valmax=10, val0=-10)
+    result = newton_with_kwargs(deriv, 0, valmin=-10, valmax=10, val0=-10, **kwargs)
     msg = ('The newton algorithm should find the zero crossing at -5.0. ' +
            str(round(result, 1)) + ' was found instead.')
-    assert -5.0 == result, msg
+    assert -5.0 == approx(result), msg
 
-    result = newton(func, deriv, [], 0, valmin=-4, valmax=-2, val0=-3)
+    result = newton_with_kwargs(deriv, 0, valmin=-4, valmax=-2, val0=-3, **kwargs)
     msg = ('The newton algorithm should not be able to find a zero crossing. '
            'The value ' + str(round(result, 1)) + ' was found, but the '
            'algorithm should have found the lower boundary of -4.0.')
-    assert -4.0 == result, msg
+    assert -4.0 == approx(result), msg
 
-    result = newton(func, deriv, [], 0, valmin=-20, valmax=-10, val0=-10)
+    result = newton_with_kwargs(deriv, 0, valmin=-20, valmax=-10, val0=-10, **kwargs)
     msg = ('The newton algorithm should not be able to find a zero crossing. '
            'The value ' + str(round(result, 1)) + ' was found, but the '
            'algorithm should have found the upper boundary of -10.0.')
-    assert -10.0 == result, msg
+    assert -10.0 == approx(result), msg


### PR DESCRIPTION
The convergence critereon for the newon helper algorithms needed to be updated to target values equal to zero. In case the target value is zero, the tolerance mode is set to absolute difference now. On top of that the old newton function was removed and now all parts of the code use the `newton_with_kwargs` function.