### PR TITLE
Adjust heatpumps example target url.

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -19,13 +19,13 @@ your project.
       :align: center
       :alt: Heatpumps Dashboard
       :class: only-light
-      :target: https://github.com/jfreissmann/heatpumps
+      :target: https://heatpumps.streamlit.app/
 
     .. image:: /_static/images/examples/heatpumps_darkmode.png
       :align: center
       :alt: Heatpumps Dashboard
       :class: only-dark
-      :target: https://github.com/jfreissmann/heatpumps
+      :target: https://heatpumps.streamlit.app/
 
     The streamlit dashboard *heatpumps* provides users with powerful tools for
     both design and part load simulation of a comprehensive library of heat


### PR DESCRIPTION
The *heatpumps* dashboard is now available online via the streamlit community cloud. The PR changes the target URL of the examples entry for *heatpumps*.
