### PR TITLE
Steam Turbine with wet expansion

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -27,6 +27,15 @@
   year   = {1988},
 }
 
+@book{Tanuma2017,
+  doi = {10.1016/C2014-0-03636-2},
+  editor = {T. Tanuma},
+  isbn = {9780081003145},
+  publisher = {Elsevier},
+  title = {Advances in Steam Turbines for Modern Power Plants},
+  year = {2017},
+}
+
 @TechReport{Lippke1995,
   author      = {Lippke, Frank},
   institution = {Sandia National Lab.},

--- a/docs/whats_new/v0-7-9.rst
+++ b/docs/whats_new/v0-7-9.rst
@@ -7,6 +7,11 @@ New Features
   i.e. :code:`"l"` for liquid, :code:`"tp"` for two-phase and :code:`"g"` for
   gaseous. The phase is only reported in subcritical pressure
   (`PR #592 <https://github.com/oemof/tespy/pull/592>`__).
+- Implement the Baumann correlation for wet expansion in steamturbines. The
+  feature is available in a new component class,
+  :py:class:`tespy.components.turbomachinery.steam_turbine.SteamTurbine`. To
+  use the feature check the documentation of the component class
+  (`PR #602 <https://github.com/oemof/tespy/pull/602>`__).
 
 Contributors
 ############

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "matplotlib>=3.2.1",
     "numpy>=1.13.3",
     "pandas>=1.3.0",
+    "scipy",
     "tabulate>=0.8.2",
 ]
 license = {text = "MIT"}

--- a/src/tespy/components/__init__.py
+++ b/src/tespy/components/__init__.py
@@ -26,5 +26,5 @@ from .reactors.water_electrolyzer import WaterElectrolyzer  # noqa: F401
 from .subsystem import Subsystem  # noqa: F401
 from .turbomachinery.compressor import Compressor  # noqa: F401
 from .turbomachinery.pump import Pump  # noqa: F401
+from .turbomachinery.steam_turbine import SteamTurbine
 from .turbomachinery.turbine import Turbine # noqa: F401
-from .turbomachinery.turbine import SteamTurbine

--- a/src/tespy/components/__init__.py
+++ b/src/tespy/components/__init__.py
@@ -26,5 +26,5 @@ from .reactors.water_electrolyzer import WaterElectrolyzer  # noqa: F401
 from .subsystem import Subsystem  # noqa: F401
 from .turbomachinery.compressor import Compressor  # noqa: F401
 from .turbomachinery.pump import Pump  # noqa: F401
+from .turbomachinery.turbine import Turbine  # noqa: F401
 from .turbomachinery.steam_turbine import SteamTurbine
-from .turbomachinery.turbine import Turbine # noqa: F401

--- a/src/tespy/components/__init__.py
+++ b/src/tespy/components/__init__.py
@@ -26,4 +26,5 @@ from .reactors.water_electrolyzer import WaterElectrolyzer  # noqa: F401
 from .subsystem import Subsystem  # noqa: F401
 from .turbomachinery.compressor import Compressor  # noqa: F401
 from .turbomachinery.pump import Pump  # noqa: F401
-from .turbomachinery.turbine import Turbine  # noqa: F401
+from .turbomachinery.turbine import Turbine # noqa: F401
+from .turbomachinery.turbine import SteamTurbine

--- a/src/tespy/components/__init__.py
+++ b/src/tespy/components/__init__.py
@@ -26,5 +26,5 @@ from .reactors.water_electrolyzer import WaterElectrolyzer  # noqa: F401
 from .subsystem import Subsystem  # noqa: F401
 from .turbomachinery.compressor import Compressor  # noqa: F401
 from .turbomachinery.pump import Pump  # noqa: F401
-from .turbomachinery.steam_turbine import SteamTurbine
+from .turbomachinery.steam_turbine import SteamTurbine  # noqa: F401
 from .turbomachinery.turbine import Turbine  # noqa: F401

--- a/src/tespy/components/__init__.py
+++ b/src/tespy/components/__init__.py
@@ -26,5 +26,5 @@ from .reactors.water_electrolyzer import WaterElectrolyzer  # noqa: F401
 from .subsystem import Subsystem  # noqa: F401
 from .turbomachinery.compressor import Compressor  # noqa: F401
 from .turbomachinery.pump import Pump  # noqa: F401
-from .turbomachinery.turbine import Turbine  # noqa: F401
 from .turbomachinery.steam_turbine import SteamTurbine
+from .turbomachinery.turbine import Turbine  # noqa: F401

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -117,7 +117,7 @@ class SteamTurbine(Turbine):
     >>> so = Source('source')
     >>> st = SteamTurbine('steam turbine')
     >>> st.component()
-    'turbine'
+    'steam turbine'
     >>> inc = Connection(so, 'out1', st, 'in1')
     >>> outg = Connection(st, 'out1', si, 'in1')
     >>> nw.add_conns(inc, outg)
@@ -135,12 +135,12 @@ class SteamTurbine(Turbine):
     To capture the effect of liquid drop-out on the isentropic
     efficiency, the dry turbine efficiency is specified
     >>> st.set_attr(eta_s=None)
-    >>> st.set_attr(eta_dry_s=0.9, alpha=1.0)
+    >>> st.set_attr(eta_s_dry=0.9, alpha=1.0)
     >>> nw.solve('design')
     >>> round(st.P.val, 0)
     -7009682.0
     >>> round(outg.x.val, 3)
-    0.840
+    0.84
     """
 
     @staticmethod

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -12,16 +12,15 @@ SPDX-License-Identifier: MIT
 
 from scipy.optimize import brentq
 
-
 from tespy.components.component import component_registry
 from tespy.components.turbomachinery.turbine import Turbine
 from tespy.tools.data_containers import ComponentProperties as dc_cp
 from tespy.tools.data_containers import GroupedComponentProperties as dc_gcp
-from tespy.tools.fluid_properties import isentropic
 from tespy.tools.fluid_properties import h_mix_pQ
-from tespy.tools.logger import logger
-from tespy.tools.helpers import fluidalias_in_list
+from tespy.tools.fluid_properties import isentropic
 from tespy.tools.fluid_properties.helpers import single_fluid
+from tespy.tools.helpers import fluidalias_in_list
+from tespy.tools.logger import logger
 
 
 @component_registry

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -222,21 +222,21 @@ class SteamTurbine(Turbine):
 
             # calculate the final outlet enthalpy
             hout_isen = isentropic(
-                                psat,
-                                hsat,
-                                outl.p.val_SI,
-                                inl.fluid_data,
-                                inl.mixing_rule,
-                                T0=inl.T.val_SI
-                            )
+                psat,
+                hsat,
+                outl.p.val_SI,
+                inl.fluid_data,
+                inl.mixing_rule,
+                T0=inl.T.val_SI
+            )
             hout = hsat - eta_s * (hsat - hout_isen)
 
             # calculate the difference in enthalpy
-            dh_isen = hout - inl.h.val_SI
+            dh_bisectioned = hout - inl.h.val_SI
             dh = outl.h.val_SI - inl.h.val_SI
 
             # return residual
-            return -dh + dh_isen
+            return dh - dh_bisectioned
 
     def eta_s_wet_deriv(self, increment_filter, k):
 

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -239,12 +239,8 @@ class SteamTurbine(Turbine):
             )
             hout = hsat - eta_s * (hsat - hout_isen)
 
-            # calculate the difference in enthalpy
-            dh_bisectioned = hout - inl.h.val_SI
-            dh = outl.h.val_SI - inl.h.val_SI
-
-            # return residual
-            return dh - dh_bisectioned
+            # return residual: outlet enthalpy = calculated outlet enthalpy
+            return outl.h.val_SI - hout
 
     def eta_s_wet_deriv(self, increment_filter, k):
         r"""

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8
+
+"""Module of class Turbine.
+
+
+This file is part of project TESPy (github.com/oemof/tespy). It's copyrighted
+by the contributors recorded in the version control history of the file,
+available from its original location tespy/components/turbomachinery/turbine.py
+
+SPDX-License-Identifier: MIT
+"""
+
+from scipy.optimize import brentq
+
+
+from tespy.components.component import component_registry
+from tespy.components.turbomachinery.turbine import Turbine
+from tespy.tools.data_containers import ComponentProperties as dc_cp
+from tespy.tools.fluid_properties import isentropic
+from tespy.tools.fluid_properties import h_mix_pQ
+
+
+@component_registry
+class SteamTurbine(Turbine):
+    r"""
+    Class for steam turbines with wet expansion.
+
+    **Mandatory Equations**
+
+    - :py:meth:`tespy.components.component.Component.fluid_func`
+    - :py:meth:`tespy.components.component.Component.mass_flow_func`
+
+    **Optional Equations**
+
+    - :py:meth:`tespy.components.component.Component.pr_func`
+    - :py:meth:`tespy.components.turbomachinery.base.Turbomachine.energy_balance_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_dry_s_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_s_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_s_char_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.cone_func`
+
+    Inlets/Outlets
+
+    - in1
+    - out1
+
+    Image
+
+    .. image:: /api/_images/Turbine.svg
+       :alt: flowsheet of the turbine
+       :align: center
+       :class: only-light
+
+    .. image:: /api/_images/Turbine_darkmode.svg
+       :alt: flowsheet of the turbine
+       :align: center
+       :class: only-dark
+
+    Parameters
+    ----------
+    label : str
+        The label of the component.
+
+    design : list
+        List containing design parameters (stated as String).
+
+    offdesign : list
+        List containing offdesign parameters (stated as String).
+
+    design_path : str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings : boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout : boolean
+        Include this component in the network's results printout.
+
+    P : float, dict
+        Power, :math:`P/\text{W}`
+
+    eta_s : float, dict
+        Isentropic efficiency, :math:`\eta_s/1`
+
+    eta_dry_s : float, dict
+        Dry isentropic efficiency, :math:`\eta_s/1`
+
+    pr : float, dict, :code:`"var"`
+        Outlet to inlet pressure ratio, :math:`pr/1`
+
+    eta_s_char : tespy.tools.characteristics.CharLine, dict
+        Characteristic curve for isentropic efficiency, provide CharLine as
+        function :code:`func`.
+
+    cone : dict
+        Apply Stodola's cone law (works in offdesign only).
+
+    Example
+    -------
+    A steam turbine expands 10 kg/s of superheated steam at 550 °C and 110 bar
+    to 0,5 bar at the outlet. For example, it is possible to calulate the power
+    output and vapour content at the outlet for a given isentropic efficiency.
+
+    >>> from tespy.components import Sink, Source, Turbine
+    >>> from tespy.connections import Connection
+    >>> from tespy.networks import Network
+    >>> from tespy.tools import ComponentCharacteristics as dc_cc
+    >>> import shutil
+    >>> nw = Network(p_unit='bar', T_unit='C', h_unit='kJ / kg', iterinfo=False)
+    >>> si = Sink('sink')
+    >>> so = Source('source')
+    >>> st = SteamTurbine('steam turbine')
+    >>> st.component()
+    'turbine'
+    >>> inc = Connection(so, 'out1', st, 'in1')
+    >>> outg = Connection(st, 'out1', si, 'in1')
+    >>> nw.add_conns(inc, outg)
+
+    In design conditions the isentropic efficiency is specified.
+    >>> st.set_attr(eta_s=0.9)
+    >>> inc.set_attr(fluid={'water': 1}, m=10, T=250, p=20)
+    >>> outg.set_attr(p=0.1)
+    >>> nw.solve('design')
+    >>> round(st.P.val, 0)
+    -7471296.0
+    >>> round(outg.x.val, 3)
+    0.821
+
+    To capture the effect of liquid drop-out on the isentropic efficiency, the dry turbine efficiency is specified
+    >>> st.set_attr(eta_s=None)
+    >>> st.set_attr(eta_dry_s=0.9)
+    >>> nw.solve('design')
+    >>> round(st.P.val, 0)
+    -7009682.0
+    >>> round(outg.x.val, 3)
+    0.840
+    """
+
+
+    @staticmethod
+    def component():
+        return 'steam turbine'
+
+    def get_parameters(self):
+
+        params = super().get_parameters()
+
+        params["alpha"] = dc_cp(
+            min_val=0.4, max_val=2.5, num_eq=0)
+        params["eta_dry_s"] = dc_cp(
+            min_val=0, max_val=1, num_eq=1,
+            func=self.eta_dry_s_func,
+            deriv=self.eta_dry_s_deriv
+        )
+
+        return params
+
+    def eta_dry_s_func(self):
+
+        inl = self.inl[0]
+        outl = self.outl[0]
+
+        state = inl.calc_phase()
+        if state == "tp":  # two-phase or saturated vapour
+
+            ym = 1 - (inl.calc_x() + outl.calc_x()) / 2  # average wetness
+            self.eta_s.val = self.eta_dry.val * (1 - self.alpha.val * ym)
+
+            return self.eta_s_func()
+
+        else:  # superheated vapour
+            dp = inl.p.val_SI - outl.p.val_SI
+
+            # compute the pressure and enthalpy at which the expansion enters the vapour dome
+            def find_sat(frac):
+                psat = inl.p.val_SI - frac * dp
+
+                # calculate enthalpy under dry expansion to psat
+                hout_isen = isentropic(
+                                    inl.p.val_SI,
+                                    inl.h.val_SI,
+                                    psat,
+                                    inl.fluid_data,
+                                    inl.mixing_rule,
+                                    T0=inl.T.val_SI
+                                )
+                hout = inl.h.val_SI - self.eta_dry_s.val * (inl.h.val_SI - hout_isen)
+
+                # calculate enthalpy of saturated vapour at psat
+                hsat = h_mix_pQ(psat, 1, inl.fluid_data)
+
+                return hout - hsat
+            frac = brentq(find_sat, 1, 0)
+            psat = inl.p.val_SI - frac * dp
+            hsat = h_mix_pQ(psat, 1, inl.fluid_data)
+
+            # calculate the isentropic efficiency for wet expansion
+            ym = 1 - (1.0 + outl.calc_x()) / 2  # average wetness
+            eta_s = self.eta_dry_s.val * (1 - self.alpha.val * ym)
+
+            # calculate the final outlet enthalpy
+            hout_isen = isentropic(
+                                psat,
+                                hsat,
+                                outl.p.val_SI,
+                                inl.fluid_data,
+                                inl.mixing_rule,
+                                T0=inl.T.val_SI
+                            )
+            hout = hsat - eta_s * (hsat- hout_isen)
+
+            # calculate the difference in enthalpy
+            dh_isen = hout - inl.h.val_SI
+            dh = outl.h.val_SI - inl.h.val_SI
+
+            # return residual
+            return -dh + dh_isen
+
+    def eta_dry_s_deriv(self, increment_filter, k):
+
+        f = self.eta_dry_s_func
+        i = self.inl[0]
+        o = self.outl[0]
+        if self.is_variable(i.p, increment_filter):
+            self.jacobian[k, i.p.J_col] = self.numeric_deriv(f, "p", i)
+        if self.is_variable(o.p, increment_filter):
+            self.jacobian[k, o.p.J_col] = self.numeric_deriv(f, "p", o)
+        if self.is_variable(i.h, increment_filter):
+            self.jacobian[k, i.h.J_col] = self.numeric_deriv(f, "h", i)
+        if self.is_variable(o.h, increment_filter):
+            self.jacobian[k, o.h.J_col] = self.numeric_deriv(f, "h", o)

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -16,6 +16,7 @@ from scipy.optimize import brentq
 from tespy.components.component import component_registry
 from tespy.components.turbomachinery.turbine import Turbine
 from tespy.tools.data_containers import ComponentProperties as dc_cp
+from tespy.tools.data_containers import GroupedComponentProperties as dc_gcp
 from tespy.tools.document_models import generate_latex_eq
 from tespy.tools.fluid_properties import isentropic
 from tespy.tools.fluid_properties import h_mix_pQ
@@ -136,7 +137,7 @@ class SteamTurbine(Turbine):
     To capture the effect of liquid drop-out on the isentropic
     efficiency, the dry turbine efficiency is specified
     >>> st.set_attr(eta_s=None)
-    >>> st.set_attr(eta_dry_s=0.9)
+    >>> st.set_attr(eta_dry_s=0.9, alpha=1.0)
     >>> nw.solve('design')
     >>> round(st.P.val, 0)
     -7009682.0
@@ -151,20 +152,19 @@ class SteamTurbine(Turbine):
     def get_parameters(self):
 
         params = super().get_parameters()
-        params["alpha"] = dc_cp(
-            min_val=0.4, max_val=2.5, num_eq=0)
-        params["eta_dry_s"] = dc_cp(
-            min_val=0, max_val=1, num_eq=1,
-            func=self.eta_dry_s_func,
-            deriv=self.eta_dry_s_deriv,
-            latex=self.eta_dry_s_func_doc
-        )
+        params["alpha"] = dc_cp(min_val=0.4, max_val=2.5)
+        params["eta_s_dry"] = dc_cp(min_val=0.0, max_val=1.0)
+        params["eta_s_dry_group"] = dc_gcp(
+            num_eq=1, elements=["alpha", "eta_s_dry"],
+            func=self.eta_s_wet_func,
+            deriv=self.eta_s_wet_deriv,
+            latex=self.eta_s_wet_func_doc)
 
         return params
 
-    def eta_dry_s_func(self):
+    def eta_s_wet_func(self):
         r"""
-                Equation for given dry isentropic efficiency of a turbine.
+                Equation for given dry isentropic efficiency of a turbine under wet expansion.
 
                 Returns
                 -------
@@ -209,7 +209,7 @@ class SteamTurbine(Turbine):
                                     inl.mixing_rule,
                                     T0=inl.T.val_SI
                                 )
-                hout = inl.h.val_SI - self.eta_dry_s.val * (inl.h.val_SI - hout_isen)
+                hout = inl.h.val_SI - self.eta_s_dry.val * (inl.h.val_SI - hout_isen)
 
                 # calculate enthalpy of saturated vapour at psat
                 hsat = h_mix_pQ(psat, 1, inl.fluid_data)
@@ -221,7 +221,7 @@ class SteamTurbine(Turbine):
 
             # calculate the isentropic efficiency for wet expansion
             ym = 1 - (1.0 + outl.calc_x()) / 2  # average wetness
-            eta_s = self.eta_dry_s.val * (1 - self.alpha.val * ym)
+            eta_s = self.eta_s_dry.val * (1 - self.alpha.val * ym)
 
             # calculate the final outlet enthalpy
             hout_isen = isentropic(
@@ -241,7 +241,7 @@ class SteamTurbine(Turbine):
             # return residual
             return -dh + dh_isen
 
-    def eta_dry_s_deriv(self, increment_filter, k):
+    def eta_s_wet_deriv(self, increment_filter, k):
 
         r"""
                 Partial derivatives for dry isentropic efficiency function.
@@ -255,7 +255,7 @@ class SteamTurbine(Turbine):
                     Position of derivatives in Jacobian matrix (k-th equation).
                 """
 
-        f = self.eta_dry_s_func
+        f = self.eta_s_wet_func
         i = self.inl[0]
         o = self.outl[0]
         if self.is_variable(i.p, increment_filter):
@@ -267,7 +267,7 @@ class SteamTurbine(Turbine):
         if self.is_variable(o.h, increment_filter):
             self.jacobian[k, o.h.J_col] = self.numeric_deriv(f, "h", o)
 
-    def eta_dry_s_func_doc(self, label):
+    def eta_s_wet_func_doc(self, label):
         r"""
         Equation for given dry isentropic efficiency of a turbine.
 

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -109,6 +109,8 @@ class SteamTurbine(Turbine):
     A steam turbine expands 10 kg/s of superheated steam at 550 °C and 110 bar
     to 0,5 bar at the outlet. For example, it is possible to calulate the power
     output and vapour content at the outlet for a given isentropic efficiency.
+    The :code:`SteamTurbine` class follows the implementation of the Baumann
+    rule :cite:`Tanuma2017`
 
     >>> from tespy.components import Sink, Source, SteamTurbine
     >>> from tespy.connections import Connection

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -162,23 +162,25 @@ class SteamTurbine(Turbine):
 
     def eta_s_wet_func(self):
         r"""
-                Equation for given dry isentropic efficiency of a turbine under wet expansion.
+        Equation for given dry isentropic efficiency of a turbine under wet
+        expansion.
 
-                Returns
-                -------
-                residual : float
-                    Residual value of equation.
+        Returns
+        -------
+        residual : float
+            Residual value of equation.
 
-                    .. math::
+            .. math::
 
-                        0 = -\left( h_{out} - h_{in} \right) +
-                        \left( h_{out,s} - h_{in} \right) \cdot \eta_{s,e}
+                0 = -\left( h_{out} - h_{in} \right) +
+                \left( h_{out,s} - h_{in} \right) \cdot \eta_{s,e}
 
-                        \eta_{s,e} = \eta_{s,e}^{dry} \cdot \left( 1 - \alpha \cdot y_m \right)
+                \eta_{s,e} = \eta_{s,e}^{dry} \cdot \left( 1 - \alpha
+                \cdot y_m \right)
 
-                        y_m = \frac{\left( 1-x_{in}\right)+ \left( 1-x_{out} \right)}{2}
-                """
-
+                y_m = \frac{\left( 1-x_{in}\right)+ \left( 1-x_{out}
+                \right)}{2}
+        """
         inl = self.inl[0]
         outl = self.outl[0]
 
@@ -186,7 +188,10 @@ class SteamTurbine(Turbine):
         if state == "tp":  # two-phase or saturated vapour
 
             ym = 1 - (inl.calc_x() + outl.calc_x()) / 2  # average wetness
-            return self.calc_eta_s() - self.eta_s_dry.val * (1 - self.alpha.val * ym)
+            return (
+                self.calc_eta_s()
+                - self.eta_s_dry.val * (1 - self.alpha.val * ym)
+            )
 
         else:  # superheated vapour
             dp = inl.p.val_SI - outl.p.val_SI
@@ -198,14 +203,17 @@ class SteamTurbine(Turbine):
 
                 # calculate enthalpy under dry expansion to psat
                 hout_isen = isentropic(
-                                    inl.p.val_SI,
-                                    inl.h.val_SI,
-                                    psat,
-                                    inl.fluid_data,
-                                    inl.mixing_rule,
-                                    T0=inl.T.val_SI
-                                )
-                hout = inl.h.val_SI - self.eta_s_dry.val * (inl.h.val_SI - hout_isen)
+                    inl.p.val_SI,
+                    inl.h.val_SI,
+                    psat,
+                    inl.fluid_data,
+                    inl.mixing_rule,
+                    T0=inl.T.val_SI
+                )
+                hout = (
+                    inl.h.val_SI - self.eta_s_dry.val
+                    * (inl.h.val_SI - hout_isen)
+                )
 
                 # calculate enthalpy of saturated vapour at psat
                 hsat = h_mix_pQ(psat, 1, inl.fluid_data)
@@ -239,19 +247,17 @@ class SteamTurbine(Turbine):
             return dh - dh_bisectioned
 
     def eta_s_wet_deriv(self, increment_filter, k):
-
         r"""
-                Partial derivatives for dry isentropic efficiency function.
+        Partial derivatives for dry isentropic efficiency function.
 
-                Parameters
-                ----------
-                increment_filter : ndarray
-                    Matrix for filtering non-changing variables.
+        Parameters
+        ----------
+        increment_filter : ndarray
+            Matrix for filtering non-changing variables.
 
-                k : int
-                    Position of derivatives in Jacobian matrix (k-th equation).
-                """
-
+        k : int
+            Position of derivatives in Jacobian matrix (k-th equation).
+        """
         f = self.eta_s_wet_func
         i = self.inl[0]
         o = self.outl[0]
@@ -281,9 +287,12 @@ class SteamTurbine(Turbine):
         latex = (
             r'\begin{split}' + '\n'
             r'0 &=-\left(h_\mathrm{out}-h_\mathrm{in}\right)+\left('
-            r'h_\mathrm{out,s}-h_\mathrm{in}\right)\cdot\eta_\mathrm{s}\\' + '\n'
-            r'\eta_\mathrm{s} &=\eta_\mathrm{s}^\mathrm{dry}\cdot \left( 1 - \alpha \cdot y_\mathrm{m} \right)\\' + '\n'
-            r'y_\mathrm{m} &=\frac{\left( 1-x_\mathrm{in} \right)+\left( 1-x_\mathrm{out} \right)}{2}\\' + '\n'
+            r'h_\mathrm{out,s}-h_\mathrm{in}\right)\cdot\eta_\mathrm{s}\\'
+            + '\n'
+            r'\eta_\mathrm{s} &=\eta_\mathrm{s}^\mathrm{dry}\cdot \left( 1 - '
+            r'\alpha \cdot y_\mathrm{m} \right)\\' + '\n'
+            r'y_\mathrm{m} &=\frac{\left( 1-x_\mathrm{in} \right)+\left( '
+            r'1-x_\mathrm{out} \right)}{2}\\' + '\n'
             r'\end{split}'
         )
         return generate_latex_eq(self, latex, label)

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -186,9 +186,7 @@ class SteamTurbine(Turbine):
         if state == "tp":  # two-phase or saturated vapour
 
             ym = 1 - (inl.calc_x() + outl.calc_x()) / 2  # average wetness
-            self.eta_s.val = self.eta_dry.val * (1 - self.alpha.val * ym)
-
-            return self.eta_s_func()
+            return self.calc_eta_s() - self.eta_s_dry.val * (1 - self.alpha.val * ym)
 
         else:  # superheated vapour
             dp = inl.p.val_SI - outl.p.val_SI
@@ -213,6 +211,7 @@ class SteamTurbine(Turbine):
                 hsat = h_mix_pQ(psat, 1, inl.fluid_data)
 
                 return hout - hsat
+
             frac = brentq(find_sat, 1, 0)
             psat = inl.p.val_SI - frac * dp
             hsat = h_mix_pQ(psat, 1, inl.fluid_data)

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -109,11 +109,9 @@ class SteamTurbine(Turbine):
     to 0,5 bar at the outlet. For example, it is possible to calulate the power
     output and vapour content at the outlet for a given isentropic efficiency.
 
-    >>> from tespy.components import Sink, Source, Turbine
+    >>> from tespy.components import Sink, Source, SteamTurbine
     >>> from tespy.connections import Connection
     >>> from tespy.networks import Network
-    >>> from tespy.tools import ComponentCharacteristics as dc_cc
-    >>> import shutil
     >>> nw = Network(p_unit='bar', T_unit='C', h_unit='kJ / kg', iterinfo=False)
     >>> si = Sink('sink')
     >>> so = Source('source')

--- a/src/tespy/components/turbomachinery/steam_turbine.py
+++ b/src/tespy/components/turbomachinery/steam_turbine.py
@@ -151,7 +151,6 @@ class SteamTurbine(Turbine):
     def get_parameters(self):
 
         params = super().get_parameters()
-
         params["alpha"] = dc_cp(
             min_val=0.4, max_val=2.5, num_eq=0)
         params["eta_dry_s"] = dc_cp(
@@ -164,6 +163,23 @@ class SteamTurbine(Turbine):
         return params
 
     def eta_dry_s_func(self):
+        r"""
+                Equation for given dry isentropic efficiency of a turbine.
+
+                Returns
+                -------
+                residual : float
+                    Residual value of equation.
+
+                    .. math::
+
+                        0 = -\left( h_{out} - h_{in} \right) +
+                        \left( h_{out,s} - h_{in} \right) \cdot \eta_{s,e}
+
+                        \eta_{s,e} = \eta_{s,e}^{dry} \cdot \left( 1 - \alpha \cdot y_m \right)
+
+                        y_m = \frac{\left( 1-x_{in}\right)+ \left( 1-x_{out} \right)}{2}
+                """
 
         inl = self.inl[0]
         outl = self.outl[0]
@@ -227,6 +243,18 @@ class SteamTurbine(Turbine):
 
     def eta_dry_s_deriv(self, increment_filter, k):
 
+        r"""
+                Partial derivatives for dry isentropic efficiency function.
+
+                Parameters
+                ----------
+                increment_filter : ndarray
+                    Matrix for filtering non-changing variables.
+
+                k : int
+                    Position of derivatives in Jacobian matrix (k-th equation).
+                """
+
         f = self.eta_dry_s_func
         i = self.inl[0]
         o = self.outl[0]
@@ -257,8 +285,8 @@ class SteamTurbine(Turbine):
             r'\begin{split}' + '\n'
             r'0 &=-\left(h_\mathrm{out}-h_\mathrm{in}\right)+\left('
             r'h_\mathrm{out,s}-h_\mathrm{in}\right)\cdot\eta_\mathrm{s}\\' + '\n'
-            r'\eta_\mathrm{s} &=\eta_\mathrm{s}^\mathrm{dry}\cdot(1 - \alpha*y_\mathrm{m})\\' + '\n'
-            r'y_\mathrm{m} &=\frac{(1-x_\mathrm{in})+(1-x_\mathrm{out})}{2}\\' + '\n'
+            r'\eta_\mathrm{s} &=\eta_\mathrm{s}^\mathrm{dry}\cdot \left( 1 - \alpha \cdot y_\mathrm{m} \right)\\' + '\n'
+            r'y_\mathrm{m} &=\frac{\left( 1-x_\mathrm{in} \right)+\left( 1-x_\mathrm{out} \right)}{2}\\' + '\n'
             r'\end{split}'
         )
         return generate_latex_eq(self, latex, label)

--- a/src/tespy/components/turbomachinery/turbine.py
+++ b/src/tespy/components/turbomachinery/turbine.py
@@ -583,4 +583,3 @@ class Turbine(Turbomachine):
         self.E_bus = {"chemical": 0, "physical": 0, "massless": -self.P.val}
         self.E_D = self.E_F - self.E_P
         self.epsilon = self._calc_epsilon()
-

--- a/src/tespy/components/turbomachinery/turbine.py
+++ b/src/tespy/components/turbomachinery/turbine.py
@@ -11,7 +11,6 @@ SPDX-License-Identifier: MIT
 """
 
 import numpy as np
-from scipy.optimize import brentq
 
 
 from tespy.components.component import component_registry
@@ -22,13 +21,16 @@ from tespy.tools.data_containers import ComponentProperties as dc_cp
 from tespy.tools.data_containers import SimpleDataContainer as dc_simple
 from tespy.tools.document_models import generate_latex_eq
 from tespy.tools.fluid_properties import isentropic
-from tespy.tools.fluid_properties import h_mix_pQ
 
 
 @component_registry
 class Turbine(Turbomachine):
     r"""
     Class for gas or steam turbines.
+
+    The component Turbine is the parent class for the components:
+
+    - :py:class:`tespy.components.turbomachinery.steam_turbine.SteamTurbine`
 
     **Mandatory Equations**
 
@@ -582,219 +584,3 @@ class Turbine(Turbomachine):
         self.E_D = self.E_F - self.E_P
         self.epsilon = self._calc_epsilon()
 
-@component_registry
-class SteamTurbine(Turbine):
-    r"""
-    Class for steam turbines with wet expansion.
-
-    **Mandatory Equations**
-
-    - :py:meth:`tespy.components.component.Component.fluid_func`
-    - :py:meth:`tespy.components.component.Component.mass_flow_func`
-
-    **Optional Equations**
-
-    - :py:meth:`tespy.components.component.Component.pr_func`
-    - :py:meth:`tespy.components.turbomachinery.base.Turbomachine.energy_balance_func`
-    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_dry_s_func`
-    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_s_func`
-    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_s_char_func`
-    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.cone_func`
-
-    Inlets/Outlets
-
-    - in1
-    - out1
-
-    Image
-
-    .. image:: /api/_images/Turbine.svg
-       :alt: flowsheet of the turbine
-       :align: center
-       :class: only-light
-
-    .. image:: /api/_images/Turbine_darkmode.svg
-       :alt: flowsheet of the turbine
-       :align: center
-       :class: only-dark
-
-    Parameters
-    ----------
-    label : str
-        The label of the component.
-
-    design : list
-        List containing design parameters (stated as String).
-
-    offdesign : list
-        List containing offdesign parameters (stated as String).
-
-    design_path : str
-        Path to the components design case.
-
-    local_offdesign : boolean
-        Treat this component in offdesign mode in a design calculation.
-
-    local_design : boolean
-        Treat this component in design mode in an offdesign calculation.
-
-    char_warnings : boolean
-        Ignore warnings on default characteristics usage for this component.
-
-    printout : boolean
-        Include this component in the network's results printout.
-
-    P : float, dict
-        Power, :math:`P/\text{W}`
-
-    eta_s : float, dict
-        Isentropic efficiency, :math:`\eta_s/1`
-
-    pr : float, dict, :code:`"var"`
-        Outlet to inlet pressure ratio, :math:`pr/1`
-
-    eta_s_char : tespy.tools.characteristics.CharLine, dict
-        Characteristic curve for isentropic efficiency, provide CharLine as
-        function :code:`func`.
-
-    cone : dict
-        Apply Stodola's cone law (works in offdesign only).
-
-    Example
-    -------
-    A steam turbine expands 10 kg/s of superheated steam at 550 °C and 110 bar
-    to 0,5 bar at the outlet. For example, it is possible to calulate the power
-    output and vapour content at the outlet for a given isentropic efficiency.
-
-    >>> from tespy.components import Sink, Source, Turbine
-    >>> from tespy.connections import Connection
-    >>> from tespy.networks import Network
-    >>> from tespy.tools import ComponentCharacteristics as dc_cc
-    >>> import shutil
-    >>> nw = Network(p_unit='bar', T_unit='C', h_unit='kJ / kg', iterinfo=False)
-    >>> si = Sink('sink')
-    >>> so = Source('source')
-    >>> t = Turbine('turbine')
-    >>> t.component()
-    'turbine'
-    >>> inc = Connection(so, 'out1', t, 'in1')
-    >>> outg = Connection(t, 'out1', si, 'in1')
-    >>> nw.add_conns(inc, outg)
-
-    In design conditions the isentropic efficiency is specified. For offdesign
-    a characteristic function will be applied, together with Stodola's cone
-    law coupling the turbine mass flow to inlet pressure.
-
-    >>> t.set_attr(eta_s=0.9, design=['eta_s'],
-    ... offdesign=['eta_s_char', 'cone'])
-    >>> inc.set_attr(fluid={'water': 1}, m=10, T=550, p=110, design=['p'])
-    >>> outg.set_attr(p=0.5)
-    >>> nw.solve('design')
-    >>> nw.save('tmp')
-    >>> round(t.P.val, 0)
-    -10452574.0
-    >>> round(outg.x.val, 3)
-    0.914
-    >>> inc.set_attr(m=8)
-    >>> nw.solve('offdesign', design_path='tmp')
-    >>> round(t.eta_s.val, 3)
-    0.898
-    >>> round(inc.p.val, 1)
-    88.6
-    >>> shutil.rmtree('./tmp', ignore_errors=True)
-    """
-
-
-    @staticmethod
-    def component():
-        return 'steam turbine'
-
-    def get_parameters(self):
-
-        params = super().get_parameters()
-
-        params["alpha"] = dc_cp(
-            min_val=0.4, max_val=2.5, num_eq=0)
-        params["eta_dry_s"] = dc_cp(
-            min_val=0, max_val=1, num_eq=1,
-            func=self.eta_dry_s_func,
-            deriv=self.eta_dry_s_deriv
-        )
-
-        return params
-
-    def eta_dry_s_func(self):
-
-        inl = self.inl[0]
-        outl = self.outl[0]
-
-        state = inl.calc_phase()
-        if state == "tp":  # two-phase or saturated vapour
-
-            ym = 1 - (inl.calc_x() + outl.calc_x()) / 2  # average wetness
-            self.eta_s.val = self.eta_dry.val * (1 - self.alpha.val * ym)
-
-            return self.eta_s_func()
-
-        else:  # superheated vapour
-            dp = inl.p.val_SI - outl.p.val_SI
-
-            # compute the pressure and enthalpy at which the expansion enters the vapour dome
-            def find_sat(frac):
-
-                psat = inl.p.val_SI - frac * dp
-
-                # calculate enthalpy under dry expansion to psat
-                hout_isen = isentropic(
-                                    inl.p.val_SI,
-                                    inl.h.val_SI,
-                                    psat,
-                                    inl.fluid_data,
-                                    inl.mixing_rule,
-                                    T0=inl.T.val_SI
-                                )
-                hout = inl.h.val_SI - self.eta_dry_s.val * (inl.h.val_SI - hout_isen)
-
-                # calculate enthalpy of saturated vapour at psat
-                hsat = h_mix_pQ(psat, 1, inl.fluid_data)
-
-                return hout - hsat
-            frac = brentq(find_sat, 1, 0)
-            psat = inl.p.val_SI - frac * dp
-            hsat = h_mix_pQ(psat, 1, inl.fluid_data)
-
-            # calculate the isentropic efficiency for wet expansion
-            ym = 1 - (1.0 + outl.calc_x()) / 2  # average wetness
-            eta_s = self.eta_dry_s.val * (1 - self.alpha.val * ym)
-
-            # calculate the final outlet enthalpy
-            hout_isen = isentropic(
-                                psat,
-                                hsat,
-                                outl.p.val_SI,
-                                inl.fluid_data,
-                                inl.mixing_rule,
-                                T0=inl.T.val_SI
-                            )
-            hout = hsat - eta_s * (hsat- hout_isen)
-
-            # calculate the difference in enthalpy
-            dh_isen = hout - inl.h.val_SI
-            dh = outl.h.val_SI - inl.h.val_SI
-
-            # return residual
-            return -dh + dh_isen
-
-    def eta_dry_s_deriv(self, increment_filter, k):
-
-        f = self.eta_dry_s_func
-        i = self.inl[0]
-        o = self.outl[0]
-        if self.is_variable(i.p, increment_filter):
-            self.jacobian[k, i.p.J_col] = self.numeric_deriv(f, "p", i)
-        if self.is_variable(o.p, increment_filter):
-            self.jacobian[k, o.p.J_col] = self.numeric_deriv(f, "p", o)
-        if self.is_variable(i.h, increment_filter):
-            self.jacobian[k, i.h.J_col] = self.numeric_deriv(f, "h", i)
-        if self.is_variable(o.h, increment_filter):
-            self.jacobian[k, o.h.J_col] = self.numeric_deriv(f, "h", o)

--- a/src/tespy/components/turbomachinery/turbine.py
+++ b/src/tespy/components/turbomachinery/turbine.py
@@ -11,6 +11,8 @@ SPDX-License-Identifier: MIT
 """
 
 import numpy as np
+from scipy.optimize import brentq
+
 
 from tespy.components.component import component_registry
 from tespy.components.turbomachinery.base import Turbomachine
@@ -20,6 +22,7 @@ from tespy.tools.data_containers import ComponentProperties as dc_cp
 from tespy.tools.data_containers import SimpleDataContainer as dc_simple
 from tespy.tools.document_models import generate_latex_eq
 from tespy.tools.fluid_properties import isentropic
+from tespy.tools.fluid_properties import h_mix_pQ
 
 
 @component_registry
@@ -520,6 +523,8 @@ class Turbine(Turbomachine):
             )
         )
 
+        self.pr.val = self.outl[0].p.val_SI / self.inl[0].p.val_SI
+
     def exergy_balance(self, T0):
         r"""
         Calculate exergy balance of a turbine.
@@ -576,3 +581,220 @@ class Turbine(Turbomachine):
         self.E_bus = {"chemical": 0, "physical": 0, "massless": -self.P.val}
         self.E_D = self.E_F - self.E_P
         self.epsilon = self._calc_epsilon()
+
+@component_registry
+class SteamTurbine(Turbine):
+    r"""
+    Class for steam turbines with wet expansion.
+
+    **Mandatory Equations**
+
+    - :py:meth:`tespy.components.component.Component.fluid_func`
+    - :py:meth:`tespy.components.component.Component.mass_flow_func`
+
+    **Optional Equations**
+
+    - :py:meth:`tespy.components.component.Component.pr_func`
+    - :py:meth:`tespy.components.turbomachinery.base.Turbomachine.energy_balance_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_dry_s_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_s_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.eta_s_char_func`
+    - :py:meth:`tespy.components.turbomachinery.turbine.Turbine.cone_func`
+
+    Inlets/Outlets
+
+    - in1
+    - out1
+
+    Image
+
+    .. image:: /api/_images/Turbine.svg
+       :alt: flowsheet of the turbine
+       :align: center
+       :class: only-light
+
+    .. image:: /api/_images/Turbine_darkmode.svg
+       :alt: flowsheet of the turbine
+       :align: center
+       :class: only-dark
+
+    Parameters
+    ----------
+    label : str
+        The label of the component.
+
+    design : list
+        List containing design parameters (stated as String).
+
+    offdesign : list
+        List containing offdesign parameters (stated as String).
+
+    design_path : str
+        Path to the components design case.
+
+    local_offdesign : boolean
+        Treat this component in offdesign mode in a design calculation.
+
+    local_design : boolean
+        Treat this component in design mode in an offdesign calculation.
+
+    char_warnings : boolean
+        Ignore warnings on default characteristics usage for this component.
+
+    printout : boolean
+        Include this component in the network's results printout.
+
+    P : float, dict
+        Power, :math:`P/\text{W}`
+
+    eta_s : float, dict
+        Isentropic efficiency, :math:`\eta_s/1`
+
+    pr : float, dict, :code:`"var"`
+        Outlet to inlet pressure ratio, :math:`pr/1`
+
+    eta_s_char : tespy.tools.characteristics.CharLine, dict
+        Characteristic curve for isentropic efficiency, provide CharLine as
+        function :code:`func`.
+
+    cone : dict
+        Apply Stodola's cone law (works in offdesign only).
+
+    Example
+    -------
+    A steam turbine expands 10 kg/s of superheated steam at 550 °C and 110 bar
+    to 0,5 bar at the outlet. For example, it is possible to calulate the power
+    output and vapour content at the outlet for a given isentropic efficiency.
+
+    >>> from tespy.components import Sink, Source, Turbine
+    >>> from tespy.connections import Connection
+    >>> from tespy.networks import Network
+    >>> from tespy.tools import ComponentCharacteristics as dc_cc
+    >>> import shutil
+    >>> nw = Network(p_unit='bar', T_unit='C', h_unit='kJ / kg', iterinfo=False)
+    >>> si = Sink('sink')
+    >>> so = Source('source')
+    >>> t = Turbine('turbine')
+    >>> t.component()
+    'turbine'
+    >>> inc = Connection(so, 'out1', t, 'in1')
+    >>> outg = Connection(t, 'out1', si, 'in1')
+    >>> nw.add_conns(inc, outg)
+
+    In design conditions the isentropic efficiency is specified. For offdesign
+    a characteristic function will be applied, together with Stodola's cone
+    law coupling the turbine mass flow to inlet pressure.
+
+    >>> t.set_attr(eta_s=0.9, design=['eta_s'],
+    ... offdesign=['eta_s_char', 'cone'])
+    >>> inc.set_attr(fluid={'water': 1}, m=10, T=550, p=110, design=['p'])
+    >>> outg.set_attr(p=0.5)
+    >>> nw.solve('design')
+    >>> nw.save('tmp')
+    >>> round(t.P.val, 0)
+    -10452574.0
+    >>> round(outg.x.val, 3)
+    0.914
+    >>> inc.set_attr(m=8)
+    >>> nw.solve('offdesign', design_path='tmp')
+    >>> round(t.eta_s.val, 3)
+    0.898
+    >>> round(inc.p.val, 1)
+    88.6
+    >>> shutil.rmtree('./tmp', ignore_errors=True)
+    """
+
+
+    @staticmethod
+    def component():
+        return 'steam turbine'
+
+    def get_parameters(self):
+
+        params = super().get_parameters()
+
+        params["alpha"] = dc_cp(
+            min_val=0.4, max_val=2.5, num_eq=0)
+        params["eta_dry_s"] = dc_cp(
+            min_val=0, max_val=1, num_eq=1,
+            func=self.eta_dry_s_func,
+            deriv=self.eta_dry_s_deriv
+        )
+
+        return params
+
+    def eta_dry_s_func(self):
+
+        inl = self.inl[0]
+        outl = self.outl[0]
+
+        state = inl.calc_phase()
+        if state == "tp":  # two-phase or saturated vapour
+
+            ym = 1 - (inl.calc_x() + outl.calc_x()) / 2  # average wetness
+            self.eta_s.val = self.eta_dry.val * (1 - self.alpha.val * ym)
+
+            return self.eta_s_func()
+
+        else:  # superheated vapour
+            dp = inl.p.val_SI - outl.p.val_SI
+
+            # compute the pressure and enthalpy at which the expansion enters the vapour dome
+            def find_sat(frac):
+
+                psat = inl.p.val_SI - frac * dp
+
+                # calculate enthalpy under dry expansion to psat
+                hout_isen = isentropic(
+                                    inl.p.val_SI,
+                                    inl.h.val_SI,
+                                    psat,
+                                    inl.fluid_data,
+                                    inl.mixing_rule,
+                                    T0=inl.T.val_SI
+                                )
+                hout = inl.h.val_SI - self.eta_dry_s.val * (inl.h.val_SI - hout_isen)
+
+                # calculate enthalpy of saturated vapour at psat
+                hsat = h_mix_pQ(psat, 1, inl.fluid_data)
+
+                return hout - hsat
+            frac = brentq(find_sat, 1, 0)
+            psat = inl.p.val_SI - frac * dp
+            hsat = h_mix_pQ(psat, 1, inl.fluid_data)
+
+            # calculate the isentropic efficiency for wet expansion
+            ym = 1 - (1.0 + outl.calc_x()) / 2  # average wetness
+            eta_s = self.eta_dry_s.val * (1 - self.alpha.val * ym)
+
+            # calculate the final outlet enthalpy
+            hout_isen = isentropic(
+                                psat,
+                                hsat,
+                                outl.p.val_SI,
+                                inl.fluid_data,
+                                inl.mixing_rule,
+                                T0=inl.T.val_SI
+                            )
+            hout = hsat - eta_s * (hsat- hout_isen)
+
+            # calculate the difference in enthalpy
+            dh_isen = hout - inl.h.val_SI
+            dh = outl.h.val_SI - inl.h.val_SI
+
+            # return residual
+            return -dh + dh_isen
+
+    def eta_dry_s_deriv(self, increment_filter, k):
+
+        f = self.eta_dry_s_func
+        i = self.inl[0]
+        o = self.outl[0]
+        if self.is_variable(i.p, increment_filter):
+            self.jacobian[k, i.p.J_col] = self.numeric_deriv(f, "p", i)
+        if self.is_variable(o.p, increment_filter):
+            self.jacobian[k, o.p.J_col] = self.numeric_deriv(f, "p", o)
+        if self.is_variable(i.h, increment_filter):
+            self.jacobian[k, i.h.J_col] = self.numeric_deriv(f, "h", i)
+        if self.is_variable(o.h, increment_filter):
+            self.jacobian[k, o.h.J_col] = self.numeric_deriv(f, "h", o)

--- a/src/tespy/components/turbomachinery/turbine.py
+++ b/src/tespy/components/turbomachinery/turbine.py
@@ -12,7 +12,6 @@ SPDX-License-Identifier: MIT
 
 import numpy as np
 
-
 from tespy.components.component import component_registry
 from tespy.components.turbomachinery.base import Turbomachine
 from tespy.tools import logger

--- a/src/tespy/components/turbomachinery/turbine.py
+++ b/src/tespy/components/turbomachinery/turbine.py
@@ -251,6 +251,22 @@ class Turbine(Turbomachine):
         if o.h.is_var and self.it == 0:
             self.jacobian[k, o.h.J_col] = -1
 
+    def calc_eta_s(self):
+        inl = self.inl[0]
+        outl = self.outl[0]
+        return (
+            (outl.h.val_SI - inl.h.val_SI)
+            / (isentropic(
+                    inl.p.val_SI,
+                    inl.h.val_SI,
+                    outl.p.val_SI,
+                    inl.fluid_data,
+                    inl.mixing_rule,
+                    T0=inl.T.val_SI
+                ) - inl.h.val_SI
+            )
+        )
+
     def cone_func(self):
         r"""
         Equation for stodolas cone law.
@@ -510,22 +526,8 @@ class Turbine(Turbomachine):
 
         inl = self.inl[0]
         outl = self.outl[0]
-        self.eta_s.val = (
-            (outl.h.val_SI - inl.h.val_SI)
-            / (
-                isentropic(
-                    inl.p.val_SI,
-                    inl.h.val_SI,
-                    outl.p.val_SI,
-                    inl.fluid_data,
-                    inl.mixing_rule,
-                    T0=inl.T.val_SI
-                )
-                - inl.h.val_SI
-            )
-        )
-
-        self.pr.val = self.outl[0].p.val_SI / self.inl[0].p.val_SI
+        self.eta_s.val = self.calc_eta_s()
+        self.pr.val = outl.p.val_SI / inl.p.val_SI
 
     def exergy_balance(self, T0):
         r"""

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -231,16 +231,15 @@ class CoolPropWrapper(FluidPropertyWrapper):
     def Q_ph(self, p, h):
         p = self._make_p_subcritical(p)
         self.AS.update(CP.HmassP_INPUTS, h, p)
-        return self.AS.Q()
 
-        # if self.AS.phase() == CP.iphase_twophase:
-        #     return self.AS.Q()
-        # elif self.AS.phase() == CP.iphase_liquid:
-        #     return 0
-        # elif self.AS.phase() == CP.iphase_gas:
-        #     return 1
-        # else:  # all other phases - though this should be unreachable as p is sub-critical
-        #     return -1
+        if self.AS.phase() == CP.iphase_twophase:
+            return self.AS.Q()
+        elif self.AS.phase() == CP.iphase_liquid:
+            return 0
+        elif self.AS.phase() == CP.iphase_gas:
+            return 1
+        else:  # all other phases - though this should be unreachable as p is sub-critical
+            return -1
 
     def phase_ph(self, p, h):
         p = self._make_p_subcritical(p)

--- a/tests/test_components/test_turbomachinery.py
+++ b/tests/test_components/test_turbomachinery.py
@@ -258,12 +258,22 @@ class TestTurbomachinery:
 
         # design value of isentropic efficiency
         eta_s_d = (
-            (self.c2.h.val_SI - self.c1.h.val_SI) / (
-                isentropic(self.c1.p.val_SI, self.c1.h.val_SI, self.c2.p.val_SI, self.c1.fluid_data, self.c1.mixing_rule) -
-                self.c1.h.val_SI))
-        msg = ('Value of isentropic efficiency must be ' +
-               str(round(eta_s_d, 3)) + ', is ' + str(instance.eta_s.val) +
-               '.')
+            (self.c2.h.val_SI - self.c1.h.val_SI)
+            / (
+                isentropic(
+                    self.c1.p.val_SI,
+                    self.c1.h.val_SI,
+                    self.c2.p.val_SI,
+                    self.c1.fluid_data,
+                    self.c1.mixing_rule
+                )
+               - self.c1.h.val_SI
+            )
+        )
+        msg = (
+            f'Value of isentropic efficiency must be {round(eta_s_d, 3)}, is '
+            f'{instance.eta_s.val}.'
+        )
         assert round(eta_s_d, 3) == round(instance.eta_s.val, 3), msg
 
         # trigger invalid value for isentropic efficiency
@@ -271,11 +281,22 @@ class TestTurbomachinery:
         self.nw.solve('design')
         self.nw._convergence_check()
         eta_s = (
-            (self.c2.h.val_SI - self.c1.h.val_SI) / (
-                isentropic(self.c1.p.val_SI, self.c1.h.val_SI, self.c2.p.val_SI, self.c1.fluid_data, self.c1.mixing_rule) -
-                self.c1.h.val_SI))
-        msg = ('Value of isentropic efficiency must be ' + str(eta_s) +
-               ', is ' + str(instance.eta_s.val) + '.')
+            (self.c2.h.val_SI - self.c1.h.val_SI)
+            / (
+                isentropic(
+                    self.c1.p.val_SI,
+                    self.c1.h.val_SI,
+                    self.c2.p.val_SI,
+                    self.c1.fluid_data,
+                    self.c1.mixing_rule
+                )
+               - self.c1.h.val_SI
+            )
+        )
+        msg = (
+            f'Value of isentropic efficiency must be {round(eta_s, 3)}, is '
+            f'{instance.eta_s.val}.'
+        )
         assert round(eta_s, 3) == round(instance.eta_s.val, 3), msg
 
         # unset isentropic efficiency and inlet pressure,
@@ -288,21 +309,23 @@ class TestTurbomachinery:
         self.nw.solve('offdesign', design_path=tmp_path)
         self.nw._convergence_check()
         # check efficiency
-        msg = ('Value of isentropic efficiency (' + str(instance.eta_s.val) +
-               ') must be identical to design case (' + str(eta_s_d) + ').')
+        msg = (
+            f'Value of isentropic efficiency ({instance.eta_s.val}) must be '
+            f'identical to design case ({eta_s_d}).'
+        )
         assert round(eta_s_d, 2) == round(instance.eta_s.val, 2), msg
         # check pressure
-        msg = ('Value of inlet pressure (' + str(round(self.c1.p.val_SI)) +
-               ') must be identical to design case (' +
-               str(round(self.c1.p.design)) + ').')
+        msg = (
+            f'Value of inlet pressure ({round(self.c1.p.val_SI)}) must be '
+            f'identical to design case ({round(self.c1.p.design)}).'
+        )
         assert round(self.c1.p.design) == round(self.c1.p.val_SI), msg
 
         # lowering mass flow, inlet pressure must sink according to cone law
         self.c1.set_attr(m=self.c1.m.val * 0.8)
         self.nw.solve('offdesign', design_path=tmp_path)
         self.nw._convergence_check()
-        msg = ('Value of pressure ratio (' + str(instance.pr.val) +
-               ') must be at (' + str(0.128) + ').')
+        msg = f'Value of pressure ratio ({instance.pr.val}) must be at 0.128.'
         assert 0.128 == round(instance.pr.val, 3), msg
 
         # testing more parameters for eta_s_char
@@ -313,31 +336,40 @@ class TestTurbomachinery:
         self.nw._convergence_check()
         expr = self.c1.v.val_SI / self.c1.v.design
         eta_s = round(eta_s_d * instance.eta_s_char.char_func.evaluate(expr), 3)
-        msg = ('Value of isentropic efficiency (' +
-               str(round(instance.eta_s.val, 3)) +
-               ') must be (' + str(eta_s) + ').')
+        msg = (
+            f'Value of isentropic efficiency ({round(instance.eta_s.val, 3)}) '
+            f'must be {eta_s}.'
+        )
         assert eta_s == round(instance.eta_s.val, 3), msg
 
         # test parameter specification pr
         instance.eta_s_char.param = 'pr'
         self.nw.solve('offdesign', design_path=tmp_path)
         self.nw._convergence_check()
-        expr = (self.c2.p.val_SI * self.c1.p.design /
-                (self.c2.p.design * self.c1.p.val_SI))
+        expr = (
+            self.c2.p.val_SI * self.c1.p.design
+            / (self.c2.p.design * self.c1.p.val_SI)
+        )
         eta_s = round(eta_s_d * instance.eta_s_char.char_func.evaluate(expr), 3)
-        msg = ('Value of isentropic efficiency (' +
-               str(round(instance.eta_s.val, 3)) +
-               ') must be (' + str(eta_s) + ').')
+        msg = (
+            f'Value of isentropic efficiency ({round(instance.eta_s.val, 3)}) '
+            f'must be {eta_s}.'
+        )
         assert eta_s == round(instance.eta_s.val, 3), msg
 
-    def test_SteamTurbine(self, temp_path):
-        pass
+    def test_SteamTurbine(self, tmp_path):
+        instance = SteamTurbine('turbine')
+        self.setup_network(instance)
+        fl = {'H2O': 1}
+        self.c1.set_attr(fluid=fl, m=15, p=100, T=500)
+        self.c2.set_attr(Td_bp=5)
+        instance.set_attr(eta_s_dry=0.99, alpha=1)
+        self.nw.solve('design')
 
     def test_Turbomachine(self):
         """Test component properties of turbomachines."""
         instance = Turbomachine('turbomachine')
-        msg = ('Component name must be turbomachine, is ' +
-               instance.component() + '.')
+        msg = f'Component name must be turbomachine, is {instance.component()}.'
         assert 'turbomachine' == instance.component(), msg
         self.setup_network(instance)
         fl = {'N2': 0.7556, 'O2': 0.2315, 'Ar': 0.0129}

--- a/tests/test_components/test_turbomachinery.py
+++ b/tests/test_components/test_turbomachinery.py
@@ -16,6 +16,7 @@ from tespy.components import Compressor
 from tespy.components import Pump
 from tespy.components import Sink
 from tespy.components import Source
+from tespy.components import SteamTurbine
 from tespy.components import Turbine
 from tespy.components.turbomachinery.base import Turbomachine
 from tespy.connections import Connection
@@ -328,6 +329,9 @@ class TestTurbomachinery:
                str(round(instance.eta_s.val, 3)) +
                ') must be (' + str(eta_s) + ').')
         assert eta_s == round(instance.eta_s.val, 3), msg
+
+    def test_SteamTurbine(self, temp_path):
+        pass
 
     def test_Turbomachine(self):
         """Test component properties of turbomachines."""


### PR DESCRIPTION
**General**

With this PR I would like to submit a new turbine component, which accounts for wet expansion effects using the empirical Baumann correlation.

The expansion of saturated steam (e.g. geothermal or nuclear power applications) inevitably enters the vapour dome and two-phase effects lead to a reduction in the isentropic efficiency. The empirical Baumann rule effectively corrects the dry isentropic turbine efficiency with the average wetness across the turbine.

* Implementation of the `SteamTurbine` component. I chose to make this a separate component (inheriting from `Turbine`) to avoid confusion - though the `SteamTurbine` behaves exactly like a `Turbine` unless the `eta_dry_s` attribute is set
* Updated the `CoolPropWrapper` `Q_ph` function so that it now returns a meaningful value for `Q` when the fluid is single phase (i.e. 0.0 for liquid and 1.0 for vapour)

**Documentation**

This is still work in progress... I was not quite sure what would be the mvp for this

**Testing**

This is still work in progress... I was thinking to shadow the testing for the regular `Turbine` component


Comments and suggestions are welcome :)
