### PR TITLE
Fix: only inject parameters in to_exerpy when results exist

### DIFF
--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -3063,7 +3063,12 @@ class Network:
                 component_json[key][c.label] = {
                     "name": c.label,
                     "type": comp_type,
-                    "parameters": result.loc[c.label].to_dict()
+                    **(
+                        {"parameters": result.loc[c.label].dropna().to_dict()}
+                        if c.label in result.index
+                        and not result.loc[c.label].dropna().empty
+                        else {}
+                    )
                 }
 
         connection_json = {}


### PR DESCRIPTION
This pull request addresses issue #687 by ensuring that when exporting a TESPy network to ExerPy via `Network.to_exerpy()`, junction‐type components (e.g. `Drum`, `Merge`) that have no entries in the TESPy results table do not trigger a `KeyError`. Previously, the code assumed every component label would exist in the `result` DataFrame and blindly did:
```
"parameters": result.loc[c.label].to_dict()
```
which fails if the row is missing or contains only NaNs.

With this change, we only inject a `"parameters"` field if:
1. The component’s label exists in `result.index`, and
2. The row, after dropping NaNs, is non‐empty.

Otherwise, we omit the `"parameters"` key entirely.