### PR TITLE
Make the network loader only import valid tespy component class names

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -3,6 +3,7 @@ What's New
 
 Discover notable new features and improvements in each release
 
+.. include::  whats_new/v0-7-7.rst
 .. include::  whats_new/v0-7-6-001.rst
 .. include::  whats_new/v0-7-6.rst
 .. include::  whats_new/v0-7-5.rst

--- a/docs/whats_new/v0-7-7.rst
+++ b/docs/whats_new/v0-7-7.rst
@@ -1,0 +1,13 @@
+Under development
++++++++++++++++++
+
+Bug Fixes
+#########
+- Only :code:`.json` format files are loaded by the `load_network` method.
+  Furthermore, it is checked whether a file is represented by a class
+  available in the namespace via the :code:`@component_registry` decorator
+  (`PR #536 <https://github.com/oemof/tespy/pull/536>`__).
+
+Contributors
+############
+- Francesco Witte (`@fwitte <https://github.com/fwitte>`__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = ["docs/_build"]
 
 [project]
 name = "tespy"
-version = "0.7.6.post1"
+version = "0.7.7.dev0"
 description = "Thermal Engineering Systems in Python (TESPy)"
 readme = "README.rst"
 authors = [

--- a/src/tespy/__init__.py
+++ b/src/tespy/__init__.py
@@ -3,7 +3,7 @@ import importlib.resources
 import os
 
 __datapath__ = os.path.join(importlib.resources.files("tespy"), "data")
-__version__ = '0.7.6.post1 - Newton\'s Nature'
+__version__ = '0.7.7 - Newton\'s Nature'
 
 # tespy data and connections import
 from . import connections  # noqa: F401

--- a/src/tespy/networks/network_reader.py
+++ b/src/tespy/networks/network_reader.py
@@ -193,7 +193,10 @@ def load_network(path):
 
         if component not in component_registry.items:
             msg = (
-                f"Unknown tespy.component class {component}."
+                f"A class {component} is not available through the "
+                "tespy.components.component.component_registry decorator. "
+                "If you are using a custom component make sure to decorate the "
+                "class."
             )
             logger.warning(msg)
             continue

--- a/src/tespy/networks/network_reader.py
+++ b/src/tespy/networks/network_reader.py
@@ -186,9 +186,19 @@ def load_network(path):
 
     files = os.listdir(path_comps)
     for f in files:
-        fn = os.path.join(path_comps, f)
+        if not f.endswith(".json"):
+            continue
+
         component = f.replace(".json", "")
 
+        if component not in component_registry.items:
+            msg = (
+                f"Unknown tespy.component class {component}."
+            )
+            logger.warning(msg)
+            continue
+
+        fn = os.path.join(path_comps, f)
         msg = f"Reading component data ({component}) from {fn}."
         logger.debug(msg)
 

--- a/tests/test_networks/test_network.py
+++ b/tests/test_networks/test_network.py
@@ -9,7 +9,7 @@ tests/test_networks/test_network.py
 
 SPDX-License-Identifier: MIT
 """
-
+import json
 import os
 
 from pytest import mark
@@ -143,6 +143,38 @@ class TestNetworks:
         a.set_attr(fluid={"H2O": 1})
         self.nw.solve('design', init_only=True)
         self.nw.export(tmp_path)
+        imported_nwk = load_network(tmp_path)
+        imported_nwk.solve('design', init_only=True)
+        msg = ('If the network import was successful the network check '
+               'should have been successful, too, but it is not.')
+        assert imported_nwk.checked, msg
+
+    def test_Network_reader_superflouus_files(self, tmp_path):
+        """Test state of network if loaded successfully from export."""
+        a = Connection(self.source, 'out1', self.sink, 'in1')
+        self.nw.add_conns(a)
+        a.set_attr(fluid={"H2O": 1})
+        self.nw.solve('design', init_only=True)
+        self.nw.export(tmp_path)
+        with open(os.path.join(tmp_path, "components", "test.csv"), "w") as f:
+            f.write("nothing to see here")
+
+        imported_nwk = load_network(tmp_path)
+        imported_nwk.solve('design', init_only=True)
+        msg = ('If the network import was successful the network check '
+               'should have been successful, too, but it is not.')
+        assert imported_nwk.checked, msg
+
+    def test_Network_reader_unknown_component_class(self, tmp_path):
+        """Test state of network if loaded successfully from export."""
+        a = Connection(self.source, 'out1', self.sink, 'in1')
+        self.nw.add_conns(a)
+        a.set_attr(fluid={"H2O": 1})
+        self.nw.solve('design', init_only=True)
+        self.nw.export(tmp_path)
+        with open(os.path.join(tmp_path, "components", "Test.json"), "w") as f:
+            json.dump({}, f)
+
         imported_nwk = load_network(tmp_path)
         imported_nwk.solve('design', init_only=True)
         msg = ('If the network import was successful the network check '


### PR DESCRIPTION
Resolve #535 