### PR TITLE
Only calculate x and Td_bp in subcritical conditions

### DIFF
--- a/src/tespy/components/turbomachinery/pump.py
+++ b/src/tespy/components/turbomachinery/pump.py
@@ -371,11 +371,12 @@ class Pump(Turbomachine):
         if o.h.is_var:
             fluid = single_fluid(i.fluid_data)
             if fluid is not None:
-                if i.fluid_data[fluid]["wrapper"].back_end != "INCOMP":
-                    h_max = h_mix_pQ(i.p.val_SI, 0, i.fluid_data)
+                if i.p.val_SI < i.fluid_data[fluid]["wrapper"]._p_crit:
+                    if i.fluid_data[fluid]["wrapper"].back_end != "INCOMP":
+                        h_max = h_mix_pQ(i.p.val_SI, 0, i.fluid_data)
 
-                    if o.h.val_SI > h_max:
-                        o.h.set_reference_val_SI(h_max - 20e3)
+                        if o.h.val_SI > h_max:
+                            o.h.set_reference_val_SI(h_max - 20e3)
 
         if i.h.is_var and o.h.val_SI < i.h.val_SI:
             i.h.set_reference_val_SI(o.h.val_SI - 10e3)

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -101,9 +101,6 @@ class FluidPropertyWrapper:
     def _is_below_T_critical(self, T):
         self._not_implemented()
 
-    def _make_p_subcritical(self, p):
-        self._not_implemented()
-
     def T_ph(self, p, h):
         self._not_implemented()
 
@@ -216,14 +213,6 @@ class CoolPropWrapper(FluidPropertyWrapper):
             self._T_crit = self.AS.trivial_keyed_output(CP.iT_critical)
             self._molar_mass = self.AS.trivial_keyed_output(CP.imolar_mass)
 
-    def _is_below_T_critical(self, T):
-        return T < self._T_crit
-
-    def _make_p_subcritical(self, p):
-        if p > self._p_crit:
-            p = self._p_crit * 0.99
-        return p
-
     def get_T_max(self, p):
         if self.back_end == "INCOMP":
             return self.T_sat(p)
@@ -262,7 +251,6 @@ class CoolPropWrapper(FluidPropertyWrapper):
         return self.AS.smass()
 
     def T_sat(self, p):
-        p = self._make_p_subcritical(p)
         self.AS.update(CP.PQ_INPUTS, p, 0)
         return self.AS.T()
 
@@ -274,7 +262,6 @@ class CoolPropWrapper(FluidPropertyWrapper):
         return self.AS.p()
 
     def Q_ph(self, p, h):
-        p = self._make_p_subcritical(p)
         self.AS.update(CP.HmassP_INPUTS, h, p)
         if len(self.fractions) > 1:
             return self.AS.Q()
@@ -290,7 +277,6 @@ class CoolPropWrapper(FluidPropertyWrapper):
             return -1
 
     def phase_ph(self, p, h):
-        p = self._make_p_subcritical(p)
         self.AS.update(CP.HmassP_INPUTS, h, p)
         phase = self.AS.phase()
 
@@ -300,7 +286,7 @@ class CoolPropWrapper(FluidPropertyWrapper):
             return "l"
         elif phase == CP.iphase_gas:
             return "g"
-        else:  # all other phases - though this should be unreachable as p is sub-critical
+        else:
             return "state not recognised"
 
     def d_ph(self, p, h):
@@ -386,11 +372,6 @@ class IAPWSWrapper(FluidPropertyWrapper):
     def _is_below_T_critical(self, T):
         return T < self._T_crit
 
-    def _make_p_subcritical(self, p):
-        if p > self._p_crit:
-            p = self._p_crit * 0.99
-        return p
-
     def isentropic(self, p_1, h_1, p_2):
         return self.h_ps(p_2, self.s_ph(p_1, h_1))
 
@@ -416,7 +397,6 @@ class IAPWSWrapper(FluidPropertyWrapper):
         return self.AS(T=T, x=Q).s * 1e3
 
     def T_sat(self, p):
-        p = self._make_p_subcritical(p)
         return self.AS(P=p / 1e6, x=0).T
 
     def p_sat(self, T):
@@ -426,12 +406,9 @@ class IAPWSWrapper(FluidPropertyWrapper):
         return self.AS(T=T / 1e6, x=0).P * 1e6
 
     def Q_ph(self, p, h):
-        p = self._make_p_subcritical(p)
         return self.AS(h=h / 1e3, P=p / 1e6).x
 
     def phase_ph(self, p, h):
-        p = self._make_p_subcritical(p)
-
         phase = self.AS(h=h / 1e3, P=p / 1e6).phase
 
         if phase in ["Liquid"]:

--- a/src/tespy/tools/fluid_properties/wrappers.py
+++ b/src/tespy/tools/fluid_properties/wrappers.py
@@ -213,6 +213,9 @@ class CoolPropWrapper(FluidPropertyWrapper):
             self._T_crit = self.AS.trivial_keyed_output(CP.iT_critical)
             self._molar_mass = self.AS.trivial_keyed_output(CP.imolar_mass)
 
+    def _is_below_T_critical(self, T):
+        return T < self._T_crit
+
     def get_T_max(self, p):
         if self.back_end == "INCOMP":
             return self.T_sat(p)


### PR DESCRIPTION
The convergence heuristics now deal with pressure value adjustments under set values for `x` and `Td_bp`. For post-processing these return `nan` in supercritical conditions. There are two open tasks:

- Create a test with initially supercritical conditions but set x or Td_bp to test whether the convergence helpers are doing their job
- Create a test that will force a pressure into supercritical state indirectly and set x or Td_bp for that state. Here, the convergence helpers should make sure, the pressure remains subcritical and therefore the calculation does not crash prior to the 10th iteration. After that the calculation is expected to crash, because then the two-phase properties are accessed in supercritical pressure.