### PR TITLE
Fixed bug

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -3,6 +3,7 @@ What's New
 
 Discover notable new features and improvements in each release
 
+.. include::  whats_new/v0-7-8-002.rst
 .. include::  whats_new/v0-7-8-001.rst
 .. include::  whats_new/v0-7-8.rst
 .. include::  whats_new/v0-7-7.rst

--- a/docs/whats_new/v0-7-8-002.rst
+++ b/docs/whats_new/v0-7-8-002.rst
@@ -1,0 +1,13 @@
+v0.7.8.post2 - Newton's Nature (December, 29, 2024)
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Bug Fixes
+#########
+- Fixed a bug in post processing of the :code:`ttd_min` parameter of
+  :code:`HeatExchangers`
+  (`PR #587 <https://github.com/oemof/tespy/pull/587>`__).
+
+Contributors
+############
+- `@tlmerbecks <https://github.com/tlmerbecks>`__
+- Francesco Witte (`@fwitte <https://github.com/fwitte>`__)

--- a/src/tespy/components/heat_exchangers/base.py
+++ b/src/tespy/components/heat_exchangers/base.py
@@ -1121,7 +1121,7 @@ class HeatExchanger(Component):
         )
         self.ttd_u.val = self.inl[0].T.val_SI - self.outl[1].T.val_SI
         self.ttd_l.val = self.outl[0].T.val_SI - self.inl[1].T.val_SI
-        self.ttd_min.val = min(self.ttd_u.val, self.ttd_min.val)
+        self.ttd_min.val = min(self.ttd_u.val, self.ttd_l.val)
 
         # pr and zeta
         for i in range(2):

--- a/src/tespy/components/heat_exchangers/condenser.py
+++ b/src/tespy/components/heat_exchangers/condenser.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from tespy.components.component import component_registry
 from tespy.components.heat_exchangers.base import HeatExchanger
+from tespy.tools import logger
 from tespy.tools.data_containers import SimpleDataContainer as dc_simple
 from tespy.tools.document_models import generate_latex_eq
 from tespy.tools.fluid_properties import dh_mix_dpQ
@@ -474,7 +475,7 @@ class Condenser(HeatExchanger):
         )
         self.ttd_u.val = self.inl[0].calc_T_sat() - self.outl[1].T.val_SI
         self.ttd_l.val = self.outl[0].T.val_SI - self.inl[1].T.val_SI
-        self.ttd_min.val = min(self.ttd_u.val, self.ttd_min.val)
+        self.ttd_min.val = min(self.ttd_u.val, self.ttd_l.val)
 
         # pr and zeta
         for i in range(2):

--- a/tests/test_components/test_heat_exchangers.py
+++ b/tests/test_components/test_heat_exchangers.py
@@ -10,11 +10,11 @@ tests/test_components/test_heat_exchangers.py
 SPDX-License-Identifier: MIT
 """
 import math
+
+import numpy as np
 from pytest import approx
 from pytest import fixture
 from pytest import mark
-
-import numpy as np
 
 from tespy.components import Condenser
 from tespy.components import Desuperheater


### PR DESCRIPTION
In the post-solve calculation of ttd_min (see calc_parameters() ) there was a typo, resulting in the ttd_min being calculated as the minimum value of ttd_u and tdd_min (incorrect) instead of the minimum of ttd_u and ttd_l.

This fixes issue #586 