### PR TITLE
Fix: SimpleHeatExchanger considered in to_exerpy and problem with ttd…

### DIFF
--- a/docs/whats_new/v0-9-3.rst
+++ b/docs/whats_new/v0-9-3.rst
@@ -6,6 +6,9 @@ Hotfix for Postrelease
 - :code:`UserDefinedEquations` now automatically reassign their connection and
   component objections. This is necessary in context of pygmo base
   optimization (`PR #726 <https://github.com/oemof/tespy/pull/726>`__).
+- When either :code:`ttd_u` or :code:`ttd_l` on a class :code:`HeatExchanger`
+  component is zero, :code:`kA` will be set to nan to pervent a crash
+  (`PR #728 <https://github.com/oemof/tespy/pull/728>`__).
 
 Other Changes
 #############

--- a/src/tespy/components/heat_exchangers/base.py
+++ b/src/tespy/components/heat_exchangers/base.py
@@ -979,11 +979,14 @@ class HeatExchanger(Component):
             self.td_log.val = np.nan
         elif round(self.ttd_l.val, 6) == round(self.ttd_u.val, 6):
             self.td_log.val = self.ttd_l.val
+        elif round(self.ttd_l.val, 6) == 0 or round(self.ttd_u.val, 6) == 0:
+            self.td_log.val = np.nan
         else:
             self.td_log.val = (
                 (self.ttd_l.val - self.ttd_u.val)
                 / math.log(self.ttd_l.val / self.ttd_u.val)
             )
+            
         self.kA.val = -self.Q.val / self.td_log.val
 
         # heat exchanger efficiencies

--- a/src/tespy/components/heat_exchangers/condenser.py
+++ b/src/tespy/components/heat_exchangers/condenser.py
@@ -395,6 +395,8 @@ class Condenser(HeatExchanger):
             self.td_log.val = np.nan
         elif round(self.ttd_l.val, 6) == round(self.ttd_u.val, 6):
             self.td_log.val = self.ttd_l.val
+        elif round(self.ttd_l.val, 6) == 0 or round(self.ttd_u.val, 6) == 0:
+            self.td_log.val = np.nan
         else:
             self.td_log.val = (
                 (self.ttd_l.val - self.ttd_u.val)

--- a/src/tespy/connections/powerconnection.py
+++ b/src/tespy/connections/powerconnection.py
@@ -206,6 +206,8 @@ class PowerConnection(_ConnectionBase):
             source_connector = 0
         elif self.source.__class__.__name__ in ["Turbine"]:
             source_connector = 1
+        elif self.source.__class__.__name__ in ["SimpleHeatExchanger"]:
+            source_connector = 1
         elif self.source.__class__.__name__ in ["PowerBus"]:
             if self.source_id.startswith("power_out"):
                 s_id = self.source_id.removeprefix("power_out")
@@ -219,6 +221,8 @@ class PowerConnection(_ConnectionBase):
         if self.target.__class__.__name__ in ["Motor", "Generator"]:
             target_connector = 0
         elif self.target.__class__.__name__ in ["Compressor", "Pump"]:
+            target_connector = 1
+        elif self.target.__class__.__name__ in ["SimpleHeatExchanger"]:
             target_connector = 1
         elif self.target.__class__.__name__ in ["PowerBus"]:
             if self.target_id.startswith("power_in"):


### PR DESCRIPTION
1) The SimpleHeatExchanger's connectors are now correctly parsed to ExerPy. 
2) The numerical problem of HeatExchangers having ttd_l = ttd_u is now skipped to avoid numerical problems. 