### PR TITLE
Assign rng based on the connection's label

### DIFF
--- a/docs/whats_new/v0-9-5.rst
+++ b/docs/whats_new/v0-9-5.rst
@@ -6,6 +6,9 @@ New Features
 
 Other Changes
 #############
+- Selection of mass flow starting values, where no value is available is now
+  reproducibly random
+  (`PR #755 <https://github.com/oemof/tespy/pull/755>`__).
 
 Contributors
 ############

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -2078,7 +2078,9 @@ class Network:
             # starting value for mass flow is random between 1 and 2 kg/s
             # (should be generated based on some hash maybe?)
             if key == 'm':
-                value = float(np.random.random() + 1)
+                seed = abs(hash(c.label)) % (2**32)
+                rng = np.random.default_rng(seed=seed)
+                value = float(rng.random() + 1)
 
             # generic starting values for pressure and enthalpy
             elif key in ['p', 'h']:


### PR DESCRIPTION
The mass flow starting value is selected by random in the very first setup of a model. This is usually not a problem, but in some cases leads to non-reproducible errors. This change should fix that.

Resolve #509 
Resolve #519 