### PR TITLE
Improve writing JSON file method.

### DIFF
--- a/docs/scripts/generate_tespy_data_module.py
+++ b/docs/scripts/generate_tespy_data_module.py
@@ -12,7 +12,7 @@ def get_char_data(filename):
     path = resource_filename('tespy.data', filename + '.json')
 
     with open(path) as f:
-        data = json.loads(f.read())
+        data = json.load(f)
 
     return data
 

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -2711,7 +2711,7 @@ class Network:
             Path/filename for the network configuration file.
         """
         with open(fn + 'network.json', 'w') as f:
-            f.write(json.dumps(self._serialize(), indent=4))
+            json.dump(self._serialize(), f, indent=4)
 
         logger.debug('Network information saved to %s.', fn)
 
@@ -2758,7 +2758,7 @@ class Network:
                 bus_data[label] = self.results[label]["design value"].to_dict()
             fn = fn + 'busses.json'
             with open(fn, "w", encoding="utf-8") as f:
-                f.write(json.dumps(bus_data, indent=4))
+                json.dump(bus_data, f, indent=4)
             logger.debug('Bus information saved to %s.', fn)
 
     def export_connections(self, fn):
@@ -2768,7 +2768,7 @@ class Network:
 
         fn = fn + "connections.json"
         with open(fn, "w", encoding="utf-8") as f:
-            f.write(json.dumps(connections, indent=4).replace("NaN", "null"))
+            json.dump(connections, f, indent=4)
         logger.debug('Connection information exported to %s.', fn)
 
     def export_components(self, fn):
@@ -2779,7 +2779,7 @@ class Network:
 
             fname = f"{fn}{c}.json"
             with open(fname, "w", encoding="utf-8") as f:
-                f.write(json.dumps(components, indent=4).replace("NaN", "null"))
+                json.dump(components, f, indent=4)
             logger.debug('Component information exported to %s.', fname)
 
     def export_busses(self, fn):
@@ -2789,5 +2789,5 @@ class Network:
                 busses.update(bus._serialize())
             fn = fn + 'busses.json'
             with open(fn, "w", encoding="utf-8") as f:
-                f.write(json.dumps(busses, indent=4).replace("NaN", "null"))
+                json.dump(busses, f, indent=4)
             logger.debug('Bus information exported to %s.', fn)

--- a/src/tespy/networks/network_reader.py
+++ b/src/tespy/networks/network_reader.py
@@ -254,7 +254,7 @@ def load_network(path):
         logger.debug(msg)
 
         with open(path_comps + f, "r", encoding="utf-8") as c:
-            data = json.loads(c.read())
+            data = json.load(c)
 
         comps.update(construct_components(component, data))
 
@@ -270,7 +270,7 @@ def load_network(path):
     logger.debug(msg)
 
     with open(fn, "r", encoding="utf-8") as c:
-        data = json.loads(c.read())
+        data = json.load(c)
 
     conns = construct_connections(data, comps)
 
@@ -289,7 +289,7 @@ def load_network(path):
         logger.debug(msg)
 
         with open(fn, "r", encoding="utf-8") as c:
-            data = json.loads(c.read())
+            data = json.load(c)
 
         busses = construct_busses(data, comps)
         # add busses to network
@@ -364,7 +364,7 @@ def construct_network(path):
     """
     # read network .json-file
     with open(path + 'network.json', 'r') as f:
-        data = json.loads(f.read())
+        data = json.load(f)
 
     # create network object with its properties
     return Network(**data)

--- a/src/tespy/tools/characteristics.py
+++ b/src/tespy/tools/characteristics.py
@@ -503,7 +503,7 @@ def load_default_char(component, parameter, function_name, char_type):
         path = os.path.join(__datapath__, 'char_maps.json')
 
     with open(path) as f:
-        data = json.loads(f.read())
+        data = json.load(f)
 
     if char_type == CharLine:
         x = data[component][parameter][function_name]['x']
@@ -546,7 +546,7 @@ def load_custom_char(name, char_type):
     if os.path.isfile(path):
 
         with open(path) as f:
-            data = json.loads(f.read())
+            data = json.load(f)
 
         if char_type == CharLine:
             x = data[name]['x']

--- a/tests/test_tools/test_characteristics.py
+++ b/tests/test_tools/test_characteristics.py
@@ -36,7 +36,7 @@ def test_custom_CharLine_import():
             shutil.copy(src=path + '/' + f, dst=tmp_path)
 
     with open(data_path) as f:
-        raw_data = json.loads(f.read())
+        raw_data = json.load(f)
 
     data = raw_data['heat exchanger']['kA_char2']
     with open(os.path.join(path, 'char_lines.json'), 'w') as outfile:
@@ -84,7 +84,7 @@ def test_custom_CharMap_import():
             shutil.copy(src=path + '/' + f, dst=tmp_path)
 
     with open(data_path) as f:
-        raw_data = json.loads(f.read())
+        raw_data = json.load(f)
 
     data = raw_data['compressor']['char_map_pr']
     with open(os.path.join(path, 'char_maps.json'), 'w') as outfile:


### PR DESCRIPTION
**General**

When writing JSON data to a file, the `json.dumps` method is used to create a string in JSON format, which is then written to disk with the `write` method of the `file` object. The extra conversion is not necessary, since the `json.dump` method directly writes the data to the file, without the extra step of converting the data to a string. See for example [this comparison on StackOverflow](https://stackoverflow.com/questions/36059194/what-is-the-difference-between-json-dump-and-json-dumps-in-python) or the [json module documentation](https://docs.python.org/3/library/json.html).
