### PR TITLE
Add combustion gasses dynamically

### DIFF
--- a/src/tespy/components/combustion/base.py
+++ b/src/tespy/components/combustion/base.py
@@ -319,6 +319,8 @@ class CombustionChamber(Component):
         hf['propane'] = -103.8
         hf['butane'] = -125.7
         hf['nDodecane'] = -289.4
+        hf['acetone']= -2.157E+02
+        hf['Dichloroethane']= -1.2979E+02
         hf['CO'] = -110.5
         hf[self.o2] = 0
         hf[self.co2] = -393.51

--- a/src/tespy/networks/network.py
+++ b/src/tespy/networks/network.py
@@ -44,6 +44,7 @@ from tespy.tools.global_vars import ERR
 from tespy.tools.global_vars import fluid_property_data as fpd
 from tespy.tools.units import SI_UNITS
 from tespy.tools.units import Units
+from tespy.tools.global_vars import combustion_gases
 
 # Only require cupy if Cuda shall be used
 try:
@@ -179,6 +180,7 @@ class Network:
         self.design_path = None
         self.iterinfo = True
         self.units = Units()
+        self.combustion_gases = combustion_gases
 
         msg = 'Default unit specifications:\n'
         for prop, unit in self.units.default.items():

--- a/src/tespy/tools/__init__.py
+++ b/src/tespy/tools/__init__.py
@@ -15,3 +15,4 @@ from .data_containers import SimpleDataContainer  # noqa: F401
 from .helpers import UserDefinedEquation  # noqa: F401
 from .optimization import OptimizationProblem  # noqa: F401
 from .units import Units  # noqa: F401
+from .global_vars import combustion_gases

--- a/src/tespy/tools/global_vars.py
+++ b/src/tespy/tools/global_vars.py
@@ -103,8 +103,49 @@ class FluidAliases:
 
 FLUID_ALIASES = FluidAliases()
 
+class COMBUSTION_GASES:
+    def __init__(self):
+        self.fluids={
+            'hydrogen': {'hf':0,
+                         'LHV':None
+            },
+            'methane': {'hf':-74.6,
+                         'LHV':None
+            },
+            'ethane': {'hf':-84.0,
+                         'LHV':None
+            }, 
+            'propane':{'hf':-103.8,
+                         'LHV':None
+            }, 
+            'butane':{'hf':-125.7,
+                         'LHV':None
+            }, 
+            'nDodecane':{'hf':-289.4,
+                         'LHV':None
+            }, 
 
-combustion_gases = [
-    'methane', 'ethane', 'propane', 'butane', 'hydrogen', 'nDodecane',
-    'CO', 'acetone', 'Dichloroethane'
-]
+            'Dichloroethane':{'hf':-1.2979E+02,
+                         'LHV':None
+            }, 
+            'CO':{'hf': -110.5,
+                         'LHV':None
+            },
+        }
+    def add_fluid(self, fluid, hf= None, LHV=None):
+        """Add a new fluid to the possible combustion gases.
+
+        Parameters
+        ----------
+        fluid : str
+            name of the fluid. Must be a valid fluid within the fluid property backend.
+        hf: float
+            specific enthalpy of formation at standard conditions in kJ/mol
+        LHV: float
+            lower heating value of the fuel in J/mol
+        """
+        self.fluids[fluid] = {'hf':hf,
+                              'LHV':LHV
+        }
+
+combustion_gases = COMBUSTION_GASES()

--- a/src/tespy/tools/global_vars.py
+++ b/src/tespy/tools/global_vars.py
@@ -106,5 +106,5 @@ FLUID_ALIASES = FluidAliases()
 
 combustion_gases = [
     'methane', 'ethane', 'propane', 'butane', 'hydrogen', 'nDodecane',
-    'CO'
+    'CO', 'acetone', 'Dichloroethane'
 ]


### PR DESCRIPTION
**General**

Implement a dynamic method to add combustion gasses (#760) .
Therefore a new class COMBUSTION_GASES is created which is defined, initialized and located in global_vars. 
With the method "add_fluids" new combustion gasses can be added. 

**Example**

An example from the turbine example from the documentation:

```python
from tespy.networks import Network
from tespy.components import (
    DiabaticCombustionChamber, Turbine, Source, Sink, Compressor,
)
from tespy.connections import Connection
from tespy.tools.global_vars import combustion_gases

#add a fluid with the heat of formation in kJ/mol:
combustion_gases.add_fluid('ethanol', hf=-2.3495E+02)
# or direct the heat of combustion value in J/mol:
combustion_gases.add_fluid('acetone', LHV=1.659E+06)

nw = Network()
nw.units.set_defaults(temperature="degC", pressure="bar", heat="MW", power="MW")
cp = Compressor("Compressor")
cc = DiabaticCombustionChamber("combustion chamber")
tu = Turbine("turbine")
air = Source("air source")
fuel = Source("fuel source")
fg = Sink("flue gas sink")
c2 = Connection(air, "out1", cc, "in1", label="2")
c3 = Connection(cc, "out1", fg, "in1", label="3")
c5 = Connection(fuel, "out1", cc, "in2", label="5")
nw.add_conns(c2, c3, c5)
cc.set_attr(pr=1, eta=1, lamb=1.5, ti=10)

c2.set_attr(
    p=1, T=20,
    fluid={"Ar": 0.0129, "N2": 0.7553, "CO2": 0.0004, "O2": 0.2314}
)
c5.set_attr(p=1, T=20, fluid={"CO2": 0.04, "ethanol": 0.96, "H2": 0})

nw.solve(mode="design")
nw.print_results()


nw2 = Network()
nw2.units.set_defaults(temperature="degC", pressure="bar", heat="MW", power="MW")

cp = Compressor("Compressor")
cc = DiabaticCombustionChamber("combustion chamber")
tu = Turbine("turbine")
air = Source("air source")
fuel = Source("fuel source")
fg = Sink("flue gas sink")

c2 = Connection(air, "out1", cc, "in1", label="2")
c3 = Connection(cc, "out1", fg, "in1", label="3")
c5 = Connection(fuel, "out1", cc, "in2", label="5")
nw2.add_conns(c2, c3, c5)

cc.set_attr(pr=1, eta=1, lamb=1.5, ti=10)

c2.set_attr(
    p=1, T=20,
    fluid={"Ar": 0.0129, "N2": 0.7553, "CO2": 0.0004, "O2": 0.2314}
)
c5.set_attr(p=1, T=20, fluid={"CO2": 0.04, "acetone": 0.96, "H2": 0})

nw2.solve(mode="design")
nw2.print_results()

```


**ToDo**
- [ ] documentation
- [ ] testing

**Questions and Comments**

- Right now the heat of formation needs to be passed in kJ/mol and heat of combustion in J/mol. This might be unified to SI, I just used the units as it was before.
- The resulting flue gas temperatures in the example varies greatly (Ethanol= 1545°C and Acetone =  122°C). I might miss a point but that seems a too high difference for me. So that should be validaded and if necessary debuged. 