### PR TITLE
Extend get_plotting_data method of Drum class.

### DIFF
--- a/docs/whats_new/v0-7-5.rst
+++ b/docs/whats_new/v0-7-5.rst
@@ -7,7 +7,13 @@ Documentation
   process into the results.
   (`PR #514 <https://github.com/oemof/tespy/pull/514>`__).
 
+Other Features
+##############
+- More isolines are now available for the drum
+  (`PR #521 <https://github.com/oemof/tespy/pull/521>`__).
+
 Contributors
 ############
 - Francesco Witte (`@fwitte <https://github.com/fwitte>`__)
 - `@Nzb0731 <https://github.com/Nzb0731>`__
+- `@jfreissmann <https://github.com/jfreissmann>`__

--- a/src/tespy/components/nodes/drum.py
+++ b/src/tespy/components/nodes/drum.py
@@ -10,6 +10,8 @@ available from its original location tespy/components/nodes/drum.py
 SPDX-License-Identifier: MIT
 """
 
+import warnings
+
 import numpy as np
 
 from tespy.components.component import component_registry
@@ -422,8 +424,25 @@ class Drum(DropletSeparator):
             the keys :code:`3` and :code:`4` connect the (superheated) gas of
             'in2' with the same.
         """
+        msg = (
+            """
+            For now the dict entry of key '1' will contain the old isoline
+            between saturated liquid and saturated vapor. This entry will be
+            dropped in future versions of this method.
+            """
+        )
+        warnings.warn(msg, FutureWarning)
         return {
             1: {
+                'isoline_property': 'p',
+                'isoline_value': self.outl[0].p.val,
+                'isoline_value_end': self.outl[1].p.val,
+                'starting_point_property': 'v',
+                'starting_point_value': self.outl[0].vol.val,
+                'ending_point_property': 'v',
+                'ending_point_value': self.outl[1].vol.val
+            },
+            2: {
                 'isoline_property': 'p',
                 'isoline_value': self.inl[0].p.val,
                 'isoline_value_end': self.outl[0].p.val,
@@ -432,7 +451,7 @@ class Drum(DropletSeparator):
                 'ending_point_property': 'v',
                 'ending_point_value': self.outl[0].vol.val
             },
-            2: {
+            3: {
                 'isoline_property': 'p',
                 'isoline_value': self.inl[0].p.val,
                 'isoline_value_end': self.outl[1].p.val,
@@ -441,7 +460,7 @@ class Drum(DropletSeparator):
                 'ending_point_property': 'v',
                 'ending_point_value': self.outl[1].vol.val
             },
-            3: {
+            4: {
                 'isoline_property': 'p',
                 'isoline_value': self.inl[1].p.val,
                 'isoline_value_end': self.outl[0].p.val,
@@ -450,7 +469,7 @@ class Drum(DropletSeparator):
                 'ending_point_property': 'v',
                 'ending_point_value': self.outl[0].vol.val
             },
-            4: {
+            5: {
                 'isoline_property': 'p',
                 'isoline_value': self.inl[1].p.val,
                 'isoline_value_end': self.outl[1].p.val,

--- a/src/tespy/components/nodes/drum.py
+++ b/src/tespy/components/nodes/drum.py
@@ -418,17 +418,19 @@ class Drum(DropletSeparator):
         data : dict
             A nested dictionary containing the keywords required by the
             :code:`calc_individual_isoline` method of the
-            :code:`FluidPropertyDiagram` class. The keys :code:`1` and
-            :code:`2` connect the saturated liquid-vapor mixture of 'in1' with
+            :code:`FluidPropertyDiagram` class. The keys :code:`2` and
+            :code:`3` connect the saturated liquid-vapor mixture of 'in1' with
             the saturated liquid ('out1') and saturated vapor ('out2'), while
-            the keys :code:`3` and :code:`4` connect the (superheated) gas of
+            the keys :code:`4` and :code:`5` connect the (superheated) gas of
             'in2' with the same.
+            The key :code:`1` connects both saturated states.
         """
         msg = (
             """
-            For now the dict entry of key '1' will contain the old isoline
-            between saturated liquid and saturated vapor. This entry will be
-            dropped in future versions of this method.
+            The keys will change in the next major release. Keys '1' to '4'
+            will contain the isolines now available through the keys '2' to '5'.
+            The old contents of key '1' (outlet 1 to outlet 2) will be moved to
+            key '5'.
             """
         )
         warnings.warn(msg, FutureWarning)

--- a/src/tespy/components/nodes/drum.py
+++ b/src/tespy/components/nodes/drum.py
@@ -416,11 +416,11 @@ class Drum(DropletSeparator):
         data : dict
             A nested dictionary containing the keywords required by the
             :code:`calc_individual_isoline` method of the
-            :code:`FluidPropertyDiagram` class. The keys :code:`1` and :code:`2`
-            connect the saturated liquid-vapor mixture of 'in1' with the
-            saturated liquid ('out1') and saturated vapor ('out2'), while the
-            keys :code:`3` and :code:`4` connect the (superheated) gas of 'in2'
-            with the same.
+            :code:`FluidPropertyDiagram` class. The keys :code:`1` and
+            :code:`2` connect the saturated liquid-vapor mixture of 'in1' with
+            the saturated liquid ('out1') and saturated vapor ('out2'), while
+            the keys :code:`3` and :code:`4` connect the (superheated) gas of
+            'in2' with the same.
         """
         return {
             1: {

--- a/src/tespy/components/nodes/drum.py
+++ b/src/tespy/components/nodes/drum.py
@@ -416,16 +416,47 @@ class Drum(DropletSeparator):
         data : dict
             A nested dictionary containing the keywords required by the
             :code:`calc_individual_isoline` method of the
-            :code:`FluidPropertyDiagram` class. First level keys are the
-            connection index ('in1' -> 'out1', therefore :code:`1` etc.).
+            :code:`FluidPropertyDiagram` class. The keys :code:`1` and :code:`2`
+            connect the saturated liquid-vapor mixture of 'in1' with the
+            saturated liquid ('out1') and saturated vapor ('out2'), while the
+            keys :code:`3` and :code:`4` connect the (superheated) gas of 'in2'
+            with the same.
         """
         return {
             1: {
                 'isoline_property': 'p',
-                'isoline_value': self.outl[0].p.val,
+                'isoline_value': self.inl[0].p.val,
+                'isoline_value_end': self.outl[0].p.val,
+                'starting_point_property': 'v',
+                'starting_point_value': self.inl[0].vol.val,
+                'ending_point_property': 'v',
+                'ending_point_value': self.outl[0].vol.val
+            },
+            2: {
+                'isoline_property': 'p',
+                'isoline_value': self.inl[0].p.val,
                 'isoline_value_end': self.outl[1].p.val,
                 'starting_point_property': 'v',
-                'starting_point_value': self.outl[0].vol.val,
+                'starting_point_value': self.inl[0].vol.val,
                 'ending_point_property': 'v',
                 'ending_point_value': self.outl[1].vol.val
-            }}
+            },
+            3: {
+                'isoline_property': 'p',
+                'isoline_value': self.inl[1].p.val,
+                'isoline_value_end': self.outl[0].p.val,
+                'starting_point_property': 'v',
+                'starting_point_value': self.inl[1].vol.val,
+                'ending_point_property': 'v',
+                'ending_point_value': self.outl[0].vol.val
+            },
+            4: {
+                'isoline_property': 'p',
+                'isoline_value': self.inl[1].p.val,
+                'isoline_value_end': self.outl[1].p.val,
+                'starting_point_property': 'v',
+                'starting_point_value': self.inl[1].vol.val,
+                'ending_point_property': 'v',
+                'ending_point_value': self.outl[1].vol.val
+            }
+        }


### PR DESCRIPTION
**General**

The `get_plotting_data` method of the `Drum` class only returns one process line connecting the saturated liquid `'out1'` with the saturated vapor `'out2'` so far. This can work sometimes, because the input saturated liquid-vapor mixture falls somewhere between these points, but the desuperheating of the gas `'in2'` is lost and can not be shown. Unfortunately, the `Drum` component does not lend itself to a clear fix that is in line with other components and the general discription of the method. That is, because changing the returned dict to contain one line from `'in1'` to `'out1'` and one from `'in2'` to `'out2'` loses the depiction of the isolation of the saturated vapor from the mixture. Therefore, I propose this solution connecting every inlet to every output and letting the user decide which lines they want to plot.

What do you think about this? Either way, in my opinion the old version can not stay, as you can not show the desuperheating. Additionally, the method desciption did not match the return value in the case of the `Drum`. 

