### PR TITLE
Include link to github repo in introduction.

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -31,8 +31,8 @@ mixers and splitters as well as some advanced components
 Everybody is welcome to use and/or develop TESPy. Contribution is already
 possible on a low level by simply fixing typos in TESPy's documentation or
 rephrasing sections which are unclear. If you want to support us that way
-please fork the TESPy repository to your own GitHub account and make
-changes as described in the GitHub guidelines:
+please fork the `TESPy repository <https://github.com/oemof/tespy>`_ to your
+own GitHub account and make changes as described in the GitHub guidelines:
 https://guides.github.com/activities/hello-world/
 
 Key Features


### PR DESCRIPTION
In my opinion, there should be a link to the github repository on the main landing page of the documentation. Until now, the contribution guidelines are the first link to github you see. I added a link to the existing reference of the TESPy repository within the text.