### PR TITLE
Vapour Quality and State Reporting

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -3,6 +3,7 @@ What's New
 
 Discover notable new features and improvements in each release
 
+.. include::  whats_new/v0-7-9.rst
 .. include::  whats_new/v0-7-8-002.rst
 .. include::  whats_new/v0-7-8-001.rst
 .. include::  whats_new/v0-7-8.rst

--- a/docs/whats_new/v0-7-9.rst
+++ b/docs/whats_new/v0-7-9.rst
@@ -1,0 +1,14 @@
+v0.7.9 - Under development
+++++++++++++++++++++++++++
+
+New Features
+############
+- Implement a new property for connections to report the phase of the fluid,
+  i.e. :code:`"l"` for liquid, :code:`"tp"` for two-phase and :code:`"g"` for
+  gaseous. The phase is only reported in subcritical pressure
+  (`PR #592 <https://github.com/oemof/tespy/pull/592>`__).
+
+Contributors
+############
+- `@tlmerbecks <https://github.com/tlmerbecks>`__
+- Francesco Witte (`@fwitte <https://github.com/fwitte>`__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = ["docs/_build"]
 
 [project]
 name = "tespy"
-version = "0.7.8.post2"
+version = "0.7.9.dev0"
 description = "Thermal Engineering Systems in Python (TESPy)"
 readme = "README.rst"
 authors = [

--- a/src/tespy/__init__.py
+++ b/src/tespy/__init__.py
@@ -3,7 +3,7 @@ import importlib.resources
 import os
 
 __datapath__ = os.path.join(importlib.resources.files("tespy"), "data")
-__version__ = '0.7.8.post2 - Newton\'s Nature'
+__version__ = '0.7.9.dev0 - Newton\'s Nature'
 
 # tespy data and connections import
 from . import connections  # noqa: F401

--- a/src/tespy/connections/connection.py
+++ b/src/tespy/connections/connection.py
@@ -21,6 +21,7 @@ from tespy.tools.data_containers import ReferencedFluidProperties as dc_ref
 from tespy.tools.data_containers import SimpleDataContainer as dc_simple
 from tespy.tools.fluid_properties import CoolPropWrapper
 from tespy.tools.fluid_properties import Q_mix_ph
+from tespy.tools.fluid_properties import state_mix_ph
 from tespy.tools.fluid_properties import T_mix_ph
 from tespy.tools.fluid_properties import T_sat_p
 from tespy.tools.fluid_properties import dh_mix_dpQ
@@ -704,6 +705,8 @@ class Connection:
             "v_ref": dc_ref(
                 func=self.v_ref_func, deriv=self.v_ref_deriv, num_eq=1
             ),
+            "state": dc_prop(is_var=True),
+
         }
 
     def build_fluid_data(self):
@@ -933,6 +936,11 @@ class Connection:
             except ValueError:
                 self.x.val_SI = np.nan
             try:
+                if not self.state.is_set:
+                    self.state.val_SI = self.calc_state()
+            except ValueError:
+                self.state.val_SI = np.nan
+            try:
                 if not self.Td_bp.is_set:
                     self.Td_bp.val_SI = self.calc_Td_bp()
             except ValueError:
@@ -1125,6 +1133,12 @@ class Connection:
             )
 
         self.Ex_chemical = self.m.val_SI * self.ex_chemical
+
+    def calc_state(self):
+        try:
+            return state_mix_ph(self.p.val_SI, self.h.val_SI, self.fluid_data)
+        except NotImplementedError:
+            return np.nan
 
 
 class Ref:

--- a/src/tespy/connections/connection.py
+++ b/src/tespy/connections/connection.py
@@ -21,7 +21,7 @@ from tespy.tools.data_containers import ReferencedFluidProperties as dc_ref
 from tespy.tools.data_containers import SimpleDataContainer as dc_simple
 from tespy.tools.fluid_properties import CoolPropWrapper
 from tespy.tools.fluid_properties import Q_mix_ph
-from tespy.tools.fluid_properties import state_mix_ph
+from tespy.tools.fluid_properties import phase_mix_ph
 from tespy.tools.fluid_properties import T_mix_ph
 from tespy.tools.fluid_properties import T_sat_p
 from tespy.tools.fluid_properties import dh_mix_dpQ
@@ -267,6 +267,7 @@ class Connection:
             if hasattr(v, "func") and v.func is not None
         }
         self.state = dc_simple()
+        self.phase = dc_simple()
         self.property_data0 = [x + '0' for x in self.property_data.keys()]
         self.__dict__.update(self.property_data)
         self.mixing_rule = None
@@ -705,7 +706,6 @@ class Connection:
             "v_ref": dc_ref(
                 func=self.v_ref_func, deriv=self.v_ref_deriv, num_eq=1
             ),
-            "state": dc_prop(is_var=True),
 
         }
 
@@ -935,11 +935,12 @@ class Connection:
                     self.x.val_SI = self.calc_x()
             except ValueError:
                 self.x.val_SI = np.nan
+
             try:
-                if not self.state.is_set:
-                    self.state.val_SI = self.calc_state()
+                self.phase.val = self.calc_phase()
             except ValueError:
-                self.state.val_SI = np.nan
+                self.phase.val = np.nan
+
             try:
                 if not self.Td_bp.is_set:
                     self.Td_bp.val_SI = self.calc_Td_bp()
@@ -1134,9 +1135,9 @@ class Connection:
 
         self.Ex_chemical = self.m.val_SI * self.ex_chemical
 
-    def calc_state(self):
+    def calc_phase(self):
         try:
-            return state_mix_ph(self.p.val_SI, self.h.val_SI, self.fluid_data)
+            return phase_mix_ph(self.p.val_SI, self.h.val_SI, self.fluid_data)
         except NotImplementedError:
             return np.nan
 

--- a/src/tespy/connections/connection.py
+++ b/src/tespy/connections/connection.py
@@ -21,7 +21,6 @@ from tespy.tools.data_containers import ReferencedFluidProperties as dc_ref
 from tespy.tools.data_containers import SimpleDataContainer as dc_simple
 from tespy.tools.fluid_properties import CoolPropWrapper
 from tespy.tools.fluid_properties import Q_mix_ph
-from tespy.tools.fluid_properties import phase_mix_ph
 from tespy.tools.fluid_properties import T_mix_ph
 from tespy.tools.fluid_properties import T_sat_p
 from tespy.tools.fluid_properties import dh_mix_dpQ
@@ -32,6 +31,7 @@ from tespy.tools.fluid_properties import dv_mix_dph
 from tespy.tools.fluid_properties import dv_mix_pdh
 from tespy.tools.fluid_properties import h_mix_pQ
 from tespy.tools.fluid_properties import h_mix_pT
+from tespy.tools.fluid_properties import phase_mix_ph
 from tespy.tools.fluid_properties import s_mix_ph
 from tespy.tools.fluid_properties import v_mix_ph
 from tespy.tools.fluid_properties import viscosity_mix_ph

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -2571,7 +2571,7 @@ class Network:
                         )
 
         # connection properties
-        df = self.results['Connection'].loc[:, ['m', 'p', 'h', 'T']].copy()
+        df = self.results['Connection'].loc[:, ['m', 'p', 'h', 'T', 'x', 'state']].copy()
         df = df.astype(str)
         for c in df.index:
             if not self.get_conn(c).printout:

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -1187,7 +1187,7 @@ class Network:
         self.all_fluids = set(self.all_fluids)
         cols = (
             [col for prop in properties for col in [prop, f"{prop}_unit"]]
-            + list(self.all_fluids)
+            + list(self.all_fluids) + ['phase']
         )
         self.results['Connection'] = pd.DataFrame(columns=cols, dtype='float64')
         # include column for fluid balance in specs dataframe
@@ -2476,7 +2476,10 @@ class Network:
                 ] + [
                     c.fluid.val[fluid] if fluid in c.fluid.val else np.nan
                     for fluid in self.all_fluids
+                ] + [
+                    c.phase.val
                 ]
+
             )
 
     def process_components(self):
@@ -2571,7 +2574,7 @@ class Network:
                         )
 
         # connection properties
-        df = self.results['Connection'].loc[:, ['m', 'p', 'h', 'T', 'x', 'state']].copy()
+        df = self.results['Connection'].loc[:, ['m', 'p', 'h', 'T', 'x', 'phase']].copy()
         df = df.astype(str)
         for c in df.index:
             if not self.get_conn(c).printout:

--- a/src/tespy/tools/document_models.py
+++ b/src/tespy/tools/document_models.py
@@ -333,6 +333,8 @@ def document_connection_params(nw, df, specs, eqs, c, rpt):
         unit = col + '_unit'
         if col == 'Td_bp':
             unit = 'T_unit'
+        elif col == 'phase':
+            continue
         col_header = (
             col.replace('_', r'\_') + ' in ' +
             hlp.latex_unit(nw.get_attr(unit)))

--- a/src/tespy/tools/fluid_properties/__init__.py
+++ b/src/tespy/tools/fluid_properties/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8
 
-from .functions import phase_mix_ph
 from .functions import Q_mix_ph  # noqa: F401
 from .functions import T_mix_ph  # noqa: F401
 from .functions import T_mix_ps  # noqa: F401
@@ -14,6 +13,7 @@ from .functions import dv_mix_pdh  # noqa: F401
 from .functions import h_mix_pQ  # noqa: F401
 from .functions import h_mix_pT  # noqa: F401
 from .functions import isentropic  # noqa: F401
+from .functions import phase_mix_ph  # noqa: F401
 from .functions import s_mix_ph  # noqa: F401
 from .functions import s_mix_pT  # noqa: F401
 from .functions import v_mix_ph  # noqa: F401

--- a/src/tespy/tools/fluid_properties/__init__.py
+++ b/src/tespy/tools/fluid_properties/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8
 
-from .functions import state_mix_ph
+from .functions import phase_mix_ph
 from .functions import Q_mix_ph  # noqa: F401
 from .functions import T_mix_ph  # noqa: F401
 from .functions import T_mix_ps  # noqa: F401

--- a/src/tespy/tools/fluid_properties/__init__.py
+++ b/src/tespy/tools/fluid_properties/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8
 
+from .functions import state_mix_ph
 from .functions import Q_mix_ph  # noqa: F401
 from .functions import T_mix_ph  # noqa: F401
 from .functions import T_mix_ps  # noqa: F401

--- a/src/tespy/tools/fluid_properties/functions.py
+++ b/src/tespy/tools/fluid_properties/functions.py
@@ -155,6 +155,14 @@ def Q_mix_ph(p, h, fluid_data, mixing_rule=None):
         msg = "Saturation function cannot be called on mixtures."
         raise ValueError(msg)
 
+def state_mix_ph(p, h, fluid_data, mixing_rule=None):
+    if get_number_of_fluids(fluid_data) == 1:
+        pure_fluid = get_pure_fluid(fluid_data)
+        return pure_fluid["wrapper"].state_ph(p, h)
+    else:
+        msg = "State function cannot be called on mixtures."
+        raise ValueError(msg)
+
 
 def p_sat_T(T, fluid_data, mixing_rule=None):
     if get_number_of_fluids(fluid_data) == 1:

--- a/src/tespy/tools/fluid_properties/functions.py
+++ b/src/tespy/tools/fluid_properties/functions.py
@@ -155,10 +155,10 @@ def Q_mix_ph(p, h, fluid_data, mixing_rule=None):
         msg = "Saturation function cannot be called on mixtures."
         raise ValueError(msg)
 
-def state_mix_ph(p, h, fluid_data, mixing_rule=None):
+def phase_mix_ph(p, h, fluid_data, mixing_rule=None):
     if get_number_of_fluids(fluid_data) == 1:
         pure_fluid = get_pure_fluid(fluid_data)
-        return pure_fluid["wrapper"].state_ph(p, h)
+        return pure_fluid["wrapper"].phase_ph(p, h)
     else:
         msg = "State function cannot be called on mixtures."
         raise ValueError(msg)

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -233,15 +233,6 @@ class CoolPropWrapper(FluidPropertyWrapper):
         self.AS.update(CP.HmassP_INPUTS, h, p)
         return self.AS.Q()
 
-        # if self.AS.phase() == CP.iphase_twophase:
-        #     return self.AS.Q()
-        # elif self.AS.phase() == CP.iphase_liquid:
-        #     return 0
-        # elif self.AS.phase() == CP.iphase_gas:
-        #     return 1
-        # else:  # all other phases - though this should be unreachable as p is sub-critical
-        #     return -1
-
     def phase_ph(self, p, h):
         p = self._make_p_subcritical(p)
         self.AS.update(CP.HmassP_INPUTS, h, p)

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -231,15 +231,16 @@ class CoolPropWrapper(FluidPropertyWrapper):
     def Q_ph(self, p, h):
         p = self._make_p_subcritical(p)
         self.AS.update(CP.HmassP_INPUTS, h, p)
+        return self.AS.Q()
 
-        if self.AS.phase() == CP.iphase_twophase:
-            return self.AS.Q()
-        elif self.AS.phase() == CP.iphase_liquid:
-            return 0
-        elif self.AS.phase() == CP.iphase_gas:
-            return 1
-        else:  # all other phases - though this should be unreachable as p is sub-critical
-            return -1
+        # if self.AS.phase() == CP.iphase_twophase:
+        #     return self.AS.Q()
+        # elif self.AS.phase() == CP.iphase_liquid:
+        #     return 0
+        # elif self.AS.phase() == CP.iphase_gas:
+        #     return 1
+        # else:  # all other phases - though this should be unreachable as p is sub-critical
+        #     return -1
 
     def phase_ph(self, p, h):
         p = self._make_p_subcritical(p)

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -94,7 +94,7 @@ class FluidPropertyWrapper:
     def Q_ph(self, p, h):
         self._not_implemented()
 
-    def state_ph(self, p, h):
+    def phase_ph(self, p, h):
         self._not_implemented()
 
     def d_ph(self, p, h):
@@ -241,7 +241,7 @@ class CoolPropWrapper(FluidPropertyWrapper):
         else:  # all other phases - though this should be unreachable as p is sub-critical
             return -1
 
-    def state_ph(self, p, h):
+    def phase_ph(self, p, h):
         p = self._make_p_subcritical(p)
         self.AS.update(CP.HmassP_INPUTS, h, p)
 
@@ -380,7 +380,7 @@ class IAPWSWrapper(FluidPropertyWrapper):
         p = self._make_p_subcritical(p)
         return self.AS(h=h / 1e3, P=p / 1e6).x
 
-    def state_ph(self, p, h):
+    def phase_ph(self, p, h):
         p = self._make_p_subcritical(p)
 
         phase = self.AS(h=h / 1e3, P=p / 1e6).phase

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -382,14 +382,17 @@ class IAPWSWrapper(FluidPropertyWrapper):
 
     def state_ph(self, p, h):
         p = self._make_p_subcritical(p)
-        x = self.AS(h=h / 1e3, P=p / 1e6).x
 
-        if x == 0:
+        phase = self.AS(h=h / 1e3, P=p / 1e6).phase
+
+        if phase in ["Liquid"]:
             return "l"
-        elif x == 1:
+        elif phase in  ["Vapour"]:
             return "g"
-        else:
+        elif phase in ["Two phases", "Saturated vapor", "Saturated liquid"]:
             return "tp"
+        else:  # to ensure consistent behaviour to CoolPropWrapper
+            return "phase not recognised"
 
     def d_ph(self, p, h):
         return self.AS(h=h / 1e3, P=p / 1e6).rho

--- a/src/tespy/tools/global_vars.py
+++ b/src/tespy/tools/global_vars.py
@@ -97,7 +97,15 @@ fluid_property_data = {
         'units': {'J / kgK': 1, 'kJ / kgK': 1e3, 'MJ / kgK': 1e6},
         'latex_eq': r'0 = s_\mathrm{spec} - s\left(p, h \right)',
         'documentation': {'float_fmt': '{:,.2f}'}
+    },
+    'state': {
+        'text': 'state',
+        'SI_unit': '-',
+        'units': {'-': 1},
+        'latex_eq': r'',
+        'documentation': {'string_fmt': '{}'}
     }
+
 }
 
 combustion_gases = ['methane', 'ethane', 'propane', 'butane', 'hydrogen', 'nDodecane']

--- a/src/tespy/tools/global_vars.py
+++ b/src/tespy/tools/global_vars.py
@@ -98,13 +98,6 @@ fluid_property_data = {
         'latex_eq': r'0 = s_\mathrm{spec} - s\left(p, h \right)',
         'documentation': {'float_fmt': '{:,.2f}'}
     },
-    'state': {
-        'text': 'state',
-        'SI_unit': '-',
-        'units': {'-': 1},
-        'latex_eq': r'',
-        'documentation': {'string_fmt': '{}'}
-    }
 
 }
 

--- a/src/tespy/tools/helpers.py
+++ b/src/tespy/tools/helpers.py
@@ -133,7 +133,8 @@ def convert_from_SI(property, SI_value, unit):
     if property == 'T':
         converters = fluid_property_data['T']['units'][unit]
         return SI_value / converters[1] - converters[0]
-
+    elif property == "state":
+        return SI_value
     else:
         return SI_value / fluid_property_data[property]['units'][unit]
 

--- a/src/tespy/tools/helpers.py
+++ b/src/tespy/tools/helpers.py
@@ -133,8 +133,6 @@ def convert_from_SI(property, SI_value, unit):
     if property == 'T':
         converters = fluid_property_data['T']['units'][unit]
         return SI_value / converters[1] - converters[0]
-    elif property == "state":
-        return SI_value
     else:
         return SI_value / fluid_property_data[property]['units'][unit]
 


### PR DESCRIPTION
Ciao @fwitte,

I noticed that the property reporting for `Connections `does not include the vapour quality or the state, hence the overall aim of this pull request is to include them in the table of properties for `Connections`.

I implemented the following changes:

- Aligned the calculation of the vapour quality for the `CoolPropWrapper` with that of the `IAPWSWrapper`. Currently the `CoolPropWrapper` reports a vapour quality of `-1` for all single phase states (irrespective of it being gas or liquid).  With the changes below, the vapour quality is now reported as `0` for liquids and `1` for gases, for subcritical conditions.
- Added a state_ph function to the base `FluidPropertiesWrapper`, the `CoolPropWrapper `and the `IAPWSWrapper`. Unfortunately, I lack expertise with Pyromat and so have not done this... yet)
- Extended the `fluid_properties_data` (global_vars) with a `state` properties field
- Added an exception rule for the unit conversion of the new `state` property
- Added the `vapour quality` and `state` to the reported `Connection` results

I hope the above is clear enough. Is there anything else that would be helpful?