### PR TITLE
Allow component parameters to invoke equations if they only specify `structure_matrix`

### DIFF
--- a/src/tespy/components/combustion/diabatic.py
+++ b/src/tespy/components/combustion/diabatic.py
@@ -198,7 +198,6 @@ class DiabaticCombustionChamber(CombustionChamber):
             'pr': dc_cp(
                 min_val=0,
                 num_eq_sets=1,
-                func=self.pr_func,
                 structure_matrix=self.pr_structure_matrix,
                 func_params={"inconn": 0, "outconn": 0, "pr": "pr"},
                 quantity="ratio"
@@ -206,7 +205,6 @@ class DiabaticCombustionChamber(CombustionChamber):
             'dp': dc_cp(
                 min_val=0,
                 num_eq_sets=1,
-                func=self.dp_func,
                 structure_matrix=self.dp_structure_matrix,
                 func_params={"inconn": 0, "outconn": 0, "dp": "dp"},
                 quantity="pressure"

--- a/src/tespy/components/combustion/engine.py
+++ b/src/tespy/components/combustion/engine.py
@@ -273,14 +273,12 @@ class CombustionEngine(CombustionChamber):
             'Qloss': dc_cp(_val=-1e5, d=1, max_val=-1, quantity="heat"),
             'pr1': dc_cp(
                 min_val=1e-4, max_val=1, num_eq_sets=1,
-                func=self.pr_func,
                 structure_matrix=self.pr_structure_matrix,
                 func_params={'pr': 'pr1'},
                 quantity="ratio"
             ),
             'pr2': dc_cp(
                 min_val=1e-4, max_val=1, num_eq_sets=1,
-                func=self.pr_func,
                 structure_matrix=self.pr_structure_matrix,
                 func_params={'pr': 'pr2', 'inconn': 1, 'outconn': 1},
                 quantity="ratio"
@@ -288,14 +286,12 @@ class CombustionEngine(CombustionChamber):
             'dp1': dc_cp(
                 min_val=0, num_eq_sets=1,
                 structure_matrix=self.dp_structure_matrix,
-                func=self.dp_func,
                 func_params={"inconn": 0, "outconn": 0, "dp": "dp1"},
                 quantity="pressure"
             ),
             'dp2': dc_cp(
                 min_val=0, num_eq_sets=1,
                 structure_matrix=self.dp_structure_matrix,
-                func=self.dp_func,
                 func_params={"inconn": 1, "outconn": 1, "dp": "dp2"},
                 quantity="pressure"
             ),

--- a/src/tespy/components/heat_exchangers/base.py
+++ b/src/tespy/components/heat_exchangers/base.py
@@ -264,32 +264,24 @@ class HeatExchanger(Component):
             ),
             'pr1': dc_cp(
                 min_val=1e-4, max_val=1, num_eq_sets=1,
-                func=self.pr_func,
-                dependents=self.pr_dependents,
                 structure_matrix=self.pr_structure_matrix,
                 func_params={'pr': 'pr1'},
                 quantity="ratio"
             ),
             'pr2': dc_cp(
                 min_val=1e-4, max_val=1, num_eq_sets=1,
-                func=self.pr_func,
-                dependents=self.pr_dependents,
                 structure_matrix=self.pr_structure_matrix,
                 func_params={'pr': 'pr2', 'inconn': 1, 'outconn': 1},
                 quantity="ratio"
             ),
             'dp1': dc_cp(
                 min_val=0, max_val=1e15, num_eq_sets=1,
-                func=self.dp_func,
-                dependents=self.dp_dependents,
                 structure_matrix=self.dp_structure_matrix,
                 func_params={'dp': 'dp1', 'inconn': 0, 'outconn': 0},
                 quantity="pressure"
             ),
             'dp2': dc_cp(
                 min_val=0, max_val=1e15, num_eq_sets=1,
-                func=self.dp_func,
-                dependents=self.dp_dependents,
                 structure_matrix=self.dp_structure_matrix,
                 func_params={'dp': 'dp2', 'inconn': 1, 'outconn': 1},
                 quantity="pressure"

--- a/src/tespy/components/heat_exchangers/simple.py
+++ b/src/tespy/components/heat_exchangers/simple.py
@@ -247,16 +247,12 @@ class SimpleHeatExchanger(Component):
             ),
             'pr': dc_cp(
                 min_val=1e-4, max_val=1, num_eq_sets=1,
-                func=self.pr_func,
                 structure_matrix=self.pr_structure_matrix,
-                dependents=self.pr_dependents,
                 func_params={'pr': 'pr'},
                 quantity="ratio"
             ),
             'dp': dc_cp(
                 min_val=0, max_val=1e15, num_eq_sets=1,
-                func=self.dp_func,
-                dependents=self.dp_dependents,
                 structure_matrix=self.dp_structure_matrix,
                 func_params={'dp': 'dp'},
                 quantity="pressure"

--- a/src/tespy/components/piping/valve.py
+++ b/src/tespy/components/piping/valve.py
@@ -138,8 +138,6 @@ class Valve(Component):
             'pr': dc_cp(
                 min_val=1e-4, max_val=1, num_eq_sets=1,
                 structure_matrix=self.pr_structure_matrix,
-                func=self.pr_func,
-                dependents=self.pr_dependents,
                 func_params={'pr': 'pr'},
                 quantity="ratio"
             ),
@@ -147,8 +145,6 @@ class Valve(Component):
                 min_val=0,
                 num_eq_sets=1,
                 structure_matrix=self.dp_structure_matrix,
-                func=self.dp_func,
-                dependents=self.dp_dependents,
                 func_params={"inconn": 0, "outconn": 0, "dp": "dp"},
                 quantity="pressure"
             ),

--- a/src/tespy/components/reactors/fuel_cell.py
+++ b/src/tespy/components/reactors/fuel_cell.py
@@ -172,14 +172,12 @@ class FuelCell(Component):
             'pr': dc_cp(
                 max_val=1, num_eq_sets=1,
                 structure_matrix=self.pr_structure_matrix,
-                func=self.pr_func,
                 func_params={'pr': 'pr'},
                 quantity="ratio"
             ),
             'dp': dc_cp(
                 min_val=0,
                 structure_matrix=self.dp_structure_matrix,
-                func=self.dp_func,
                 num_eq_sets=1,
                 func_params={"inconn": 0, "outconn": 0, "dp": "dp"},
                 quantity="pressure"

--- a/src/tespy/components/reactors/water_electrolyzer.py
+++ b/src/tespy/components/reactors/water_electrolyzer.py
@@ -202,14 +202,12 @@ class WaterElectrolyzer(Component):
             'pr': dc_cp(
                 max_val=1, num_eq_sets=1,
                 structure_matrix=self.pr_structure_matrix,
-                func=self.pr_func,
                 func_params={'pr': 'pr'},
                 quantity="ratio"
             ),
             'dp': dc_cp(
                 min_val=0,
                 structure_matrix=self.dp_structure_matrix,
-                func=self.dp_func,
                 num_eq_sets=1,
                 func_params={"inconn": 0, "outconn": 0, "dp": "dp"},
                 quantity="pressure"

--- a/src/tespy/components/turbomachinery/base.py
+++ b/src/tespy/components/turbomachinery/base.py
@@ -94,16 +94,12 @@ class Turbomachine(Component):
             ),
             'pr': dc_cp(
                 num_eq_sets=1,
-                func=self.pr_func,
-                dependents=self.pr_dependents,
                 func_params={'pr': 'pr'},
                 structure_matrix=self.pr_structure_matrix,
                 quantity="ratio"
             ),
             'dp': dc_cp(
                 num_eq_sets=1,
-                func=self.dp_func,
-                dependents=self.dp_dependents,
                 structure_matrix=self.dp_structure_matrix,
                 func_params={'dp': 'dp'},
                 quantity="pressure"

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -3017,7 +3017,7 @@ class Network:
             for param in self.results[key].columns:
                 p = cp.get_attr(param)
                 if (p.func is not None or (p.func is None and p.is_set) or
-                        p.is_result):
+                        p.is_result or p.structure_matrix is not None):
                     self.results[key].loc[cp.label, param] = p.val
                 else:
                     self.results[key].loc[cp.label, param] = np.nan

--- a/tests/test_components/test_heat_exchangers.py
+++ b/tests/test_components/test_heat_exchangers.py
@@ -329,17 +329,9 @@ class TestHeatExchangers:
         assert zeta == round(instance.zeta.val, 0), msg
         assert round(diameter, 3) == round(instance.D.val, 3)
 
-        # same test with pressure ratio as system variable
-        pr = round(instance.pr.val, 3)
-        instance.set_attr(zeta=None, pr='var')
-        self.nw.solve('design')
-        self.nw.assert_convergence()
-        msg = f"Value of pressure ratio must be {pr}, is {instance.pr.val}."
-        assert pr == round(instance.pr.val, 3), msg
-
         # test heat transfer coefficient as variable of the system (ambient
         # temperature required)
-        instance.set_attr(kA='var', pr=None)
+        instance.set_attr(kA='var', zeta=None)
         b.set_attr(P=-5e4)
         self.nw.solve('design')
         self.nw.assert_convergence()

--- a/tests/test_components/test_piping.py
+++ b/tests/test_components/test_piping.py
@@ -42,14 +42,13 @@ class TestPiping:
         self.c1.set_attr(fluid={'CH4': 1}, m=10, p=10, T=120)
         self.c2.set_attr(p=1)
 
-        # test variable pressure ration
-        instance.set_attr(pr='var')
         self.nw.solve('design')
         self.nw.assert_convergence()
         assert self.nw.status == 0
-        pr = round(self.c2.p.val_SI / self.c1.p.val_SI, 2)
-        msg = ('Value of pressure ratio must be ' + str(pr) + ', is ' +
-               str(round(instance.pr.val, 2)) + '.')
+        pr = round(self.c2.p.val / self.c1.p.val, 2)
+        msg = (
+            f'Value of pressure ratio must be {pr}, is {instance.pr.val}.'
+        )
         assert pr == round(instance.pr.val, 2), msg
 
         # test variable zeta value
@@ -57,8 +56,10 @@ class TestPiping:
         instance.set_attr(zeta='var', pr=None)
         self.nw.solve('design')
         self.nw.assert_convergence()
-        msg = ('Value of dimension independent zeta value must be ' +
-               str(zeta) + ', is ' + str(round(instance.zeta.val, 0)) + '.')
+        msg = (
+            f'Value of dimension independent zeta value must be {zeta}, is '
+            f'{instance.zeta.val}.'
+        )
         assert zeta == round(instance.zeta.val, 0), msg
 
         # dp char


### PR DESCRIPTION
Component parameters were only invoking equations when there was a `func` present and if the value is set by the user. Now, if the value is set and a `structure_matrix` is present, the equation is also invoked with no `func` present. On top it removes all specifications of `func`, where it does not make sense because the `structure_matrix` is present anyway.